### PR TITLE
[bug fix] DAGMC Advanced tallies were not producing vector tagged mes…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(DAGMC)
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.1)
 enable_language(Fortran)
 
 # Set DAGMC version

--- a/src/mcnp/meshtal_funcs.cpp
+++ b/src/mcnp/meshtal_funcs.cpp
@@ -141,7 +141,8 @@ void dagmc_fmesh_setup_mesh_(int* fm_ipt, int* id, int* fmesh_idx,
   std::vector<double> energy_boundaries;
   // if there is more than 1 bin, dont want 0->bottom bin
   int bottom = 0;
-  if(*n_energy_mesh > 2) bottom = 1;
+  if (*n_energy_mesh > 2)
+    bottom = 1;
   for (int i = bottom ; i < *n_energy_mesh; ++i) {
     energy_boundaries.push_back(energy_mesh[i]);
   }

--- a/src/mcnp/meshtal_funcs.cpp
+++ b/src/mcnp/meshtal_funcs.cpp
@@ -139,7 +139,10 @@ void dagmc_fmesh_setup_mesh_(int* fm_ipt, int* id, int* fmesh_idx,
 
   // Copy emesh bin boundaries from MCNP (includes 0.0 MeV)
   std::vector<double> energy_boundaries;
-  for (int i = 0; i < *n_energy_mesh; ++i) {
+  // if there is more than 1 bin, dont want 0->bottom bin
+  int bottom = 0;
+  if(*n_energy_mesh > 2) bottom = 1;
+  for (int i = bottom ; i < *n_energy_mesh; ++i) {
     energy_boundaries.push_back(energy_mesh[i]);
   }
 

--- a/src/tally/CMakeLists.txt
+++ b/src/tally/CMakeLists.txt
@@ -6,6 +6,8 @@ file(GLOB PUB_HEADERS "*.hpp")
 set(LINK_LIBS lapack dagmc)
 set(LINK_LIBS_EXTERN_NAMES)
 
+set(CMAKE_CXX_STANDARD 11)
+
 dagmc_install_library(dagtally)
 
 if (BUILD_TESTS)

--- a/src/tally/KDEMeshTally.cpp
+++ b/src/tally/KDEMeshTally.cpp
@@ -185,11 +185,12 @@ void KDEMeshTally::write_data(double num_histories) {
 
     unsigned int num_ebins = data->get_num_energy_bins();
     // if there is a total, dont do anything with it
-    if(data->has_total_energy_bin()) num_ebins--;
+    if (data->has_total_energy_bin())
+      num_ebins--;
 
     double tally_vect[num_ebins];
     double error_vect[num_ebins];
-   
+
     for (unsigned int j = 0; j < num_ebins; ++ j) {
       std::pair <double, double> tally_data = data->get_data(point_index, j);
       double tally = tally_data.first;

--- a/src/tally/MeshTally.cpp
+++ b/src/tally/MeshTally.cpp
@@ -113,42 +113,43 @@ moab::ErrorCode MeshTally::setup_tags(moab::Interface* mbi, const char* prefix) 
   int tag_size = 1;
 
   unsigned int num_bins = data->get_num_energy_bins();
-  if(data->has_total_energy_bin()) num_bins--;
+  if (data->has_total_energy_bin())
+    num_bins--;
 
   std::string tag_name = pfx + "TALLY_TAG";
   std::string error_tag_name = pfx + "ERROR_TAG";
 
   // create vector tag to score particle spectra
   rval = mbi->tag_get_handle(tag_name.c_str(),
-			     num_bins,
-			     moab::MB_TYPE_DOUBLE,
-			     tally_tag,
-			     moab::MB_TAG_DENSE | moab::MB_TAG_CREAT);
-  MB_CHK_SET_ERR(rval,"Failed to get the tag handle");
-  
+                             num_bins,
+                             moab::MB_TYPE_DOUBLE,
+                             tally_tag,
+                             moab::MB_TAG_DENSE | moab::MB_TAG_CREAT);
+  MB_CHK_SET_ERR(rval, "Failed to get the tag handle");
+
   rval = mbi->tag_get_handle(error_tag_name.c_str(),
-			     num_bins,
-			     moab::MB_TYPE_DOUBLE,
-			     error_tag,
-			     moab::MB_TAG_DENSE | moab::MB_TAG_CREAT);
-  MB_CHK_SET_ERR(rval,"Failed to get the tag handle");
-   
+                             num_bins,
+                             moab::MB_TYPE_DOUBLE,
+                             error_tag,
+                             moab::MB_TAG_DENSE | moab::MB_TAG_CREAT);
+  MB_CHK_SET_ERR(rval, "Failed to get the tag handle");
+
   // create single tag to store the total
   std::string total_tally_tag_name = tag_name + "_TOTAL";
   rval = mbi->tag_get_handle(total_tally_tag_name.c_str(),
-			     tag_size,
-			     moab::MB_TYPE_DOUBLE,
-			     total_tally_tag,
-			     moab::MB_TAG_DENSE | moab::MB_TAG_CREAT);
-  MB_CHK_SET_ERR(rval,"Failed to get the tag handle");
+                             tag_size,
+                             moab::MB_TYPE_DOUBLE,
+                             total_tally_tag,
+                             moab::MB_TAG_DENSE | moab::MB_TAG_CREAT);
+  MB_CHK_SET_ERR(rval, "Failed to get the tag handle");
 
   std::string total_error_tag_name = error_tag_name + "_TOTAL";
   rval = mbi->tag_get_handle(total_error_tag_name.c_str(),
-			     tag_size,
-			     moab::MB_TYPE_DOUBLE,
-			     total_error_tag,
-			     moab::MB_TAG_DENSE | moab::MB_TAG_CREAT);
-  MB_CHK_SET_ERR(rval,"Failed to get the tag handle");
+                             tag_size,
+                             moab::MB_TYPE_DOUBLE,
+                             total_error_tag,
+                             moab::MB_TAG_DENSE | moab::MB_TAG_CREAT);
+  MB_CHK_SET_ERR(rval, "Failed to get the tag handle");
 
 
   return moab::MB_SUCCESS;

--- a/src/tally/MeshTally.hpp
+++ b/src/tally/MeshTally.hpp
@@ -81,7 +81,9 @@ class MeshTally : public Tally {
   moab::Range tally_points;
 
   /// Tag arrays for storing energy bin labels
-  std::vector<moab::Tag> tally_tags, error_tags;
+  //  std::vector<moab::Tag> tally_tags, error_tags;
+  moab::Tag tally_tag, error_tag;
+  moab::Tag total_tally_tag, total_error_tag;
 
   // >>> PROTECTED METHODS
 

--- a/src/tally/TallyData.cpp
+++ b/src/tally/TallyData.cpp
@@ -37,7 +37,7 @@ TallyData::TallyData(unsigned int num_energy_bins, bool total_energy_bin) {
 //---------------------------------------------------------------------------//
 std::pair <double, double> TallyData::get_data(unsigned int tally_point_index,
                                                unsigned int energy_bin) const {
-  
+
   assert(energy_bin < num_energy_bins + this->total_energy_bin);
   assert(tally_point_index < num_tally_points);
 

--- a/src/tally/TallyData.cpp
+++ b/src/tally/TallyData.cpp
@@ -37,7 +37,8 @@ TallyData::TallyData(unsigned int num_energy_bins, bool total_energy_bin) {
 //---------------------------------------------------------------------------//
 std::pair <double, double> TallyData::get_data(unsigned int tally_point_index,
                                                unsigned int energy_bin) const {
-  assert(energy_bin < num_energy_bins);
+  
+  assert(energy_bin < num_energy_bins + this->total_energy_bin);
   assert(tally_point_index < num_tally_points);
 
   int index = tally_point_index * num_energy_bins + energy_bin;

--- a/src/tally/TrackLengthMeshTally.cpp
+++ b/src/tally/TrackLengthMeshTally.cpp
@@ -236,7 +236,7 @@ void TrackLengthMeshTally::write_data(double num_histories) {
   }
   assert(rval == MB_SUCCESS);
 
-  
+
   for (Range::const_iterator i = all_tets.begin(); i != all_tets.end(); ++i) {
     EntityHandle t = *i;
 
@@ -258,11 +258,12 @@ void TrackLengthMeshTally::write_data(double num_histories) {
     unsigned int num_ebins = data->get_num_energy_bins();
 
     // if there is a total, dont do anything with it
-    if(data->has_total_energy_bin()) num_ebins--;
-    
+    if (data->has_total_energy_bin())
+      num_ebins--;
+
     double tally_vect[num_ebins];
     double error_vect[num_ebins];
-    
+
     for (unsigned j = 0; j < num_ebins ; ++j) {
       std::pair <double, double> tally_data = data->get_data(tet_index, j);
       double tally = tally_data.first;
@@ -280,12 +281,12 @@ void TrackLengthMeshTally::write_data(double num_histories) {
       tally_vect[j] = score;
       error_vect[j] = rel_err;
     }
-    
-    rval = mb->tag_set_data(tally_tag,&t,1,tally_vect);
-    MB_CHK_SET_ERR_RET(rval,"Failed to set tally_tag "+std::to_string(rval)+" "+std::to_string(t));
-    rval = mb->tag_set_data(error_tag,&t,1,error_vect);
-    MB_CHK_SET_ERR_RET(rval,"Failed to set error_tag "+std::to_string(rval)+" "+std::to_string(t));
-  
+
+    rval = mb->tag_set_data(tally_tag, &t, 1, tally_vect);
+    MB_CHK_SET_ERR_RET(rval, "Failed to set tally_tag " + std::to_string(rval) + " " + std::to_string(t));
+    rval = mb->tag_set_data(error_tag, &t, 1, error_vect);
+    MB_CHK_SET_ERR_RET(rval, "Failed to set error_tag " + std::to_string(rval) + " " + std::to_string(t));
+
 
     // if we have a total bin, write it out
     if (data->has_total_energy_bin()) {
@@ -293,23 +294,23 @@ void TrackLengthMeshTally::write_data(double num_histories) {
       std::pair <double, double> tally_data = data->get_data(tet_index, j);
       double tally = tally_data.first;
       double error = tally_data.second;
-      
+
       double score = (tally / (volume * num_histories));
-      
+
       // Use 0 as the error output value if nothing has been computed for this mesh cell;
       // this reflects MCNP's approach to avoiding a divide-by-zero situation.
       double rel_err = 0;
       if (error != 0) {
-	rel_err = sqrt((error / (tally * tally)) - (1. / num_histories));
+        rel_err = sqrt((error / (tally * tally)) - (1. / num_histories));
       }
-      
-      rval = mb->tag_set_data(total_tally_tag,&t,1,&score);
-      MB_CHK_SET_ERR_RET(rval,"Failed to set tally_tag "+std::to_string(rval)+" "+std::to_string(t));
-      rval = mb->tag_set_data(total_error_tag,&t,1,&rel_err);
-      MB_CHK_SET_ERR_RET(rval,"Failed to set error_tag "+std::to_string(rval)+" "+std::to_string(t));    
+
+      rval = mb->tag_set_data(total_tally_tag, &t, 1, &score);
+      MB_CHK_SET_ERR_RET(rval, "Failed to set tally_tag " + std::to_string(rval) + " " + std::to_string(t));
+      rval = mb->tag_set_data(total_error_tag, &t, 1, &rel_err);
+      MB_CHK_SET_ERR_RET(rval, "Failed to set error_tag " + std::to_string(rval) + " " + std::to_string(t));
     }
   }
-  
+
   std::vector<Tag> output_tags;
   output_tags.push_back(tally_tag);
   output_tags.push_back(error_tag);

--- a/src/tally/tests/test_TrackLengthMeshTally.cpp
+++ b/src/tally/tests/test_TrackLengthMeshTally.cpp
@@ -1216,7 +1216,7 @@ TEST_F(TrackLengthMeshTallyTest, ComputeScoreTallyManager1RayProton) {
 }
 
 //---------------------------------------------------------------------------//
-TEST_F(TrackLengthMeshTallyTest, EnsureVectorTags ) {
+TEST_F(TrackLengthMeshTallyTest, EnsureVectorTags) {
   input.tally_type = "unstr_track";
   input.energy_bin_bounds.push_back(20.0);
 
@@ -1237,36 +1237,36 @@ TEST_F(TrackLengthMeshTallyTest, EnsureVectorTags ) {
   // write all 0's
   tallyManager->writeData(1.);
 
-  moab::Core *MBI = new moab::Core();
+  moab::Core* MBI = new moab::Core();
   // make a meshset
   moab::EntityHandle mesh_set;
   moab::ErrorCode rval = MBI->create_meshset(moab::MESHSET_SET, mesh_set);
   EXPECT_EQ(rval, moab::MB_SUCCESS);
   // load the mesh
   rval = MBI->load_file("mesh.out.h5m");
-  EXPECT_EQ(rval,moab::MB_SUCCESS);
+  EXPECT_EQ(rval, moab::MB_SUCCESS);
   // look for the tag
   moab::Tag tally_tag;
   std::string tag_name = "TALLY_TAG";
   // get the tag handle for the vector tag
   rval = MBI->tag_get_handle(tag_name.c_str(),
-			     2,
-			     moab::MB_TYPE_DOUBLE,
-			     tally_tag,
-			     moab::MB_TAG_DENSE | moab::MB_TAG_CREAT);
-  // expect that this succeeded 
-  EXPECT_EQ(rval,moab::MB_SUCCESS);
+                             2,
+                             moab::MB_TYPE_DOUBLE,
+                             tally_tag,
+                             moab::MB_TAG_DENSE | moab::MB_TAG_CREAT);
+  // expect that this succeeded
+  EXPECT_EQ(rval, moab::MB_SUCCESS);
 
   // now look for the scalar tag
   tag_name = "TALLY_TAG_TOTAL";
   // get the tag handle for the vector tag
   rval = MBI->tag_get_handle(tag_name.c_str(),
-			     1,
-			     moab::MB_TYPE_DOUBLE,
-			     tally_tag,
-			     moab::MB_TAG_DENSE | moab::MB_TAG_CREAT);
-  // expect that this succeeded 
-  EXPECT_EQ(rval,moab::MB_SUCCESS);
-  
+                             1,
+                             moab::MB_TYPE_DOUBLE,
+                             tally_tag,
+                             moab::MB_TAG_DENSE | moab::MB_TAG_CREAT);
+  // expect that this succeeded
+  EXPECT_EQ(rval, moab::MB_SUCCESS);
+
   // all done :)
 }


### PR DESCRIPTION
This PR modified the underlying routines to fix a number of issues regarding the DAGMC mesh tallies interfacing with pyne.r2s. The routines produced n_group+2 scalar tags, when we should have produced a single n_group sized vector tag. The +2 tags comes form 0-bottom group, and a total group tag. This has been modified for both the KDE tally and Tetmesh tracklength tally. 

A future fix could figure out how automatically tag the total group into a separate TOTAL_TAG, it may need some reworking of the logic, refactor into a common tagging function maybe?