### PR TITLE
Add some tests and fix others

### DIFF
--- a/.build_dagmc.sh
+++ b/.build_dagmc.sh
@@ -3,7 +3,11 @@
 export LD_LIBRARY_PATH="/root/moab/lib"
 mkdir bld
 cd bld
-cmake ../. -DBUILD_TALLY=ON -DBUILD_GEANT4=ON -DGEANT4_DIR=/root/geant4.10.00.p02 -DCMAKE_INSTALL_PREFIX=/root/dagmc
+cmake ../. -DBUILD_TALLY=ON \
+           -DBUILD_TESTS=ON \
+           -DBUILD_GEANT4=ON \
+           -DGEANT4_DIR=/root/geant4.10.00.p02 \
+           -DCMAKE_INSTALL_PREFIX=/root/dagmc
 make 
 make install
 export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/root/dagmc/lib"

--- a/.run_tests.sh
+++ b/.run_tests.sh
@@ -29,6 +29,7 @@ cd tests
 ./make_watertight_sphere_n_box_test
 ./make_watertight_cylinder_tests
 ./make_watertight_cone_tests
+./dagmcnp_unit_tests
 # if this is not a pull request, run regression tests
 if [ ! -z $TRAVIS_PULL_REQUEST ] && [ $TRAVIS_PULL_REQUEST == "false" ] ; then
     wget $MW_REG_TEST_MODELS_URL -O mw_reg_test_files.tar.gz -o wget.out

--- a/.run_tests.sh
+++ b/.run_tests.sh
@@ -32,12 +32,12 @@ cd tests
 ./dagmcnp_unit_tests
 # if this is not a pull request, run regression tests
 if [ ! -z $TRAVIS_PULL_REQUEST ] && [ $TRAVIS_PULL_REQUEST == "false" ] ; then
-    wget $MW_REG_TEST_MODELS_URL -O mw_reg_test_files.tar.gz -o wget.out
-    tar xzvf mw_reg_test_files.tar.gz
-    ./make_watertight_regression_tests
-    if [ $? != 0 ]; then
-	exit 1
-    fi
+  wget $MW_REG_TEST_MODELS_URL -O mw_reg_test_files.tar.gz -o wget.out
+  tar xzvf mw_reg_test_files.tar.gz
+  ./make_watertight_regression_tests
+  if [ $? != 0 ]; then
+    exit 1
+  fi
 fi
 # move to the base directory
 cd ..

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,10 @@ add_subdirectory(tools)
 
 # Build tests that wouldn't normally be built for the CI
 if (BUILD_TESTS)
-  add_subdirectory(tally)
-  add_subdirectory(mcnp/test)
+  if (NOT BUILD_TALLY)
+    add_subdirectory(tally)
+  endif (NOT BUILD_TALLY)
+  if (NOT BUILD_MCNP5 AND NOT BUILD_MCNP6)
+    add_subdirectory(mcnp/test)
+  endif (NOT BUILD_MCNP5 AND NOT BUILD_MCNP6)
 endif (BUILD_TESTS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,3 +102,9 @@ add_subdirectory(common)
 
 # Build tools
 add_subdirectory(tools)
+
+# Build tests that wouldn't normally be built for the CI
+if (BUILD_TESTS)
+  add_subdirectory(tally)
+  add_subdirectory(mcnp/test)
+endif (BUILD_TESTS)

--- a/common/test/dagmciface_unit_tests.cpp
+++ b/common/test/dagmciface_unit_tests.cpp
@@ -1,5 +1,3 @@
-// FluDAG/src/test/test_FlukaFuncs.cpp
-
 #include <gtest/gtest.h>
 
 #include "DagMC.hpp"

--- a/fluka/CMakeLists.txt
+++ b/fluka/CMakeLists.txt
@@ -28,7 +28,8 @@ target_link_libraries(fludag ${LINK_LIBS})
 install(TARGETS fludag LIBRARY       DESTINATION ${INSTALL_LIB_DIR}
                        ARCHIVE       DESTINATION ${INSTALL_LIB_DIR}
                        PUBLIC_HEADER DESTINATION ${INSTALL_INCLUDE_DIR}
-                       LIBRARY       PERMISSIONS ${PERMS})
+                       LIBRARY       PERMISSIONS ${PERMS}
+                       ARCHIVE       PERMISSIONS ${PERMS})
 
 # Build FluDAG
 add_subdirectory(build)

--- a/mcnp/test/CMakeLists.txt
+++ b/mcnp/test/CMakeLists.txt
@@ -18,7 +18,7 @@ include_directories(${GTEST_INCLUDE_DIR})
 # Setup unit tests
 set(TEST_NAME dagmcnp_unit_tests)
 set(DRIVER mcnp5_unit_test_driver.cc)
-add_executable(${test_name} R{TEST_NAME}.cpp ../mcnp_funcs.cpp ${DRIVER})
+add_executable(${TEST_NAME} ${TEST_NAME}.cpp ../mcnp_funcs.cpp ${DRIVER})
 target_link_libraries(${TEST_NAME} "${LINK_LIBS}")
 install(TARGETS ${TEST_NAME} DESTINATION tests
                              PERMISSIONS ${PERMS})

--- a/mcnp/test/CMakeLists.txt
+++ b/mcnp/test/CMakeLists.txt
@@ -10,13 +10,19 @@ list(APPEND LINK_LIBS ${DAG_LINK_LIBS})
 
 # Include directories
 include_directories(..)
+include_directories(../../common)
 include_directories(${MOAB_INCLUDE_DIRS})
 include_directories(${HDF5_INCLUDE_DIRS})
 include_directories(${GTEST_INCLUDE_DIR})
 
 # Setup unit tests
+set(TEST_NAME dagmcnp_unit_tests)
 set(DRIVER mcnp5_unit_test_driver.cc)
-setup_test(dagmcnp_unit_tests cpp ${DRIVER} "${LINK_LIBS}")
+add_executable(${test_name} R{TEST_NAME}.cpp ../mcnp_funcs.cpp ${DRIVER})
+target_link_libraries(${TEST_NAME} "${LINK_LIBS}")
+install(TARGETS ${TEST_NAME} DESTINATION tests
+                             PERMISSIONS ${PERMS})
+add_test(${TEST_NAME} ${TEST_NAME})
 
 # Install h5m files
 install(FILES test_geom_legacy.h5m DESTINATION tests)

--- a/mcnp/test/CMakeLists.txt
+++ b/mcnp/test/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LINK_LIBS)
 list(APPEND LINK_LIBS gtest)
 list(APPEND LINK_LIBS pthread)
 list(APPEND LINK_LIBS dagmciface)
+list(APPEND LINK_LIBS dagtally)
 list(APPEND LINK_LIBS ${DAG_LINK_LIBS})
 
 # Include directories

--- a/mcnp/test/CMakeLists.txt
+++ b/mcnp/test/CMakeLists.txt
@@ -10,7 +10,7 @@ list(APPEND LINK_LIBS ${DAG_LINK_LIBS})
 
 # Include directories
 include_directories(..)
-include_directories(../../common)
+include_directories(${CMAKE_SOURCE_DIR}/common)
 include_directories(${MOAB_INCLUDE_DIRS})
 include_directories(${HDF5_INCLUDE_DIRS})
 include_directories(${GTEST_INCLUDE_DIR})

--- a/mcnp/test/dagmcnp_unit_tests.cpp
+++ b/mcnp/test/dagmcnp_unit_tests.cpp
@@ -69,8 +69,8 @@ TEST_F(DAGMCNP5Test, dagmcinit_test)
                             "7 3 -2.0 imp:n=1 imp:p=1 ",
                             "8 3 -2.0 imp:n=1 imp:p=1 ",
                             "9 1 0.022 imp:n=1 imp:p=1 ",
-                            "12 0  imp:n=0 imp:p=0 ",
-                            "13 0  imp:n=1 imp:p=1 "
+                            "12 0  imp:n=0 imp:p=0   $ graveyard",
+                            "13 0  imp:n=1 imp:p=1   $ implicit complement"
                            };
   std::vector<std::string> expected_lcad(expected,expected+11);
 
@@ -122,8 +122,8 @@ TEST_F(DAGMCNP5Test, dagmcinit_comp_test)
                             "7 3 -2.0 imp:n=1 imp:p=1 ",
                             "8 3 -2.0 imp:n=1 imp:p=1 ",
                             "9 1 0.022 imp:n=1 imp:p=1 ",
-                            "12 0  imp:n=0 imp:p=0 ",
-                            "13 2 -3.1 imp:n=1 imp:p=1 "
+                            "12 0  imp:n=0 imp:p=0   $ graveyard",
+                            "13 2 -3.1 imp:n=1 imp:p=1   $ implicit complement"
                            };
   std::vector<std::string> expected_lcad(expected,expected+11);
 

--- a/tally/tests/test_TrackLengthMeshTally.cpp
+++ b/tally/tests/test_TrackLengthMeshTally.cpp
@@ -1181,10 +1181,10 @@ TEST_F(TrackLengthMeshTallyTest, ComputeScoreTallyManager1RayNeutron)
 
   mod_event(event, 1.0, 1.0, 1.0);
   tallyManager->setTrackEvent(event.particle,
-      event.position[0], event.position[1], event.position[2],
-      event.direction[0], event.direction[1], event.direction[2],
-      event.particle_energy, event.particle_weight, event.track_length,
-      event.current_cell);
+                              event.position[0], event.position[1], event.position[2],
+                              event.direction[0], event.direction[1], event.direction[2],
+                              event.particle_energy, event.particle_weight, event.track_length,
+                              event.current_cell);
   tallyManager->updateTallies();
   tallyManager->endHistory();
 
@@ -1219,10 +1219,10 @@ TEST_F(TrackLengthMeshTallyTest, ComputeScoreTallyManager1RayProton)
 
   mod_event(event, 1.0, 1.0, 1.0);
   tallyManager->setTrackEvent(event.particle,
-      event.position[0], event.position[1], event.position[2],
-      event.direction[0], event.direction[1], event.direction[2],
-      event.particle_energy, event.particle_weight, event.track_length,
-      event.current_cell);
+                              event.position[0], event.position[1], event.position[2],
+                              event.direction[0], event.direction[1], event.direction[2],
+                              event.particle_energy, event.particle_weight, event.track_length,
+                              event.current_cell);
   tallyManager->updateTallies();
   tallyManager->endHistory();
 

--- a/tally/tests/test_TrackLengthMeshTally.cpp
+++ b/tally/tests/test_TrackLengthMeshTally.cpp
@@ -6,6 +6,7 @@
 #include "../Tally.hpp"
 #include "../TallyEvent.hpp"
 #include "../TrackLengthMeshTally.hpp"
+#include "../TallyManager.cpp"
 
 //---------------------------------------------------------------------------//
 // TEST FIXTURES
@@ -1159,4 +1160,80 @@ TEST_F(TrackLengthMeshTallyTest, HashtagMeshReentrantSeparateTracks_3)
     total += track_data[i];
 
   EXPECT_DOUBLE_EQ(total, 20.0);
+}
+
+//---------------------------------------------------------------------------//
+TEST_F(TrackLengthMeshTallyTest, ComputeScoreTallyManager1RayNeutron)
+{
+  input.tally_type = "unstr_track";
+  input.options.insert(std::make_pair("inp", "unstructured_mesh.h5m"));
+
+  // dummy variable to prevent segfault during teardown
+  mesh_tally = Tally::create_tally(input);
+
+  TallyEvent event;
+  make_event(event);
+  event.particle = 1;  // neutron
+
+  TallyManager* tallyManager = new TallyManager();
+  tallyManager->addNewTally(input.tally_id, input.tally_type, event.particle,
+                            input.energy_bin_bounds, input.options);
+
+  mod_event(event, 1.0, 1.0, 1.0);
+  tallyManager->setTrackEvent(event.particle,
+      event.position[0], event.position[1], event.position[2],
+      event.direction[0], event.direction[1], event.direction[2],
+      event.particle_energy, event.particle_weight, event.track_length,
+      event.current_cell);
+  tallyManager->updateTallies();
+  tallyManager->endHistory();
+
+  std::cout << tallyManager->numTallies() << std::endl;
+
+  int length;
+  double* track_data = tallyManager->getTallyData(input.tally_id, length);
+
+  double total = 0.0;
+  for (int i = 0; i < length; i++)
+    total += track_data[i];
+
+  EXPECT_EQ(total, event.track_length);
+}
+
+//---------------------------------------------------------------------------//
+TEST_F(TrackLengthMeshTallyTest, ComputeScoreTallyManager1RayProton)
+{
+  input.tally_type = "unstr_track";
+  input.options.insert(std::make_pair("inp", "unstructured_mesh.h5m"));
+
+  // dummy variable to prevent segfault during teardown
+  mesh_tally = Tally::create_tally(input);
+
+  TallyEvent event;
+  make_event(event);
+  event.particle = 9; // proton
+
+  TallyManager* tallyManager = new TallyManager();
+  tallyManager->addNewTally(input.tally_id, input.tally_type, event.particle,
+                            input.energy_bin_bounds, input.options);
+
+  mod_event(event, 1.0, 1.0, 1.0);
+  tallyManager->setTrackEvent(event.particle,
+      event.position[0], event.position[1], event.position[2],
+      event.direction[0], event.direction[1], event.direction[2],
+      event.particle_energy, event.particle_weight, event.track_length,
+      event.current_cell);
+  tallyManager->updateTallies();
+  tallyManager->endHistory();
+
+  std::cout << tallyManager->numTallies() << std::endl;
+
+  int length;
+  double* track_data = tallyManager->getTallyData(input.tally_id, length);
+
+  double total = 0.0;
+  for (int i = 0; i < length; i++)
+    total += track_data[i];
+
+  EXPECT_EQ(total, event.track_length);
 }

--- a/uwuw/CMakeLists.txt
+++ b/uwuw/CMakeLists.txt
@@ -28,5 +28,4 @@ target_link_libraries(uwuw_preprocessor dagmciface
 # Build UWUW tests
 add_subdirectory(tests)
 
-install(TARGETS uwuw_preproc DESTINATION bin)
-
+install(TARGETS uwuw_preproc DESTINATION ${INSTALL_BIN_DIR} PERMISSIONS ${PERMS})


### PR DESCRIPTION
This PR adds 2 tests to test_TrackLengthMeshTally which make sure tetmeshes work for neutrons and protons. It also fixes some existing dagmcnp tests and adds them to the travis run script.