### PR TITLE
Remove geant4 10.1 and 10.2 from docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,6 @@ env:
     # vary moab version
     - COMPILER="gcc-5"     MOAB_VERSION="master" GEANT4_VERSION="10.03.p01"
     - COMPILER="clang-4.0" MOAB_VERSION="master" GEANT4_VERSION="10.03.p01"
-    # vary geant4 version
-    - COMPILER="gcc-5"     MOAB_VERSION="5.0"    GEANT4_VERSION="10.01.p03"
-    - COMPILER="gcc-5"     MOAB_VERSION="5.0"    GEANT4_VERSION="10.02.p03"
     # vary compiler
     - COMPILER="gcc-4.8"   MOAB_VERSION="5.0"    GEANT4_VERSION="10.03.p01"
     - COMPILER="gcc-4.9"   MOAB_VERSION="5.0"    GEANT4_VERSION="10.03.p01"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -62,8 +62,6 @@ RUN bash /root/etc/build_hdf5.sh clang-4.0
 
 # Build Geant4
 COPY build_geant4.sh /root/etc/
-RUN bash /root/etc/build_geant4.sh gcc-5     10.01.p03
-RUN bash /root/etc/build_geant4.sh gcc-5     10.02.p03
 RUN bash /root/etc/build_geant4.sh gcc-4.8   10.03.p01
 RUN bash /root/etc/build_geant4.sh gcc-4.9   10.03.p01
 RUN bash /root/etc/build_geant4.sh gcc-5     10.03.p01


### PR DESCRIPTION
This cuts the size of the docker image from 8.431 GB to 5.946 GB. It also cuts the number of runs in the build matrix from 11 to 9.