### PR TITLE
Update amalgamated pyne documentation

### DIFF
--- a/pyne/README.md
+++ b/pyne/README.md
@@ -1,16 +1,16 @@
 Amalgamated PyNE Build
 ==========================================================
-The DAGMC toolkit now includes an amalgamated build of PyNE version 0.5, this helps
-building of DAGMC on clusters and other systems that don't need nessesarilly need 
-a full installation of PyNE.
+The DAGMC toolkit now includes an amalgamated build of PyNE version 0.5. This
+helps the building of DAGMC on clusters and other systems that don't necessarily
+need a full installation of PyNE.
 
 Updating the PyNE Build
 ==========================================================
-You need to generate the atomic and decay data from PyNE, issue the following commands from
-the pyne/src directory
+You will need to generate the atomic and decay data from PyNE. Issue the
+following commands from the pyne/src directory:
 
-     python decaygen.py
-     python atomicgen.py
+    python decaygen.py
+    python atomicgen.py
 
 To generate the PyNE amalgamated source files, we use the following command:
 
@@ -22,16 +22,29 @@ To generate the PyNE amalgamated source files, we use the following command:
      src/atomic_data.*
 
 The above represents the smallest build that is trivially compilable without
-errors. 
+errors.
 
-At the time of writing due to a bug in PyNE the produced source files will not
-compile directly you must currently modifiy the line in pyne.cpp that says
-``#include "particle.h"''
+At the time of writing, the produced file ``pyne.cpp`` will need to be edited
+slightly in order to make DAMGC compilable. You must comment out the line in
+``pyne.cpp`` that says
+
+    #include "particle.h"
+
+and you must also replace the code inside the function
+``pyne::Material pyne::Material::decay(double t)`` with
+
+    pyne::Material pyne::Material::decay(double t)
+    {
+      Material rtn;
+      std::cout << "--Warning--Warning--Warning--Warning--Warning--Warning--" << std::endl;
+      std::cout << "  There is no decay function in the material object within" << std::endl;
+      std::cout << "  this amalgamated pyne build" << std::endl;
+      std::cout << "--Warning--Warning--Warning--Warning--Warning--Warning--" << std::endl;
+      return rtn;
+    }
 
 User update of PyNE
 ===========================================================
-If a DAGMC users wishes to update the version of PyNE associated with 
-DAGMC, they need only update the the amalgamated build by including the additional
-source files they need relative to the above.
-
-
+If a DAGMC user wishes to update the version of PyNE associated with DAGMC, they
+need only update the the amalgamated build by including the additional source
+files they need relative to the above list.

--- a/pyne/README.md
+++ b/pyne/README.md
@@ -25,7 +25,7 @@ The above represents the smallest build that is trivially compilable without
 errors.
 
 At the time of writing, the produced file ``pyne.cpp`` will need to be edited
-slightly in order to make DAMGC compilable. You must comment out the line in
+slightly in order to make DAGMC compilable. You must comment out the line in
 ``pyne.cpp`` that says
 
     #include "particle.h"


### PR DESCRIPTION
Removed ``decay.*`` from the instructions and added more instructions about the manual changes you need to make to produce a working ``pyne.cpp``.