### PR TITLE
[make_watertight] alter conditions for ignoring surface without curves

### DIFF
--- a/.run_tests.sh
+++ b/.run_tests.sh
@@ -26,6 +26,7 @@ cd tests
 ./uwuw_unit_tests_tally
 ./uwuw_unit_tests_preprocessor
 ./make_watertight_no_curve_sphere_tests
+./make_watertight_sphere_n_box_test
 ./make_watertight_cylinder_tests
 ./make_watertight_cone_tests
 # if this is not a pull request, run regression tests

--- a/.run_tests.sh
+++ b/.run_tests.sh
@@ -33,6 +33,9 @@ if [ ! -z $TRAVIS_PULL_REQUEST ] && [ $TRAVIS_PULL_REQUEST == "false" ] ; then
     wget $MW_REG_TEST_MODELS_URL -O mw_reg_test_files.tar.gz -o wget.out
     tar xzvf mw_reg_test_files.tar.gz
     ./make_watertight_regression_tests
+    if [ $? != 0 ]; then
+	exit 1
+    fi
 fi
 # move to the base directory
 cd ..

--- a/tools/make_watertight/MakeWatertight.cpp
+++ b/tools/make_watertight/MakeWatertight.cpp
@@ -1046,7 +1046,7 @@ moab::ErrorCode MakeWatertight::prepare_surfaces(moab::Range &surface_sets,
       MB_CHK_SET_ERR(result, "could not skin the triangles");
       // if the surface is closed, continue to next surface
       if(tris.size() != 4 && skin_edges.size() == 0 && curve_sets.empty()) {
-	continue;
+        continue;
       }
 
       result = gen->delete_surface( *i , geom_tag, tris, surf_id, debug, verbose);

--- a/tools/make_watertight/MakeWatertight.cpp
+++ b/tools/make_watertight/MakeWatertight.cpp
@@ -1038,39 +1038,15 @@ moab::ErrorCode MakeWatertight::prepare_surfaces(moab::Range &surface_sets,
     // If all of the curves are merged, remove the surfaces facets.
     if(unmerged_curve_sets.empty()) {
 
-      // if this surface is the sole child of one of its parent volumes, it is closed, and contains triangles
+      // if this surface is closed and contains triangles
       // then we will leave it alone but continue as we normally would
-
-      //retrieve parent volumes
-      std::vector<moab::EntityHandle> parent_volumes;
-      result = MBI()->get_parent_meshsets( *i, parent_volumes);
-      MB_CHK_SET_ERR(result,"could not get the surface's parent meshsets");
-
-      //check each parent volume
-      bool keep_vol = false;
-      std::vector<moab::EntityHandle>::iterator j;
-      for( j = parent_volumes.begin(); j != parent_volumes.end(); j++) {
-        moab::EntityHandle parent_vol = *j;
-        std::vector<moab::EntityHandle> child_surfs;
-        result = MBI()->get_child_meshsets(parent_vol, child_surfs);
-        MB_CHK_SET_ERR(result, "could not get the child surfaces of the volume");
-
-        // check if surface is only child
-        if( child_surfs.size() == 1 && child_surfs[0] == *i ) {
-          moab::Range skin_edges;
-          //verify that the surface is closed
-          result = gen->find_skin( tris, 1, skin_edges, false);
-          MB_CHK_SET_ERR(result, "could not skin the triangles");
-          // if the surface is closed, change this indicator
-          if( skin_edges.size() == 0 ) {
-            keep_vol = true;
-          }
-        }
-      }
-
-      // if we've decided to keep this volume, then move on
-      if(keep_vol) {
-        continue;
+      //verify that the surface is closed
+      moab::Range skin_edges;
+      result = gen->find_skin( tris, 1, skin_edges, false);
+      MB_CHK_SET_ERR(result, "could not skin the triangles");
+      // if the surface is closed, continue to next surface
+      if(tris.size() != 4 && skin_edges.size() == 0 && curve_sets.empty()) {
+	continue;
       }
 
       result = gen->delete_surface( *i , geom_tag, tris, surf_id, debug, verbose);

--- a/tools/make_watertight/tests/CMakeLists.txt
+++ b/tools/make_watertight/tests/CMakeLists.txt
@@ -29,6 +29,7 @@ list(APPEND LINK_LIBS gtest)
 add_executable(make_watertight_cylinder_tests mw_unit_test_driver.cc test_cyl.cpp ${SRC_FILES})
 add_executable(make_watertight_cone_tests mw_unit_test_driver.cc test_cones.cpp ${SRC_FILES})
 add_executable(make_watertight_no_curve_sphere_tests mw_unit_test_driver.cc test_no_curve_sphere.cpp ${SRC_FILES})
+add_executable(make_watertight_sphere_n_box_test mw_unit_test_driver.cc test_sphere_n_box.cpp ${SRC_FILES})
 add_executable(make_watertight_regression_tests mw_unit_test_driver.cc regression_tests.cpp ${SRC_FILES})
 
 # Includes
@@ -40,17 +41,19 @@ include_directories(${MOAB_INCLUDE_DIRS})
 target_link_libraries(make_watertight_cylinder_tests ${LINK_LIBS})
 target_link_libraries(make_watertight_cone_tests ${LINK_LIBS})
 target_link_libraries(make_watertight_no_curve_sphere_tests ${LINK_LIBS})
+target_link_libraries(make_watertight_sphere_n_box_test ${LINK_LIBS})
 target_link_libraries(make_watertight_regression_tests ${LINK_LIBS})
 
 # Install tests and test models
-install(TARGETS make_watertight_cylinder_tests make_watertight_cone_tests make_watertight_no_curve_sphere_tests DESTINATION tests PERMISSIONS ${PERMS})
+install(TARGETS make_watertight_cylinder_tests make_watertight_cone_tests make_watertight_no_curve_sphere_tests make_watertight_sphere_n_box_test DESTINATION tests PERMISSIONS ${PERMS})
 install(TARGETS make_watertight_regression_tests DESTINATION tests PERMISSIONS ${PERMS})
-install(FILES cones.h5m cyl.h5m no_curve_sphere.h5m DESTINATION tests)
+install(FILES cones.h5m cyl.h5m no_curve_sphere.h5m sphere_n_box.h5m DESTINATION tests)
 
 
 # Add to unit test framework
-add_test(make_watertight_cylinder_tests make_watertight_cylinder_tests make_watertight_no_curve_sphere_tests)
+add_test(make_watertight_cylinder_tests make_watertight_cylinder_tests)
 add_test(make_watertight_cone_tests make_watertight_cone_tests)
+add_test(make_watertight_no_curve_sphere_tests make_watertight_sphere_n_box_test)
 
 # enable tests
 enable_testing()

--- a/tools/make_watertight/tests/test_sphere_n_box.cpp
+++ b/tools/make_watertight/tests/test_sphere_n_box.cpp
@@ -1,0 +1,26 @@
+
+#include "gtest/gtest.h"
+#include "test_classes.hpp"
+
+class SphereNBoxMakeWatertightTest : public MakeWatertightTest
+{
+
+ protected:
+  virtual void setFilename() {
+    filename = "sphere_n_box.h5m";
+  };
+
+};
+
+
+TEST_F(SphereNBoxMakeWatertightTest, SphereNBoxTest )
+{
+  //make sure that the expected number of surfaces exist
+  int dim = 2, expected_num_surfs = 7;
+  moab::ErrorCode rval;
+  rval = check_num_ents(dim, expected_num_surfs);
+  EXPECT_TRUE(moab::MB_SUCCESS == rval);
+  EXPECT_TRUE(seal_and_check(input_fileset, facet_tol));
+  rval = check_num_ents(dim, expected_num_surfs);
+  EXPECT_TRUE(moab::MB_SUCCESS == rval);
+}


### PR DESCRIPTION
This PR alters the conditions under which `make_watertight` will keep a surface without curves rather than deleting it.
These conditions are now: 
 - the surface has no child curves
 - the surface has at least 4 triangles
 - the surface has no skin edges (the surface is a closed body)

Removed from this list is: 
 - ~the surface is the only child of a parent volume~