### PR TITLE
Kernel efficiency

### DIFF
--- a/MCNP5/dagmc/KDEKernel.cpp
+++ b/MCNP5/dagmc/KDEKernel.cpp
@@ -1,7 +1,6 @@
 // MCNP5/dagmc/KDEKernel.cpp
 
 #include <cassert>
-#include <cmath>
 
 #include "KDEKernel.hpp"
 #include "PolynomialKernel.hpp"

--- a/MCNP5/dagmc/PolynomialKernel.cpp
+++ b/MCNP5/dagmc/PolynomialKernel.cpp
@@ -1,7 +1,6 @@
 // MCNP5/dagmc/PolynomialKernel.cpp
 
 #include <cassert>
-#include <cmath>
 #include <sstream>
 
 #include "PolynomialKernel.hpp"


### PR DESCRIPTION
Refactored the kernel evaluate functions to no longer use the cmath::pow method.  New implementation is more efficient for polynomial kernels with s > 1 and/or r > 1.
