### PR TITLE
added dag-shift info

### DIFF
--- a/doc/install/dag-shift.rst
+++ b/doc/install/dag-shift.rst
@@ -1,3 +1,8 @@
 ..  |DAG-Code| replace:: DAG-Shift
 
 ..  include:: header.txt
+
+DAG-Shift is still under development at Oak Ridge National Laboratory. Shift is
+the massively parallel Monte Carlo code in Scale. DAG-Shift is internally
+functioning, but has not yet been released. For further information about DAG-Shift
+please contact `Greg Davidson <mailto:davidsongg@ornl.gov>`_ at ORNL.


### PR DESCRIPTION
I added a brief description and contact information for DAG-Shift. No more information can be added about installation and capabilities until it is released in Scale.