### PR TITLE
Removed the pyne nuclear data path, it is no longer required

### DIFF
--- a/fluka/fluka_funcs.cpp
+++ b/fluka/fluka_funcs.cpp
@@ -828,9 +828,6 @@ void fludag_write(std::string matfile, std::string lfname)
   std::ostringstream astr;
   fludagwrite_assignma(astr, pyne_map, map_name);
 
-  // MATERIAL Cards
-  pyne::NUC_DATA_PATH = workflow_data.full_filepath; // for atomic data
-
   // write COMPOUND CARDS
   std::ostringstream mstr;
   fludag_all_materials(mstr, pyne_map);

--- a/geant4/build/src/DagSolidMaterial.cc
+++ b/geant4/build/src/DagSolidMaterial.cc
@@ -7,9 +7,6 @@ std::map<std::string,G4Material*> load_uwuw_materials(UWUW *workflow_data)
 
   //  UWUW workflow_data = UWUW(filename);
 
-  // load the pyne nuclear data
-  pyne::NUC_DATA_PATH = workflow_data->full_filepath;
-
   // new material library
   std::map<std::string,pyne::Material> material_library;
   material_library = workflow_data->material_library;


### PR DESCRIPTION
This PR removes all mentions of pyne::NUC_DATA_PATH as it is now redundant, since the atomic data we need access to is stored directly in memory.