### PR TITLE
Update build_dagmc_stack.bash

### DIFF
--- a/MCNP5/build_dagmc_stack.bash
+++ b/MCNP5/build_dagmc_stack.bash
@@ -351,16 +351,15 @@ then
    
  if [ $enable_static == "no" ]
     then
-       	../src/configure --enable-optimize --disable-debug --enable-shared\
-	  --with-cgm=$cgm_prefix  \
-	 --with-hdf5=$hdf5_prefix \ 
+       	../src/configure --enable-optimize --disable-debug --enable-shared \
+	  --with-cgm=$cgm_prefix   \
+	  --with-hdf5=$hdf5_prefix \ 
 	  --prefix=$moab_prefix     
     else
-    	../src/configure --enable-optimize --disable-debug \
-	        --enable-static  \
-	        --with-cgm=$cgm_prefix  \
-	        --with-hdf5=$hdf5_prefix \
-	        --prefix=$moab_prefix
+    	../src/configure --enable-optimize --disable-debug --enable-static \
+	  --with-cgm=$cgm_prefix   \
+	  --with-hdf5=$hdf5_prefix \
+	  --prefix=$moab_prefix
     fi
 
     checkErr "MOAB Configure failed"


### PR DESCRIPTION
Updated moab build part of the script to remove some deficiencies, namely the script previously omitted the hdf5_path for moab, and the cgm path in the case of the static build. Also added --enable-shared to the non static build. To address issue #176 
