### PR TITLE
Adding search suffixes for MOABConfig file in cmake build of MOAB.

### DIFF
--- a/cmake/FindMOAB.cmake
+++ b/cmake/FindMOAB.cmake
@@ -10,7 +10,7 @@
 find_path(MOAB_CMAKE_CONFIG NAMES MOABConfig.cmake
           HINTS ${MOAB_ROOT}
           PATHS ENV LD_LIBRARY_PATH
-          PATH_SUFFIXES lib Lib
+          PATH_SUFFIXES lib Lib cmake cmake/MOAB
           NO_DEFAULT_PATH)
 
 message(STATUS "Found MOAB in ${MOAB_CMAKE_CONFIG}")


### PR DESCRIPTION
Adding search locations to find MOABConfig.cmake file if MOAB was built and installed using cmake. (This will be the new location for the autotools build as well in MOAB 5.0 so we'll need it)