### PR TITLE
Mat3 fix

### DIFF
--- a/tally/TrackLengthMeshTally.cpp
+++ b/tally/TrackLengthMeshTally.cpp
@@ -434,7 +434,12 @@ ErrorCode TrackLengthMeshTally::compute_barycentric_data(const Range& all_tets)
     }
     assert( rval == MB_SUCCESS );
 
-    Matrix3 a( p[1]-p[0], p[2]-p[0], p[3]-p[0] );
+    CartVect row0 = p[1]-p[0];
+    CartVect row1 = p[2]-p[0];
+    CartVect row2 = p[3]-p[0]; 
+    Matrix3 a( row0[0], row0[1], row0[2],
+	       row1[0], row1[1], row1[2],
+	       row2[0], row2[1], row2[2]);
     a = a.transpose().inverse();
     tet_baryc_data.at( get_entity_index(tet) ) = a;
   }

--- a/tally/TrackLengthMeshTally.cpp
+++ b/tally/TrackLengthMeshTally.cpp
@@ -436,10 +436,10 @@ ErrorCode TrackLengthMeshTally::compute_barycentric_data(const Range& all_tets)
 
     CartVect row0 = p[1]-p[0];
     CartVect row1 = p[2]-p[0];
-    CartVect row2 = p[3]-p[0]; 
+    CartVect row2 = p[3]-p[0];
     Matrix3 a( row0[0], row0[1], row0[2],
-	       row1[0], row1[1], row1[2],
-	       row2[0], row2[1], row2[2]);
+               row1[0], row1[1], row1[2],
+               row2[0], row2[1], row2[2]);
     a = a.transpose().inverse();
     tet_baryc_data.at( get_entity_index(tet) ) = a;
   }


### PR DESCRIPTION
MOAB is deprecating the Matrix3 constructor used in TrackLengthMeshTally. This PR updates how the Matrix3 object is constructed. Should fix our current problem building against MOAB master.