### PR TITLE
Adding MOAB configuration flag to remove half facet representation.

### DIFF
--- a/.build_moab.sh
+++ b/.build_moab.sh
@@ -8,7 +8,7 @@ git checkout $MOAB_VERSION
 autoreconf -fi
 mkdir bld
 cd bld
-../configure --enable-dagmc --enable-shared --disable-debug --enable-optimize --with-hdf5 --prefix=/root/moab
+../configure --enable-dagmc --enable-shared --disable-debug --disable-ahf --enable-optimize --with-hdf5 --prefix=/root/moab
 make -j2
 make install
 export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/root/moab/lib/"


### PR DESCRIPTION
Adding the `--disable-ahf` flag to our MOAB configuration *should* fix our problems when building DAGMC against MOAB's master branch.