### PR TITLE
Set travis test script to exit on error.

### DIFF
--- a/.run_tests.sh
+++ b/.run_tests.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 export LD_LIBRARY_PATH=/root/geant4.10.00.p02/lib
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/root/moab/lib
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/root/dagmc/lib


### PR DESCRIPTION
Some failing tests were being missed because travis would continue to run this script despite the exit code of individual commands in the script. This should force the script to exit after the first failing test. If we'd rather all the tests run and the number of errors be accumulated, I can look into that as well.