### PR TITLE
Separate tally/test cmake build; update unit tests for moab 4.6.3

### DIFF
--- a/tally/CMakeLists.txt
+++ b/tally/CMakeLists.txt
@@ -17,7 +17,3 @@ ADD_LIBRARY(dagtally SHARED
 )
 
 TARGET_LINK_LIBRARIES(dagtally lapack)
-
-# Add unit testing subdirectory
-# TODO: omitting test files for now
-#ADD_SUBDIRECTORY(test)

--- a/tally/KDENeighborhood.cpp
+++ b/tally/KDENeighborhood.cpp
@@ -236,7 +236,10 @@ void KDENeighborhood::points_in_box()
 #if MB_VERSION_MAJOR == 4 && MB_VERSION_MINOR < 7 && MB_VERSION_PATCH < 3
     rval = kd_tree->leaves_within_distance(kd_tree_root, box_center, radius, leaves);
 #else
-    rval = kd_tree->distance_search(box_center, radius, leaves);
+    // moab::AdaptiveKDTree now checks if box_center is in tree's bounding box,
+    // which does not always work for neighborhood region that overlaps mesh
+    // TODO: using radius as tolerance for temporary fix
+    rval = kd_tree->distance_search(box_center, radius, leaves, radius);
 #endif
     assert(rval == moab::MB_SUCCESS);
 

--- a/tally/test/CMakeLists.txt
+++ b/tally/test/CMakeLists.txt
@@ -1,14 +1,18 @@
 # CMAKE build script for DAGMC Tally unit testing
 
+CMAKE_MINIMUM_REQUIRED(VERSION 2.8)
+
 # Where to look for includes
-INCLUDE_DIRECTORIES("${GTEST_HOME}/gtest-1.7.0/include")
+INCLUDE_DIRECTORIES("${MOAB_ROOT}/include" "${GTEST_HOME}/gtest-1.7.0/include")
+
+MESSAGE(STATUS "${GTEST_HOME}")
 
 # set libraries
 SET(LIBRARIES
     ${GTEST_HOME}/lib/libgtest.a
     ${GTEST_HOME}/lib/libgtest_main.a
     pthread
-    dagtally
+    ${DAGTALLY_LIB}/libdagtally.so
     ${MOAB_ROOT}/lib/libMOAB.so
 )
 
@@ -18,7 +22,7 @@ SET(MESH_FILES
     unstructured_mesh.h5m
 )
 
-FILE(COPY ${MESH_FILES} DESTINATION ${CMAKE_BINARY_DIR}/tally/test/)
+FILE(COPY ${MESH_FILES} DESTINATION ${CMAKE_BINARY_DIR})
 
 # set up DAGMC Tally test cases
 ADD_EXECUTABLE(test_KDEKernel test_KDEKernel.cpp)

--- a/tally/test/test_KDENeighborhood.cpp
+++ b/tally/test/test_KDENeighborhood.cpp
@@ -66,9 +66,10 @@ class GetPointsTest : public ::testing::Test
     // deallocate memory resources
     virtual void TearDown()
     {
-        delete mbi;
         delete region1;
         delete region2;
+        // need to delete mbi after regions since new kd-tree deletes entities
+        delete mbi;
     }
 
   protected:


### PR DESCRIPTION
All DAGMC tally unit tests now pass with moab 4.6.3.  Currently need to be built within tally/test directory.
