### PR TITLE
[make_watertight] regression tests

### DIFF
--- a/.run_tests.sh
+++ b/.run_tests.sh
@@ -28,9 +28,9 @@ cd tests
 ./make_watertight_cone_tests
 # if this is not a pull request, run regression tests
 if [ ! TRAVIS_PULL_REQUEST ] ; then
-wget $MW_REG_TEST_MODELS_URL -O mw_reg_test_files.tar.gz -o wget.out
-tar xzvf mw_reg_test_files.tar.gz
-./make_watertight_regression_tests
+    wget $MW_REG_TEST_MODELS_URL -O mw_reg_test_files.tar.gz -o wget.out
+    tar xzvf mw_reg_test_files.tar.gz
+    ./make_watertight_regression_tests
 fi
 # move to the base directory
 cd ..

--- a/.run_tests.sh
+++ b/.run_tests.sh
@@ -26,6 +26,12 @@ cd tests
 ./make_watertight_no_curve_sphere_tests
 ./make_watertight_cylinder_tests
 ./make_watertight_cone_tests
+# if this is not a pull request, run regression tests
+if [ ! TRAVIS_PULL_REQUEST ] ; then
+wget $MW_REG_TEST_MODELS_URL -O mw_reg_test_files.tar.gz -o wget.out
+tar xzvf mw_reg_test_files.tar.gz
+./make_watertight_regression_tests
+fi
 # move to the base directory
 cd ..
 # remove the bld dir

--- a/.run_tests.sh
+++ b/.run_tests.sh
@@ -27,7 +27,7 @@ cd tests
 ./make_watertight_cylinder_tests
 ./make_watertight_cone_tests
 # if this is not a pull request, run regression tests
-if [ ! TRAVIS_PULL_REQUEST ] ; then
+if [ ! -z $TRAVIS_PULL_REQUEST ] && [ $TRAVIS_PULL_REQUEST == "false" ] ; then
     wget $MW_REG_TEST_MODELS_URL -O mw_reg_test_files.tar.gz -o wget.out
     tar xzvf mw_reg_test_files.tar.gz
     ./make_watertight_regression_tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,6 @@ install:
   - commit_id=$(sudo docker ps -l | tail -n1 | awk '{print $1}')
   - sudo docker commit $commit_id makeclean/dagmc-ci
 script:
-  - sudo docker run makeclean/dagmc-ci /bin/sh -c "cd /root/dagmc/ ; ./.run_tests.sh"
+  - sudo docker run makeclean/dagmc-ci /bin/sh -c "cd /root/dagmc/ ; export TRAVIS_PULL_REQUEST=$TRAVIS_PULL_REQUEST ; export MW_REG_TEST_MODELS_URL=$MW_REG_TEST_MODELS_URL ; ./.run_tests.sh"
   - commit_id=$(sudo docker ps -l | tail -n1 | awk '{print $1}')
   - sudo docker commit $commit_id makeclean/dagmc-ci

--- a/tools/make_watertight/tests/CMakeLists.txt
+++ b/tools/make_watertight/tests/CMakeLists.txt
@@ -29,6 +29,7 @@ list(APPEND LINK_LIBS gtest)
 add_executable(make_watertight_cylinder_tests mw_unit_test_driver.cc test_cyl.cpp ${SRC_FILES})
 add_executable(make_watertight_cone_tests mw_unit_test_driver.cc test_cones.cpp ${SRC_FILES})
 add_executable(make_watertight_no_curve_sphere_tests mw_unit_test_driver.cc test_no_curve_sphere.cpp ${SRC_FILES})
+add_executable(make_watertight_regression_tests mw_unit_test_driver.cc regression_tests.cpp ${SRC_FILES})
 
 # Includes
 include_directories(..)
@@ -39,6 +40,7 @@ include_directories(${MOAB_INCLUDE_DIRS})
 target_link_libraries(make_watertight_cylinder_tests ${LINK_LIBS})
 target_link_libraries(make_watertight_cone_tests ${LINK_LIBS})
 target_link_libraries(make_watertight_no_curve_sphere_tests ${LINK_LIBS})
+target_link_libraries(make_watertight_regression_tests ${LINK_LIBS})
 
 # Install tests and test models
 install(TARGETS make_watertight_cylinder_tests make_watertight_cone_tests make_watertight_no_curve_sphere_tests DESTINATION tests PERMISSIONS ${PERMS})

--- a/tools/make_watertight/tests/CMakeLists.txt
+++ b/tools/make_watertight/tests/CMakeLists.txt
@@ -44,7 +44,9 @@ target_link_libraries(make_watertight_regression_tests ${LINK_LIBS})
 
 # Install tests and test models
 install(TARGETS make_watertight_cylinder_tests make_watertight_cone_tests make_watertight_no_curve_sphere_tests DESTINATION tests PERMISSIONS ${PERMS})
+install(TARGETS make_watertight_regression_tests DESTINATION tests PERMISSIONS ${PERMS})
 install(FILES cones.h5m cyl.h5m no_curve_sphere.h5m DESTINATION tests)
+
 
 # Add to unit test framework
 add_test(make_watertight_cylinder_tests make_watertight_cylinder_tests make_watertight_no_curve_sphere_tests)

--- a/tools/make_watertight/tests/regression_tests.cpp
+++ b/tools/make_watertight/tests/regression_tests.cpp
@@ -6,33 +6,33 @@
 class ITERMakeWatertightRegressionTest : public MakeWatertightTest
 {
 
-protected:
+ protected:
   virtual void setFilename() {
     filename = "iter_imprinted.h5m";
   };
-  
+
 };
 
 class FNSFMakeWatertightRegressionTest : public MakeWatertightTest
 {
 
-protected:
+ protected:
   virtual void setFilename() {
     filename = "model1_360_1.h5m";
   };
-  
+
 };
 
 class BLiteMakeWatertightRegressionTest : public MakeWatertightTest
 {
 
-protected:
+ protected:
   virtual void setFilename() {
     filename = "bllite30matls.h5m";
   };
-  
+
 };
-  
+
 TEST_F(ITERMakeWatertightRegressionTest, ITERRegressionTest )
 {
   EXPECT_TRUE(seal_and_check(input_fileset, facet_tol));

--- a/tools/make_watertight/tests/regression_tests.cpp
+++ b/tools/make_watertight/tests/regression_tests.cpp
@@ -1,0 +1,49 @@
+
+
+#include "gtest/gtest.h"
+#include "test_classes.hpp"
+
+class ITERMakeWatertightRegressionTest : public MakeWatertightTest
+{
+
+protected:
+  virtual void setFilename() {
+    filename = "iter_imprinted.h5m";
+  };
+  
+};
+
+class FNSFMakeWatertightRegressionTest : public MakeWatertightTest
+{
+
+protected:
+  virtual void setFilename() {
+    filename = "model1_360_1.h5m";
+  };
+  
+};
+
+class BLiteMakeWatertightRegressionTest : public MakeWatertightTest
+{
+
+protected:
+  virtual void setFilename() {
+    filename = "bllite30matls.h5m";
+  };
+  
+};
+  
+TEST_F(ITERMakeWatertightRegressionTest, ITERRegressionTest )
+{
+  EXPECT_TRUE(seal_and_check(input_fileset, facet_tol));
+}
+
+TEST_F(FNSFMakeWatertightRegressionTest, FNSFRegressionTest )
+{
+  EXPECT_TRUE(seal_and_check(input_fileset, facet_tol));
+}
+
+TEST_F(BLiteMakeWatertightRegressionTest, BLiteRegressionTest )
+{
+  EXPECT_TRUE(seal_and_check(input_fileset, facet_tol));
+}


### PR DESCRIPTION
This PR adds new test classes for make_watertight regression tests which will only run with DAGMC's nightly builds (so they won't be run as part of this PR). 

The test models are served from UW box and retrieved by travis via `wget` in the docker instance.