### PR TITLE
Issue #146: fix get-repo-instructions

### DIFF
--- a/doc-src/source/doc/usersguide/get_install.rst
+++ b/doc-src/source/doc/usersguide/get_install.rst
@@ -305,7 +305,8 @@ Get the FluDAG Alpha Release repository by cloning the UW-Madison DAGMC reposito
 
     prompt%> cd $HOME
     prompt%> git clone https://github.com/svalinn/DAGMC.git
-    prompt%> get checkout alpha_release.
+    prompt%> cd DAGMC
+    prompt%> git checkout alpha_release
 
 A run-script provided by FLUKA has been modified to allow it to have input filenames
 longer than 8 characters.  The following steps assume you have the FLUKA environment


### PR DESCRIPTION
This was originally incorrectly based to master.  I will do this merge in order to recreate a clean beta branch for fludag.
