### PR TITLE
Fixed error where graveyard was not assigned a material

### DIFF
--- a/geant4/build/src/ExN01DetectorConstruction.cc
+++ b/geant4/build/src/ExN01DetectorConstruction.cc
@@ -116,7 +116,12 @@ G4VPhysicalVolume* ExN01DetectorConstruction::Construct()
     DagSolid* dag_vol = new DagSolid("vol_"+idx_str,dagmc,dag_idx);
     dag_volumes.push_back(dag_vol);
     // make new logical volume
-    G4LogicalVolume* dag_vol_log = new G4LogicalVolume(dag_vol,material_lib[mat_name],
+    std::string material_name = mat_name;
+    if( mat_name == "mat:Graveyard" || mat_name == "mat:Vacuum") {
+      material_name = "mat:Vacuum"; 
+    }
+    
+    G4LogicalVolume* dag_vol_log = new G4LogicalVolume(dag_vol,material_lib[material_name],
         "vol_"+idx_str+"_log",0,0,0);
     dag_logical_volumes[dag_idx]=dag_vol_log;
     // make a new physical placement

--- a/geant4/build/src/ExN01DetectorConstruction.cc
+++ b/geant4/build/src/ExN01DetectorConstruction.cc
@@ -118,9 +118,9 @@ G4VPhysicalVolume* ExN01DetectorConstruction::Construct()
     // make new logical volume
     std::string material_name = mat_name;
     if( mat_name == "mat:Graveyard" || mat_name == "mat:Vacuum") {
-      material_name = "mat:Vacuum"; 
+      material_name = "mat:Vacuum";
     }
-    
+
     G4LogicalVolume* dag_vol_log = new G4LogicalVolume(dag_vol,material_lib[material_name],
         "vol_"+idx_str+"_log",0,0,0);
     dag_logical_volumes[dag_idx]=dag_vol_log;


### PR DESCRIPTION
In DagGeant4 the graveyard is given the material property vacuum, this is since all the DagSolids are placed within the worldvolume and particles leaving the world volume define the graveyard in Geant4.