### PR TITLE
Disable check for zero track length in history_neutral_high

### DIFF
--- a/mcnp/mcnp6/patch/dagmc.6.1.1beta.patch
+++ b/mcnp/mcnp6/patch/dagmc.6.1.1beta.patch
@@ -687,6 +687,13 @@ diff -rN '--unified=0' Source/src/fmesh_mod.F90 Source_dagmc/src/fmesh_mod.F90
 +        call dagmc_setup_mesh_tally(i)
 +      endif
 +    enddo
+diff -rN '--unified=0' Source/src/history_neutral_high.F90 Source_dagmc/src/history_neutral_high.F90
+--- Source/src/history_neutral_high.F90
++++ Source_dagmc/src/history_neutral_high.F90
+@@ -161 +161,2 @@
+-      if( D <= zero ) then  !  Review the need for this test.
++      ! DAGMC: use < instead of <=
++      if( D < zero ) then  !  Review the need for this test.
 diff -rN '--unified=0' Source/src/hstory.F90 Source_dagmc/src/hstory.F90
 --- Source/src/hstory.F90
 +++ Source_dagmc/src/hstory.F90

--- a/mcnp/mcnp6/patch/dagmc.6.1.patch
+++ b/mcnp/mcnp6/patch/dagmc.6.1.patch
@@ -675,6 +675,13 @@ diff -rN '--unified=0' Source/src/fmesh_mod.F90 Source_dagmc/src/fmesh_mod.F90
 +        call dagmc_setup_mesh_tally(i)
 +      endif
 +    enddo
+diff -rN '--unified=0' Source/src/history_neutral_high.F90 Source_dagmc/src/history_neutral_high.F90
+--- Source/src/history_neutral_high.F90
++++ Source_dagmc/src/history_neutral_high.F90
+@@ -156 +156,2 @@
+-      if( D <= zero ) then  !  Review the need for this test.
++      ! DAGMC: use < instead of <=
++      if( D < zero ) then  !  Review the need for this test.
 diff -rN '--unified=0' Source/src/hstory.F90 Source_dagmc/src/hstory.F90
 --- Source/src/hstory.F90
 +++ Source_dagmc/src/hstory.F90

--- a/mcnp/mcnp6/patch/dagmc.6_beta2.patch
+++ b/mcnp/mcnp6/patch/dagmc.6_beta2.patch
@@ -673,6 +673,13 @@ diff -rN '--unified=0' Source/src/fmesh_mod.F90 Source_dagmc/src/fmesh_mod.F90
 +        call dagmc_setup_mesh_tally(i)
 +      endif
 +    enddo
+diff -rN '--unified=0' Source/src/history_neutral_high.F90 Source_dagmc/src/history_neutral_high.F90
+--- Source/src/history_neutral_high.F90
++++ Source_dagmc/src/history_neutral_high.F90
+@@ -119 +119,2 @@
+-      if( d <= zero ) then  !  Review the need for this test.
++      ! DAGMC: use < instead of <=
++      if( d < zero ) then  !  Review the need for this test.
 diff -rN '--unified=0' Source/src/hstory.F90 Source_dagmc/src/hstory.F90
 --- Source/src/hstory.F90
 +++ Source_dagmc/src/hstory.F90


### PR DESCRIPTION
This basically does the same thing we did in `charged_particle_history`. If the track length is zero, then it's possible for MCNP to give bad trouble and exit; this PR allows it to be zero without issue.