### PR TITLE
[make_watertight] fix trelis sphere unit test

### DIFF
--- a/tools/make_watertight/gen.cpp
+++ b/tools/make_watertight/gen.cpp
@@ -2071,9 +2071,9 @@ moab::ErrorCode delete_vol(moab::EntityHandle volume)
 {
   // Remove the volume set. This also removes parent-child relationships.
   moab::ErrorCode result;
+  std::cout << "  deleting volume " << gen::geom_id_by_handle(volume)  << std::endl;
   result = MBI()->delete_entities(&volume, 1);
   assert(moab::MB_SUCCESS == result);
-  std::cout << "  deleted volume " << gen::geom_id_by_handle(volume)  << std::endl;
   return result;
 }
 

--- a/tools/make_watertight/gen.cpp
+++ b/tools/make_watertight/gen.cpp
@@ -1751,13 +1751,13 @@ moab::ErrorCode delete_surface( moab::EntityHandle surf, moab::Tag geom_tag, moa
       if(gen::error(moab::MB_SUCCESS!=result, "could not delet the parent volume")) return result;
     }
   }
-  
+
   //remove the surface set itself
   result = MBI()->delete_entities( &(surf), 1);
   if(gen::error(moab::MB_SUCCESS!=result,"could not delete surface set")) return result;
   assert(moab::MB_SUCCESS == result);
 
-  
+
   return moab::MB_SUCCESS;
 }
 
@@ -2070,12 +2070,12 @@ moab::ErrorCode check_for_geometry_sets(moab::Tag geom_tag, bool verbose)
 moab::ErrorCode delete_vol(moab::EntityHandle volume)
 {
   // Remove the volume set. This also removes parent-child relationships.
-  moab::ErrorCode result; 
+  moab::ErrorCode result;
   result = MBI()->delete_entities(&volume, 1);
   assert(moab::MB_SUCCESS == result);
-  std::cout << "  deleted volume " << gen::geom_id_by_handle(volume)  << std::endl;  
+  std::cout << "  deleted volume " << gen::geom_id_by_handle(volume)  << std::endl;
   return result;
-}  
-    
+}
+
 
 } //EOL

--- a/tools/make_watertight/gen.cpp
+++ b/tools/make_watertight/gen.cpp
@@ -1748,7 +1748,7 @@ moab::ErrorCode delete_surface( moab::EntityHandle surf, moab::Tag geom_tag, moa
     // delete volume if it only has this surface as its child
     if( child_surfs.size() == 1 && child_surfs[0] == surf ) {
       result = gen::delete_vol(parent_vol);
-      if(gen::error(moab::MB_SUCCESS!=result, "could not delet the parent volume")) return result;
+      if(gen::error(moab::MB_SUCCESS!=result, "could not delete the parent volume")) return result;
     }
   }
 

--- a/tools/make_watertight/gen.cpp
+++ b/tools/make_watertight/gen.cpp
@@ -2058,7 +2058,7 @@ moab::ErrorCode check_for_geometry_sets(moab::Tag geom_tag, bool verbose)
   if(gen::error(moab::MB_SUCCESS!=result,"could not get the geometry meshsets")) return result;
 
   //make sure they're there
-  for(unsigned dim=0; dim<4; dim++) {
+  for(unsigned dim=2; dim<4; dim++) {
 
     if(geometry_sets[dim].size() == 0) return moab::MB_FAILURE;
 

--- a/tools/make_watertight/gen.cpp
+++ b/tools/make_watertight/gen.cpp
@@ -2045,5 +2045,15 @@ moab::ErrorCode check_for_geometry_sets(moab::Tag geom_tag, bool verbose)
   return moab::MB_SUCCESS;
 }
 
+moab::ErrorCode delete_vol(moab::EntityHandle volume)
+{
+  // Remove the volume set. This also removes parent-child relationships.
+  moab::ErrorCode result; 
+  result = MBI()->delete_entities(&volume, 1);
+  assert(moab::MB_SUCCESS == result);
+  std::cout << "  deleted volume " << gen::geom_id_by_handle(*i)  << std::endl;  
+  return result;
+}  
+    
 
 } //EOL

--- a/tools/make_watertight/gen.hpp
+++ b/tools/make_watertight/gen.hpp
@@ -213,6 +213,9 @@ moab::ErrorCode get_geometry_meshsets( moab::Range geometry_sets[], moab::Tag ge
 /// returns MB_FAILURE if there are no geometry sets of any dimension in the model
 moab::ErrorCode check_for_geometry_sets(moab::Tag geom_tag, bool verbose);
 
+/// deletes volume from instance
+moab::ErrorCode delete_vol{moab::EntityHandle volume);
+
 }
 
 #endif

--- a/tools/make_watertight/gen.hpp
+++ b/tools/make_watertight/gen.hpp
@@ -214,7 +214,7 @@ moab::ErrorCode get_geometry_meshsets( moab::Range geometry_sets[], moab::Tag ge
 moab::ErrorCode check_for_geometry_sets(moab::Tag geom_tag, bool verbose);
 
 /// deletes volume from instance
-  moab::ErrorCode delete_vol(moab::EntityHandle volume);
+moab::ErrorCode delete_vol(moab::EntityHandle volume);
 
 }
 

--- a/tools/make_watertight/gen.hpp
+++ b/tools/make_watertight/gen.hpp
@@ -214,7 +214,7 @@ moab::ErrorCode get_geometry_meshsets( moab::Range geometry_sets[], moab::Tag ge
 moab::ErrorCode check_for_geometry_sets(moab::Tag geom_tag, bool verbose);
 
 /// deletes volume from instance
-moab::ErrorCode delete_vol{moab::EntityHandle volume);
+  moab::ErrorCode delete_vol(moab::EntityHandle volume);
 
 }
 

--- a/tools/make_watertight/mw_func.cpp
+++ b/tools/make_watertight/mw_func.cpp
@@ -1837,12 +1837,12 @@ moab::ErrorCode make_mesh_watertight(moab::EntityHandle input_set, double &facet
   if (verbose) std::cout << "Removing small volumes if all surfaces have been removed..." << std::endl;
   for(moab::Range::iterator i=geom_sets[3].begin(); i!=geom_sets[3].end(); ++i) {
     int n_surfs;
-    result = MBI()->num_child_meshsets( *i, &n_surfs );
+    moab::EntityHandle vol = *i;
+    result = MBI()->num_child_meshsets( vol, &n_surfs );
     assert(moab::MB_SUCCESS == result);
     if(0 == n_surfs) {
       // Remove the volume set. This also removes parent-child relationships.
-      std::cout << "  deleted volume " << gen::geom_id_by_handle(*i)  << std::endl;
-      result = MBI()->delete_entities( &(*i), 1);
+      result = gen::delete_vol(vol);
       assert(moab::MB_SUCCESS == result);
       i = geom_sets[3].erase(i) - 1;
     }

--- a/tools/make_watertight/mw_func.cpp
+++ b/tools/make_watertight/mw_func.cpp
@@ -1022,6 +1022,11 @@ moab::ErrorCode prepare_surfaces(moab::Range &surface_sets,
     result = get_unmerged_curves( *i , curve_sets, unmerged_curve_sets, merge_tag, verbose, debug);
     if(gen::error(moab::MB_SUCCESS!=result, " could not get the curves and unmerged curves" )) return result;
 
+    // Save the normals of the facets. These will later be used to determine if
+    // the tri became inverted.
+    result = gen::save_normals( tris, normal_tag );
+    if(gen::error(moab::MB_SUCCESS!=result,"could not save_normals")) return result;
+    assert(moab::MB_SUCCESS == result);
 
     // If all of the curves are merged, remove the surfaces facets.
     if(unmerged_curve_sets.empty()) {
@@ -1073,11 +1078,6 @@ moab::ErrorCode prepare_surfaces(moab::Range &surface_sets,
     if(gen::error(moab::MB_SUCCESS!=result,"could not combine the merged curve sets")) return result;
 
 
-    // Save the normals of the facets. These will later be used to determine if
-    // the tri became inverted.
-    result = gen::save_normals( tris, normal_tag );
-    if(gen::error(moab::MB_SUCCESS!=result,"could not save_normals")) return result;
-    assert(moab::MB_SUCCESS == result);
 
     // Check if edges exist
     int n_edges;

--- a/tools/make_watertight/mw_func.cpp
+++ b/tools/make_watertight/mw_func.cpp
@@ -1038,29 +1038,29 @@ moab::ErrorCode prepare_surfaces(moab::Range &surface_sets,
       bool keep_vol = false;
       std::vector<moab::EntityHandle>::iterator j;
       for( j = parent_volumes.begin(); j != parent_volumes.end(); j++) {
-	moab::EntityHandle parent_vol = *j;
-	std::vector<moab::EntityHandle> child_surfs;
-	result = MBI()->get_child_meshsets(parent_vol, child_surfs);
-	if(gen::error(moab::MB_SUCCESS!=result, "could not get the child surfaces of the volume")) return result;
+        moab::EntityHandle parent_vol = *j;
+        std::vector<moab::EntityHandle> child_surfs;
+        result = MBI()->get_child_meshsets(parent_vol, child_surfs);
+        if(gen::error(moab::MB_SUCCESS!=result, "could not get the child surfaces of the volume")) return result;
 
-	// check if surface is only child
-	if( child_surfs.size() == 1 && child_surfs[0] == *i ) {
-	  moab::Range skin_edges;
-	  //verify that the surface is closed
-	  result = gen::find_skin( tris, 1, skin_edges, false);
-	  if(gen::error(moab::MB_SUCCESS!=result, "could not skin the triangles")) return result;
-	  // if the surface is closed, change this indicator
-	  if( skin_edges.size() == 0 ){
-	    keep_vol = true;
-	  }
-	}
+        // check if surface is only child
+        if( child_surfs.size() == 1 && child_surfs[0] == *i ) {
+          moab::Range skin_edges;
+          //verify that the surface is closed
+          result = gen::find_skin( tris, 1, skin_edges, false);
+          if(gen::error(moab::MB_SUCCESS!=result, "could not skin the triangles")) return result;
+          // if the surface is closed, change this indicator
+          if( skin_edges.size() == 0 ) {
+            keep_vol = true;
+          }
+        }
       }
 
       // if we've decided to keep this volume, then move on
       if(keep_vol) {
-	continue;
+        continue;
       }
-      
+
       result = gen::delete_surface( *i , geom_tag, tris, surf_id, debug, verbose);
       if( gen::error(moab::MB_SUCCESS!=result, "could not delete surface" )) return result;
       // adjust iterator so *i is still the same surface
@@ -1856,7 +1856,7 @@ moab::ErrorCode make_mesh_watertight(moab::EntityHandle input_set, double &facet
   }
   result=gen::get_geometry_meshsets( geom_sets, geom_tag, verbose);
   if(gen::error(moab::MB_SUCCESS!=result, "could not get the geometry meshsets")) return result;
-  
+
   // As sanity check, did zipping drastically change the entity's size?
   if(check_geom_size && verbose) {
     std::cout << "Checking size change of zipped entities..." << std::endl;

--- a/tools/make_watertight/mw_func.cpp
+++ b/tools/make_watertight/mw_func.cpp
@@ -1765,8 +1765,6 @@ moab::ErrorCode make_mesh_watertight(moab::EntityHandle input_set, double &facet
     if(gen::error(moab::MB_SUCCESS!=result,"measuring geom size failed")) return result;
   }
 
-
-
   if (verbose) std::cout << "Getting entity count before sealing..." << std::endl;
   // Get entity count before sealing.
   int orig_n_tris;
@@ -1817,7 +1815,13 @@ moab::ErrorCode make_mesh_watertight(moab::EntityHandle input_set, double &facet
   result = fix_normals(geom_sets[2], id_tag, normal_tag, debug, verbose);
   assert(moab::MB_SUCCESS == result);
 
-
+  //clear out old geometry sets and repopulate (some may have been deleted)
+  for(unsigned int i = 0; i < 4; i++) {
+    geom_sets[i].clear();
+  }
+  result=gen::get_geometry_meshsets( geom_sets, geom_tag, verbose);
+  if(gen::error(moab::MB_SUCCESS!=result, "could not get the geometry meshsets")) return result;
+  
   // As sanity check, did zipping drastically change the entity's size?
   if(check_geom_size && verbose) {
     std::cout << "Checking size change of zipped entities..." << std::endl;

--- a/tools/make_watertight/tests/CMakeLists.txt
+++ b/tools/make_watertight/tests/CMakeLists.txt
@@ -28,6 +28,7 @@ list(APPEND LINK_LIBS gtest)
 # Define executables
 add_executable(make_watertight_cylinder_tests mw_unit_test_driver.cc test_cyl.cpp ${SRC_FILES})
 add_executable(make_watertight_cone_tests mw_unit_test_driver.cc test_cones.cpp ${SRC_FILES})
+add_executable(make_watertight_trelis_sphere_tests mw_unit_test_driver.cc test_trelis_sphere.cpp ${SRC_FILES})
 
 # Includes
 include_directories(..)
@@ -37,13 +38,14 @@ include_directories(${MOAB_INCLUDE_DIRS})
 # Link to libraries
 target_link_libraries(make_watertight_cylinder_tests ${LINK_LIBS})
 target_link_libraries(make_watertight_cone_tests ${LINK_LIBS})
+target_link_libraries(make_watertight_trelis_sphere_tests ${LINK_LIBS})
 
 # Install tests and test models
-install(TARGETS make_watertight_cylinder_tests make_watertight_cone_tests DESTINATION tests PERMISSIONS ${PERMS})
-install(FILES cones.h5m cyl.h5m DESTINATION tests)
+install(TARGETS make_watertight_cylinder_tests make_watertight_cone_tests make_watertight_trelis_sphere_tests DESTINATION tests PERMISSIONS ${PERMS})
+install(FILES cones.h5m cyl.h5m trelis_sphere.h5m DESTINATION tests)
 
 # Add to unit test framework
-add_test(make_watertight_cylinder_tests make_watertight_cylinder_tests)
+add_test(make_watertight_cylinder_tests make_watertight_cylinder_tests make_watertight_trelis_sphere_tests)
 add_test(make_watertight_cone_tests make_watertight_cone_tests)
 
 # enable tests

--- a/tools/make_watertight/tests/CMakeLists.txt
+++ b/tools/make_watertight/tests/CMakeLists.txt
@@ -28,7 +28,7 @@ list(APPEND LINK_LIBS gtest)
 # Define executables
 add_executable(make_watertight_cylinder_tests mw_unit_test_driver.cc test_cyl.cpp ${SRC_FILES})
 add_executable(make_watertight_cone_tests mw_unit_test_driver.cc test_cones.cpp ${SRC_FILES})
-add_executable(make_watertight_trelis_sphere_tests mw_unit_test_driver.cc test_trelis_sphere.cpp ${SRC_FILES})
+add_executable(make_watertight_no_curve_sphere_tests mw_unit_test_driver.cc test_no_curve_sphere.cpp ${SRC_FILES})
 
 # Includes
 include_directories(..)
@@ -38,14 +38,14 @@ include_directories(${MOAB_INCLUDE_DIRS})
 # Link to libraries
 target_link_libraries(make_watertight_cylinder_tests ${LINK_LIBS})
 target_link_libraries(make_watertight_cone_tests ${LINK_LIBS})
-target_link_libraries(make_watertight_trelis_sphere_tests ${LINK_LIBS})
+target_link_libraries(make_watertight_no_curve_sphere_tests ${LINK_LIBS})
 
 # Install tests and test models
-install(TARGETS make_watertight_cylinder_tests make_watertight_cone_tests make_watertight_trelis_sphere_tests DESTINATION tests PERMISSIONS ${PERMS})
-install(FILES cones.h5m cyl.h5m trelis_sphere.h5m DESTINATION tests)
+install(TARGETS make_watertight_cylinder_tests make_watertight_cone_tests make_watertight_no_curve_sphere_tests DESTINATION tests PERMISSIONS ${PERMS})
+install(FILES cones.h5m cyl.h5m no_curve_sphere.h5m DESTINATION tests)
 
 # Add to unit test framework
-add_test(make_watertight_cylinder_tests make_watertight_cylinder_tests make_watertight_trelis_sphere_tests)
+add_test(make_watertight_cylinder_tests make_watertight_cylinder_tests make_watertight_no_curve_sphere_tests)
 add_test(make_watertight_cone_tests make_watertight_cone_tests)
 
 # enable tests

--- a/tools/make_watertight/tests/test_classes.cpp
+++ b/tools/make_watertight/tests/test_classes.cpp
@@ -57,7 +57,8 @@ void MakeWatertightTest::TearDown()
   EXPECT_EQ(result,moab::MB_SUCCESS);
 };
 
-moab::ErrorCode MakeWatertightTest::check_num_ents(int ent_dimension, int expected_num) {
+moab::ErrorCode MakeWatertightTest::check_num_ents(int ent_dimension, int expected_num)
+{
   moab::ErrorCode result;
   moab::Range entities;
   moab::Tag geom_tag;
@@ -658,12 +659,13 @@ moab::ErrorCode MakeWatertightCylinderTest::nonadj_locked_pair_bump_theta(moab::
   return moab::MB_SUCCESS;
 }
 
-moab::ErrorCode MakeWatertightTrelisSphereTest::sphere_deletion_test(moab::EntityHandle input_set, double facet_tolerance, bool verbose) {
+moab::ErrorCode MakeWatertightTrelisSphereTest::sphere_deletion_test(moab::EntityHandle input_set, double facet_tolerance, bool verbose)
+{
   moab::ErrorCode result;
   //seal the model
   result = mw_func::make_mesh_watertight(input_set, facet_tolerance, verbose);
   if(gen::error(moab::MB_SUCCESS!=result, "could not make mesh watertight")) return result;
-  
+
   //make sure the sphere wasn't deleted
   int entity_dimension = 3;
   int num_ents_expected = 1;

--- a/tools/make_watertight/tests/test_classes.cpp
+++ b/tools/make_watertight/tests/test_classes.cpp
@@ -658,19 +658,3 @@ moab::ErrorCode MakeWatertightCylinderTest::nonadj_locked_pair_bump_theta(moab::
 
   return moab::MB_SUCCESS;
 }
-
-moab::ErrorCode MakeWatertightTrelisSphereTest::sphere_deletion_test(moab::EntityHandle input_set, double facet_tolerance, bool verbose)
-{
-  moab::ErrorCode result;
-  //seal the model
-  result = mw_func::make_mesh_watertight(input_set, facet_tolerance, verbose);
-  if(gen::error(moab::MB_SUCCESS!=result, "could not make mesh watertight")) return result;
-
-  //make sure the sphere wasn't deleted
-  int entity_dimension = 3;
-  int num_ents_expected = 1;
-  result = check_num_ents(entity_dimension, num_ents_expected);
-  if(gen::error(moab::MB_SUCCESS!=result, "incorrect number of entities found.")) return result;
-
-  return result;
-}

--- a/tools/make_watertight/tests/test_classes.hpp
+++ b/tools/make_watertight/tests/test_classes.hpp
@@ -45,6 +45,10 @@ class MakeWatertightTest : public ::testing::Test
   void reload_mesh();
   virtual void TearDown();
   virtual void setFilename() {};
+
+  // make sure the expected number of entities with dimension are present
+  moab::ErrorCode check_num_ents(int ent_dimension, int expected_num);
+
   // moves the vertex by dx, dy, dz
   moab::ErrorCode move_vert(moab::EntityHandle vertex, double dx, double dy, double dz, bool verbose = false);
 
@@ -154,3 +158,17 @@ class MakeWatertightCylinderTest : public MakeWatertightTest
   moab::ErrorCode nonadj_locked_pair_bump_theta(moab::Range verts, double facet_tol, bool verbose = false);
 
 };
+
+// Rename of the general test class
+class MakeWatertightTrelisSphereTest : public MakeWatertightTest
+{
+ protected:
+  // set test file name
+  virtual void setFilename() {
+    filename = "trelis_sphere.h5m";
+  };
+
+  moab::ErrorCode sphere_deletion_test(moab::EntityHandle input_set, double facet_tolerance, bool verbose = false);
+};
+
+

--- a/tools/make_watertight/tests/test_classes.hpp
+++ b/tools/make_watertight/tests/test_classes.hpp
@@ -160,12 +160,12 @@ class MakeWatertightCylinderTest : public MakeWatertightTest
 };
 
 // Rename of the general test class
-class MakeWatertightTrelisSphereTest : public MakeWatertightTest
+class MakeWatertightNoCurveSphereTest : public MakeWatertightTest
 {
  protected:
   // set test file name
   virtual void setFilename() {
-    filename = "trelis_sphere.h5m";
+    filename = "no_curve_sphere.h5m";
   };
 
   moab::ErrorCode sphere_deletion_test(moab::EntityHandle input_set, double facet_tolerance, bool verbose = false);

--- a/tools/make_watertight/tests/test_no_curve_sphere.cpp
+++ b/tools/make_watertight/tests/test_no_curve_sphere.cpp
@@ -12,13 +12,13 @@
 
 
 //Make sure the sphere is not deleted when sealing
-TEST_F(MakeWatertightTrelisSphereTest, TelisSphereDeletionCheck)
-{
-  EXPECT_NO_THROW(result = sphere_deletion_test(input_fileset, facet_tol));
-  EXPECT_TRUE(result == moab::MB_SUCCESS);
-}
-
-TEST_F(MakeWatertightTrelisSphereTest, TrelisSphereSealingCheck)
+TEST_F(MakeWatertightNoCurveSphereTest, NoCurveSphereDeletionCheck)
 {
   EXPECT_TRUE(seal_and_check(input_fileset, facet_tol));
+
+  //make sure the sphere wasn't deleted
+  int entity_dimension = 3;
+  int num_ents_expected = 1;
+  EXPECT_NO_THROW(result = check_num_ents(entity_dimension, num_ents_expected));
+  EXPECT_TRUE(result == moab::MB_SUCCESS);
 }

--- a/tools/make_watertight/tests/test_trelis_sphere.cpp
+++ b/tools/make_watertight/tests/test_trelis_sphere.cpp
@@ -1,0 +1,22 @@
+//
+// Patrick Shriwise
+// September 2016
+// This program is designed to run a set of tests on the make_watertight algorithm.
+// This will be a stand-alone piece of code that uses MOAB to open, modify
+// (break), and re-seal geometries
+// input: cyl.h5m file (found in ../make_watertight/test/)
+// output: pass/fail for each of the tests
+
+#include "test_classes.hpp"
+#include "gtest/gtest.h"
+
+
+//Make sure the sphere is not deleted when sealing
+TEST_F(MakeWatertightTrelisSphereTest, TelisSphereDeletionCheck) {
+  EXPECT_NO_THROW(result = sphere_deletion_test(input_fileset, facet_tol));
+  EXPECT_TRUE(result == moab::MB_SUCCESS);
+}
+
+TEST_F(MakeWatertightTrelisSphereTest, TrelisSphereSealingCheck) {
+  EXPECT_TRUE(seal_and_check(input_fileset, facet_tol));
+}

--- a/tools/make_watertight/tests/test_trelis_sphere.cpp
+++ b/tools/make_watertight/tests/test_trelis_sphere.cpp
@@ -12,11 +12,13 @@
 
 
 //Make sure the sphere is not deleted when sealing
-TEST_F(MakeWatertightTrelisSphereTest, TelisSphereDeletionCheck) {
+TEST_F(MakeWatertightTrelisSphereTest, TelisSphereDeletionCheck)
+{
   EXPECT_NO_THROW(result = sphere_deletion_test(input_fileset, facet_tol));
   EXPECT_TRUE(result == moab::MB_SUCCESS);
 }
 
-TEST_F(MakeWatertightTrelisSphereTest, TrelisSphereSealingCheck) {
+TEST_F(MakeWatertightTrelisSphereTest, TrelisSphereSealingCheck)
+{
   EXPECT_TRUE(seal_and_check(input_fileset, facet_tol));
 }


### PR DESCRIPTION
This PR contains a few changes to make_watertight and a new unit test for make_watertight to address issues #436 and #437

Summary of changes:

* upon deleting a surface, make_watertight now looks at all parent volumes of the surface to check if this was the last surface used to define that volume. If so, the volume is deleted along with the surface. (This condition is reached when there are no curves for the surface, so the curve sets should already be taken care of.)

* make_watertight now accepts the existence of a volume without curves so long as the following conditions are met:
    1) one of its parent volumes is composed of a single surface which is the surface w/o curves
    2) the surface of that volume contains a watertight set of triangles (this is verified by confirming that there are no skin edges returned by the find_skin operation in make_watertight)

* an addition of a unit test for make_watertight which is a sphere produced in Trelis containing no geometric curves. The test verifies that make_watertight reports a successful sealing of the model and that the volume is not deleted in the process.
