### PR TITLE
Update sigma package

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -20,5 +20,5 @@ included contributions from the following:
 
 The DAGMC project also relies heavily on the MOAB_ and CGM_ projects.
 
-.. _MOAB: http://trac.mcs.anl.gov/projects/ITAPS/wiki/MOAB
-.. _CGM: http://trac.mcs.anl.gov/projects/ITAPS/wiki/CGM
+.. _MOAB: http://sigma.mcs.anl.gov/moab-library/
+.. _CGM: http://sigma.mcs.anl.gov/cgm-library/

--- a/doc/usersguide/get_install.rst
+++ b/doc/usersguide/get_install.rst
@@ -18,8 +18,8 @@ In order to install you must have done the following:
 
  * Cloned the `DAGMC <http://github.com/svalinn/DAGMC>`_ repository
  * Installed `HDF5 <http://www.hdfgroup.org/HDF5/>`_
- * Install `CGM <http://trac.mcs.anl.gov/projects/ITAPS/wiki/CGM>`_, using the --with-cubit option
- * Installed `MOAB <http://trac.mcs.anl.gov/projects/ITAPS/wiki/MOAB>`_,
+ * Install `CGM <http://sigma.mcs.anl.gov/cgm-library/>`_, using the --with-cubit option
+ * Installed `MOAB <http://sigma.mcs.anl.gov/moab-library/>`_,
    using options --with-cgm --with-hdf5 --with-dagmc --without-netcdf 
    If you need to prepare meshed geometries the following are also required
    a) Install `CUBIT <http://cubit.sandia.gov>`_ v12.2 or v13.1

--- a/geant4/README.rst
+++ b/geant4/README.rst
@@ -3,9 +3,9 @@ DagSolid Geant4 Geometry Class
 
 The Direct Acclerated Geometry Monte Carlo (DAGMC) Toolkit is an
 interface (`DAGMC Source
-<http://trac.mcs.anl.gov/projects/ITAPS/browser/MOAB/trunk/tools/dagmc>`_)
+<https://github.com/svalinn/dagmc>`_)
 to the `MOAB mesh database
-<http://trac.mcs.anl.gov/projects/ITAPS/wiki/MOAB>`_ that provides the
+<http://sigma.mcs.anl.gov/moab-library/>`_ that provides the
 methods necessary for ray tracing on a CAD-based geometric model.
 
 This repository provides a DAG implimentation for Geant4 (`Geant4 source

--- a/pyne/pyne.h
+++ b/pyne/pyne.h
@@ -61,7 +61,7 @@
 // DE-AC04-94AL85000 with Sandia Coroporation, the U.S. Government
 // retains certain rights in this software.
 //
-// http://trac.mcs.anl.gov/projects/ITAPS/wiki/MOAB
+// http://sigma.mcs.anl.gov/moab-library/
 // //
 // end of license.txt
 //

--- a/tally/MeshTally.hpp
+++ b/tally/MeshTally.hpp
@@ -44,7 +44,7 @@ class Interface;
  * needed to compute the mesh tally scores.  It must be created in a file format
  * that is supported by the Mesh-Oriented Database (MOAB), which includes both
  * H5M and VTK options.  Source code and more information on MOAB can be found
- * at https://trac.mcs.anl.gov/projects/ITAPS/wiki/MOAB
+ * at http://sigma.mcs.anl.gov/moab-library/
  *
  * In addition to the "inp" key, all MeshTally objects can also include an
  * optional "out"="output_filename" key-value pair.  If the "out" key is not


### PR DESCRIPTION
Points appropriate CGM/MOAB links to the new SIGMA site instead of the old site on trac.


Old site: http://trac.mcs.anl.gov/projects/ITAPS/wiki/MOAB
New one: http://sigma.mcs.anl.gov/moab-library/