### PR TITLE
renamed the amalgamated pyne library name to avoid name clash

### DIFF
--- a/fluka/CMakeLists.txt
+++ b/fluka/CMakeLists.txt
@@ -26,7 +26,7 @@ ENABLE_LANGUAGE( Fortran )
 SET(FLUDAG_LIBS
      dagmciface
      ${HDF5_hdf5_hl_LIBRARY} ${HDF5_hdf5_LIBRARY}
-     pyne
+     pyne_dagmc
      ${DAGMC_LIBRARIES} 
      gfortran
   )

--- a/geant4/build/CMakeLists.txt
+++ b/geant4/build/CMakeLists.txt
@@ -48,7 +48,7 @@ add_executable(DagGeant4 exampleN01.cc ${sources} ${headers})
 target_link_libraries(DagGeant4 ${Geant4_LIBRARIES}
                                 ${HDF5_hdf5_hl_LIBRARY} ${HDF5_hdf5_LIBRARY}
 #                                ${PYNE_LIBS_DIR}/libpyne.so
-				pyne
+				pyne_dagmc
 			        ${DAGMC_LIBRARIES}
 				dagsolid
 				dagmciface)

--- a/mcnp5/build/CMakeLists.txt
+++ b/mcnp5/build/CMakeLists.txt
@@ -496,7 +496,7 @@ target_link_libraries(${mcnp_exec}
 			dagtally 
 			${DAGMC_LIBRARIES} 
 			${HDF5_hdf5_hl_LIBRARY} ${HDF5_hdf5_LIBRARY} 
-			pyne )
+			pyne_dagmc )
 if(MPI_BUILD)
   target_link_libraries(${mcnp_exec} ${MPI_LIBRARIES}) 
 endif(MPI_BUILD)

--- a/pyne/CMakeLists.txt
+++ b/pyne/CMakeLists.txt
@@ -7,12 +7,12 @@ SET ( CODE_PUB_HEADERS "pyne.h" )
 
 # make pyne library
 IF( STATIC_LIB )
-  add_library( pyne STATIC ${CODE_SRC_FILES})
+  add_library( pyne_dagmc STATIC ${CODE_SRC_FILES})
 ELSEIF( NOT STATIC_LIB )
-  add_library( pyne SHARED ${CODE_SRC_FILES})
+  add_library( pyne_dagmc SHARED ${CODE_SRC_FILES})
 ENDIF( STATIC_LIB )
  
-target_include_directories( pyne PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories( pyne_dagmc PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 # if we want a static executable
 # IF(STATIC_LIB)
@@ -23,15 +23,15 @@ target_include_directories( pyne PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 #target_link_libraries(pyne ${HDF5_hdf5_hl_LIBRARY} ${HDF5_hdf5_LIBRARY})
 
-SET_TARGET_PROPERTIES( pyne PROPERTIES PUBLIC_HEADER "${CODE_PUB_HEADERS}" )
+SET_TARGET_PROPERTIES( pyne_dagmc PROPERTIES PUBLIC_HEADER "${CODE_PUB_HEADERS}" )
 
-INSTALL( TARGETS       pyne
+INSTALL( TARGETS       pyne_dagmc
   LIBRARY        DESTINATION   "${INSTALL_LIB_DIR}"
   ARCHIVE        DESTINATION   "${INSTALL_LIB_DIR}"
   PUBLIC_HEADER  DESTINATION   "${INSTALL_INCLUDE_DIR}"
   )
 
-target_link_libraries(pyne ${HDF5_hdf5_hl_LIBRARY} ${HDF5_hdf5_LIBRARY})
+target_link_libraries(pyne_dagmc ${HDF5_hdf5_hl_LIBRARY} ${HDF5_hdf5_LIBRARY})
 
 
 

--- a/uwuw/tests/CMakeLists.txt
+++ b/uwuw/tests/CMakeLists.txt
@@ -24,7 +24,7 @@ SET(LIBS
   pthread
   gtest
   dagmciface
-  pyne
+  pyne_dagmc
   ${DAGMC_LIBRARIES}
   pthread
 )


### PR DESCRIPTION
When originally added the the local amalgamated pyne library name accidentally clashes with the libpyne.so library from PyNE itself, thus users that have both installed often get cryptic shared library problems. This fixes this. Tests pass on my machine.