### PR TITLE
Add option to enable mw regression tests. Local builds of dagmc were …

### DIFF
--- a/.build_dagmc.sh
+++ b/.build_dagmc.sh
@@ -7,6 +7,7 @@ cmake ../. -DBUILD_TALLY=ON \
            -DBUILD_TESTS=ON \
            -DBUILD_GEANT4=ON \
            -DGEANT4_DIR=/root/geant4.10.00.p02 \
+           -DENABLE_MW_REGRESSION_TESTS=ON \
            -DCMAKE_INSTALL_PREFIX=/root/dagmc
 make 
 make install

--- a/.build_dagmc.sh
+++ b/.build_dagmc.sh
@@ -4,10 +4,9 @@ export LD_LIBRARY_PATH="/root/moab/lib"
 mkdir bld
 cd bld
 cmake ../. -DBUILD_TALLY=ON \
-           -DBUILD_TESTS=ON \
+           -DBUILD_CI_TESTS=ON \
            -DBUILD_GEANT4=ON \
            -DGEANT4_DIR=/root/geant4.10.00.p02 \
-           -DENABLE_MW_REGRESSION_TESTS=ON \
            -DCMAKE_INSTALL_PREFIX=/root/dagmc
 make 
 make install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,11 +110,11 @@ add_subdirectory(common)
 add_subdirectory(tools)
 
 # Build tests that wouldn't normally be built for the CI
-if (BUILD_TESTS)
+if (BUILD_CI_TESTS)
   if (NOT BUILD_TALLY)
     add_subdirectory(tally)
   endif (NOT BUILD_TALLY)
   if (NOT BUILD_MCNP5 AND NOT BUILD_MCNP6)
     add_subdirectory(mcnp/test)
   endif (NOT BUILD_MCNP5 AND NOT BUILD_MCNP6)
-endif (BUILD_TESTS)
+endif (BUILD_CI_TESTS)

--- a/tools/make_watertight/tests/CMakeLists.txt
+++ b/tools/make_watertight/tests/CMakeLists.txt
@@ -48,7 +48,7 @@ install(TARGETS make_watertight_cylinder_tests make_watertight_cone_tests make_w
 
 install(FILES cones.h5m cyl.h5m no_curve_sphere.h5m sphere_n_box.h5m DESTINATION tests)
 
-if(ENABLE_MW_REGRESSION_TESTS)
+if(BUILD_CI_TESTS)
   add_executable(make_watertight_regression_tests mw_unit_test_driver.cc regression_tests.cpp ${SRC_FILES})
   target_link_libraries(make_watertight_regression_tests ${LINK_LIBS})
   install(TARGETS make_watertight_regression_tests DESTINATION tests PERMISSIONS ${PERMS})

--- a/tools/make_watertight/tests/CMakeLists.txt
+++ b/tools/make_watertight/tests/CMakeLists.txt
@@ -30,7 +30,6 @@ add_executable(make_watertight_cylinder_tests mw_unit_test_driver.cc test_cyl.cp
 add_executable(make_watertight_cone_tests mw_unit_test_driver.cc test_cones.cpp ${SRC_FILES})
 add_executable(make_watertight_no_curve_sphere_tests mw_unit_test_driver.cc test_no_curve_sphere.cpp ${SRC_FILES})
 add_executable(make_watertight_sphere_n_box_test mw_unit_test_driver.cc test_sphere_n_box.cpp ${SRC_FILES})
-add_executable(make_watertight_regression_tests mw_unit_test_driver.cc regression_tests.cpp ${SRC_FILES})
 
 # Includes
 include_directories(..)
@@ -42,13 +41,18 @@ target_link_libraries(make_watertight_cylinder_tests ${LINK_LIBS})
 target_link_libraries(make_watertight_cone_tests ${LINK_LIBS})
 target_link_libraries(make_watertight_no_curve_sphere_tests ${LINK_LIBS})
 target_link_libraries(make_watertight_sphere_n_box_test ${LINK_LIBS})
-target_link_libraries(make_watertight_regression_tests ${LINK_LIBS})
+
 
 # Install tests and test models
 install(TARGETS make_watertight_cylinder_tests make_watertight_cone_tests make_watertight_no_curve_sphere_tests make_watertight_sphere_n_box_test DESTINATION tests PERMISSIONS ${PERMS})
-install(TARGETS make_watertight_regression_tests DESTINATION tests PERMISSIONS ${PERMS})
+
 install(FILES cones.h5m cyl.h5m no_curve_sphere.h5m sphere_n_box.h5m DESTINATION tests)
 
+if(ENABLE_MW_REGRESSION_TESTS)
+  add_executable(make_watertight_regression_tests mw_unit_test_driver.cc regression_tests.cpp ${SRC_FILES})
+  target_link_libraries(make_watertight_regression_tests ${LINK_LIBS})
+  install(TARGETS make_watertight_regression_tests DESTINATION tests PERMISSIONS ${PERMS})
+endif()
 
 # Add to unit test framework
 add_test(make_watertight_cylinder_tests make_watertight_cylinder_tests)


### PR DESCRIPTION
…failing these tests because the test files did not exist. Removing these tests from a normal build so users aren't alarmed by the failing tests.