### PR TITLE
Update docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,51 +8,50 @@ notifications:
 env:
   matrix:
     # main
-    - COMPILER="gcc-5"     MOAB_VERSION="5.0"    GEANT4_VERSION="10.03.p01"
-    - COMPILER="clang-4.0" MOAB_VERSION="5.0"    GEANT4_VERSION="10.03.p01"
+    - COMPILER="gcc-7"     MOAB_VERSION="5.0"    BUILD_GEANT4="ON"
+    - COMPILER="clang-5.0" MOAB_VERSION="5.0"    BUILD_GEANT4="ON"
     # vary moab version
-    - COMPILER="gcc-5"     MOAB_VERSION="master" GEANT4_VERSION="10.03.p01"
-    - COMPILER="clang-4.0" MOAB_VERSION="master" GEANT4_VERSION="10.03.p01"
+    - COMPILER="gcc-7"     MOAB_VERSION="master" BUILD_GEANT4="ON"
+    - COMPILER="clang-5.0" MOAB_VERSION="master" BUILD_GEANT4="ON"
     # vary compiler
-    - COMPILER="gcc-4.8"   MOAB_VERSION="5.0"    GEANT4_VERSION="10.03.p01"
-    - COMPILER="gcc-4.9"   MOAB_VERSION="5.0"    GEANT4_VERSION="10.03.p01"
-    - COMPILER="gcc-6"     MOAB_VERSION="5.0"    GEANT4_VERSION="10.03.p01"
-    - COMPILER="clang-3.8" MOAB_VERSION="5.0"    GEANT4_VERSION="10.03.p01"
-    - COMPILER="clang-3.9" MOAB_VERSION="5.0"    GEANT4_VERSION="10.03.p01"
+    - COMPILER="gcc-4.8"   MOAB_VERSION="5.0"    BUILD_GEANT4="OFF"
+    - COMPILER="gcc-5"     MOAB_VERSION="5.0"    BUILD_GEANT4="OFF"
+    - COMPILER="gcc-6"     MOAB_VERSION="5.0"    BUILD_GEANT4="OFF"
+    - COMPILER="clang-4.0" MOAB_VERSION="5.0"    BUILD_GEANT4="OFF"
 services:
   - docker
 before_install:
-  - sudo docker pull ljacobson64/dagmc-ci
+  - sudo docker pull ljacobson64/dagmc-ci-ubuntu-16.04
   # get a container id
-  - sudo docker run ljacobson64/dagmc-ci /bin/sh -c "cd /root"
+  - sudo docker run ljacobson64/dagmc-ci-ubuntu-16.04 /bin/sh -c "cd /root"
   - commit_id=$(sudo docker ps -l | tail -n1 | awk '{print $1}')
   # make the build directory
-  - sudo docker run ljacobson64/dagmc-ci /bin/sh -c "mkdir -p /root/build/$COMPILER/DAGMC-moab-$MOAB_VERSION"
+  - sudo docker run ljacobson64/dagmc-ci-ubuntu-16.04 /bin/sh -c "mkdir -p /root/build/$COMPILER/DAGMC-moab-$MOAB_VERSION"
   - commit_id=$(sudo docker ps -l | tail -n1 | awk '{print $1}')
-  - sudo docker commit $commit_id ljacobson64/dagmc-ci
+  - sudo docker commit $commit_id ljacobson64/dagmc-ci-ubuntu-16.04
   # copy the repo in the docker instance
   - sudo docker cp ../DAGMC $commit_id:/root/build/$COMPILER/DAGMC-moab-$MOAB_VERSION
   - commit_id=$(sudo docker ps -l | tail -n1 | awk '{print $1}')
-  - sudo docker commit $commit_id ljacobson64/dagmc-ci
+  - sudo docker commit $commit_id ljacobson64/dagmc-ci-ubuntu-16.04
   # build moab
-  - sudo docker run ljacobson64/dagmc-ci /bin/sh -c "cd /root/build/$COMPILER/DAGMC-moab-$MOAB_VERSION/DAGMC;
-                                                     bash docker/build_moab.sh $COMPILER $MOAB_VERSION"
+  - sudo docker run ljacobson64/dagmc-ci-ubuntu-16.04 /bin/sh -c "cd /root/build/$COMPILER/DAGMC-moab-$MOAB_VERSION/DAGMC;
+                                                                  bash docker/build_moab.sh $COMPILER $MOAB_VERSION"
   - commit_id=$(sudo docker ps -l | tail -n1 | awk '{print $1}')
-  - sudo docker commit $commit_id ljacobson64/dagmc-ci
+  - sudo docker commit $commit_id ljacobson64/dagmc-ci-ubuntu-16.04
 install:
   # build dagmc (shared executables)
-  - sudo docker run ljacobson64/dagmc-ci /bin/sh -c "cd /root/build/$COMPILER/DAGMC-moab-$MOAB_VERSION/DAGMC;
-                                                     bash docker/build_dagmc.sh $COMPILER OFF $MOAB_VERSION $GEANT4_VERSION"
+  - sudo docker run ljacobson64/dagmc-ci-ubuntu-16.04 /bin/sh -c "cd /root/build/$COMPILER/DAGMC-moab-$MOAB_VERSION/DAGMC;
+                                                                  bash docker/build_dagmc.sh $COMPILER OFF $MOAB_VERSION $BUILD_GEANT4"
   - commit_id=$(sudo docker ps -l | tail -n1 | awk '{print $1}')
-  - sudo docker commit $commit_id ljacobson64/dagmc-ci
+  - sudo docker commit $commit_id ljacobson64/dagmc-ci-ubuntu-16.04
   # build dagmc (static executables)
-  - sudo docker run ljacobson64/dagmc-ci /bin/sh -c "cd /root/build/$COMPILER/DAGMC-moab-$MOAB_VERSION/DAGMC;
-                                                     bash docker/build_dagmc.sh $COMPILER ON $MOAB_VERSION $GEANT4_VERSION"
+  - sudo docker run ljacobson64/dagmc-ci-ubuntu-16.04 /bin/sh -c "cd /root/build/$COMPILER/DAGMC-moab-$MOAB_VERSION/DAGMC;
+                                                                  bash docker/build_dagmc.sh $COMPILER ON $MOAB_VERSION $BUILD_GEANT4"
   - commit_id=$(sudo docker ps -l | tail -n1 | awk '{print $1}')
-  - sudo docker commit $commit_id ljacobson64/dagmc-ci
+  - sudo docker commit $commit_id ljacobson64/dagmc-ci-ubuntu-16.04
 script:
   # run tests
-  - sudo docker run ljacobson64/dagmc-ci /bin/sh -c "cd /root/build/$COMPILER/DAGMC-moab-$MOAB_VERSION/DAGMC;
-                                                     export TRAVIS_PULL_REQUEST=$TRAVIS_PULL_REQUEST;
-                                                     export MW_REG_TEST_MODELS_URL=$MW_REG_TEST_MODELS_URL;
-                                                     bash docker/run_tests.sh $COMPILER $MOAB_VERSION $GEANT4_VERSION"
+  - sudo docker run ljacobson64/dagmc-ci-ubuntu-16.04 /bin/sh -c "cd /root/build/$COMPILER/DAGMC-moab-$MOAB_VERSION/DAGMC;
+                                                                  export TRAVIS_PULL_REQUEST=$TRAVIS_PULL_REQUEST;
+                                                                  export MW_REG_TEST_MODELS_URL=$MW_REG_TEST_MODELS_URL;
+                                                                  bash docker/run_tests.sh $COMPILER $MOAB_VERSION $BUILD_GEANT4"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,48 +3,30 @@ FROM ubuntu:16.04
 # Use bash as the default shell
 RUN ln -snf /bin/bash /bin/sh
 
-# Add the Ubuntu 14.04 sources
-RUN echo ""                                                                   >> /etc/apt/sources.list && \
-    echo "deb http://archive.ubuntu.com/ubuntu/ trusty universe"              >> /etc/apt/sources.list && \
-    echo "deb-src http://archive.ubuntu.com/ubuntu/ trusty universe"          >> /etc/apt/sources.list
-
-# Add the Clang 3.9 and 4.0 sources
-RUN echo ""                                                                   >> /etc/apt/sources.list && \
-    echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-3.9 main"     >> /etc/apt/sources.list && \
-    echo "deb-src http://apt.llvm.org/xenial/ llvm-toolchain-xenial-3.9 main" >> /etc/apt/sources.list && \
-    echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-4.0 main"     >> /etc/apt/sources.list && \
-    echo "deb-src http://apt.llvm.org/xenial/ llvm-toolchain-xenial-4.0 main" >> /etc/apt/sources.list
-
 RUN apt-get -y update
 RUN apt-get -y upgrade
 RUN apt-get -y dist-upgrade
 
 # Get some common utils
-RUN apt-get -y install apt-utils build-essential software-properties-common
+RUN apt-get -y install build-essential software-properties-common
 
 # Add the GCC repo
 RUN add-apt-repository ppa:ubuntu-toolchain-r/test
 RUN apt-get -y update
 
 # Get the GNU compilers
-RUN apt-get -y install gcc-4.4 g++-4.4 gfortran-4.4 \
-                       gcc-4.6 g++-4.6 gfortran-4.6 \
-                       gcc-4.7 g++-4.7 gfortran-4.7 \
-                       gcc-4.8 g++-4.8 gfortran-4.8 \
-                       gcc-4.9 g++-4.9 gfortran-4.9 \
-                       gcc-5   g++-5   gfortran-5 \
-                       gcc-6   g++-6   gfortran-6
+RUN apt-get -y install gcc-4.8 g++-4.8 gfortran-4.8
+RUN apt-get -y install gcc-5   g++-5   gfortran-5
+RUN apt-get -y install gcc-6   g++-6   gfortran-6
+RUN apt-get -y install gcc-7   g++-7   gfortran-7
 
 # Get the Clang compilers
-RUN apt-get -y install clang-3.5 clang-3.6 clang-3.7 clang-3.8
-RUN apt-get -y install clang-3.9 clang-4.0 --allow-unauthenticated
+RUN apt-get -y install clang-4.0
+RUN apt-get -y install clang-5.0
 
 # Get some more specific utils
-RUN apt-get -y install autoconf cmake curl cython emacs expat git htop \
-                       libtool man unzip vim wget
-RUN apt-get -y install libblas-dev libexpat1-dev libhdf5-dev liblapack-dev
-RUN apt-get -y install python-jinja2 python-matplotlib python-nose \
-                       python-numpy python-setuptools python-scipy python-tables
+RUN apt-get -y install autoconf cmake gfortran git libtool unzip wget
+RUN apt-get -y install libblas-dev libexpat-dev libhdf5-dev liblapack-dev libz-dev
 
 # Copy the environment variable and build instruction files
 RUN mkdir -p /root/etc/
@@ -53,21 +35,15 @@ COPY *.env /root/etc/
 # Build HDF5
 COPY build_hdf5.sh /root/etc/
 RUN bash /root/etc/build_hdf5.sh gcc-4.8
-RUN bash /root/etc/build_hdf5.sh gcc-4.9
 RUN bash /root/etc/build_hdf5.sh gcc-5
 RUN bash /root/etc/build_hdf5.sh gcc-6
-RUN bash /root/etc/build_hdf5.sh clang-3.8
-RUN bash /root/etc/build_hdf5.sh clang-3.9
+RUN bash /root/etc/build_hdf5.sh gcc-7
 RUN bash /root/etc/build_hdf5.sh clang-4.0
+RUN bash /root/etc/build_hdf5.sh clang-5.0
 
 # Build Geant4
 COPY build_geant4.sh /root/etc/
-RUN bash /root/etc/build_geant4.sh gcc-4.8   10.03.p01
-RUN bash /root/etc/build_geant4.sh gcc-4.9   10.03.p01
-RUN bash /root/etc/build_geant4.sh gcc-5     10.03.p01
-RUN bash /root/etc/build_geant4.sh gcc-6     10.03.p01
-RUN bash /root/etc/build_geant4.sh clang-3.8 10.03.p01
-RUN bash /root/etc/build_geant4.sh clang-3.9 10.03.p01
-RUN bash /root/etc/build_geant4.sh clang-4.0 10.03.p01
+RUN bash /root/etc/build_geant4.sh gcc-7
+RUN bash /root/etc/build_geant4.sh clang-5.0
 
 CMD ["bash"]

--- a/docker/build_dagmc.sh
+++ b/docker/build_dagmc.sh
@@ -1,17 +1,18 @@
 #!/bin/bash
 
-# $1: compiler (gcc-4.8, gcc-4.9, gcc-5, gcc-6, clang-3.8, clang-3.9, clang-4.0)
+# $1: compiler (gcc-4.8, gcc-5, gcc-6, gcc-7, clang-4.0, clang-5.0)
 # $2: build static (OFF, ON)
 # $3: moab version (5.0, master)
-# $4: geant4 version (10.01.p03, 10.02.p03, 10.03.p01)
+# $4: build Dag-Geant4 (OFF, ON)
 
 set -e
 
 source /root/etc/$1.env
 build_static=$2
-hdf5_version=1.8.13
 moab_version=$3
-geant4_version=$4
+build_daggeant4=$4
+hdf5_version=1.8.13
+geant4_version=10.04
 
 export PATH=${install_dir}/hdf5-${hdf5_version}/bin:${PATH}
 export PATH=${install_dir}/moab-${moab_version}/bin:${PATH}
@@ -26,9 +27,9 @@ cd ${build_dir}/DAGMC-moab-${moab_version}
 #git clone https://github.com/svalinn/DAGMC -b develop
 ln -snf DAGMC src
 cd bld
-cmake ../src -DBUILD_GEANT4=ON \
+cmake ../src -DMOAB_DIR=${install_dir}/moab-${moab_version} \
+             -DBUILD_GEANT4=${build_daggeant4} \
              -DGEANT4_DIR=${install_dir}/geant4-${geant4_version} \
-             -DBUILD_TALLY=ON \
              -DBUILD_CI_TESTS=ON \
              -DBUILD_STATIC=${build_static} \
              -DCMAKE_C_COMPILER=${CC} \

--- a/docker/build_geant4.sh
+++ b/docker/build_geant4.sh
@@ -1,12 +1,11 @@
 #!/bin/bash
 
-# $1: compiler (gcc-4.8, gcc-4.9, gcc-5, gcc-6, clang-3.8, clang-3.9, clang-4.0)
-# $2: geant4 version (10.01.p03, 10.02.p03, 10.03.p01)
+# $1: compiler (gcc-4.8, gcc-5, gcc-6, gcc-7, clang-4.0, clang-5.0)
 
 set -e
 
 source /root/etc/$1.env
-geant4_version=$2
+geant4_version=10.04
 
 mkdir -p ${build_dir}/geant4-${geant4_version}/bld
 rm -rf ${install_dir}/geant4-${geant4_version}

--- a/docker/build_geant4.sh
+++ b/docker/build_geant4.sh
@@ -15,6 +15,7 @@ tar -xzvf geant4.${geant4_version}.tar.gz
 ln -snf geant4.${geant4_version} src
 cd bld
 cmake ../src -DBUILD_STATIC_LIBS=ON \
+             -DGEANT4_USE_SYSTEM_EXPAT=OFF \
              -DCMAKE_C_COMPILER=${CC} \
              -DCMAKE_CXX_COMPILER=${CXX} \
              -DCMAKE_INSTALL_PREFIX=${install_dir}/geant4-${geant4_version}

--- a/docker/build_hdf5.sh
+++ b/docker/build_hdf5.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# $1: compiler (gcc-4.8, gcc-4.9, gcc-5, gcc-6, clang-3.8, clang-3.9, clang-4.0)
+# $1: compiler (gcc-4.8, gcc-5, gcc-6, gcc-7, clang-4.0, clang-5.0)
 
 set -e
 
@@ -10,7 +10,7 @@ hdf5_version=1.8.13
 mkdir -p ${build_dir}/hdf5-${hdf5_version}/bld
 rm -rf ${install_dir}/hdf5-${hdf5_version}
 cd ${build_dir}/hdf5-${hdf5_version}
-wget https://www.hdfgroup.org/ftp/HDF5/releases/hdf5-${hdf5_version}/src/hdf5-${hdf5_version}.tar.gz
+wget https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.8/hdf5-${hdf5_version}/src/hdf5-${hdf5_version}.tar.gz
 tar -xzvf hdf5-${hdf5_version}.tar.gz
 ln -snf hdf5-${hdf5_version} src
 cd bld

--- a/docker/build_moab.sh
+++ b/docker/build_moab.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-# $1: compiler (gcc-4.8, gcc-4.9, gcc-5, gcc-6, clang-3.8, clang-3.9, clang-4.0)
+# $1: compiler (gcc-4.8, gcc-5, gcc-6, gcc-7, clang-4.0, clang-5.0)
 # $2: moab version (5.0, master)
 
 set -e
 
 source /root/etc/$1.env
-hdf5_version=1.8.13
 moab_version=$2
+hdf5_version=1.8.13
 
 mkdir -p ${build_dir}/moab-${moab_version}/bld
 rm -rf ${install_dir}/moab-${moab_version}

--- a/docker/clang-3.5.env
+++ b/docker/clang-3.5.env
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-export build_dir=/root/build/clang-3.5
-export install_dir=/root/opt/clang-3.5
-export CC=`which clang-3.5`
-export CXX=`which clang++-3.5`
-export FC=`which gfortran-5`

--- a/docker/clang-3.6.env
+++ b/docker/clang-3.6.env
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-export build_dir=/root/build/clang-3.6
-export install_dir=/root/opt/clang-3.6
-export CC=`which clang-3.6`
-export CXX=`which clang++-3.6`
-export FC=`which gfortran-5`

--- a/docker/clang-3.7.env
+++ b/docker/clang-3.7.env
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-export build_dir=/root/build/clang-3.7
-export install_dir=/root/opt/clang-3.7
-export CC=`which clang-3.7`
-export CXX=`which clang++-3.7`
-export FC=`which gfortran-5`

--- a/docker/clang-3.8.env
+++ b/docker/clang-3.8.env
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-export build_dir=/root/build/clang-3.8
-export install_dir=/root/opt/clang-3.8
-export CC=`which clang-3.8`
-export CXX=`which clang++-3.8`
-export FC=`which gfortran-5`

--- a/docker/clang-3.9.env
+++ b/docker/clang-3.9.env
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-export build_dir=/root/build/clang-3.9
-export install_dir=/root/opt/clang-3.9
-export CC=`which clang-3.9`
-export CXX=`which clang++-3.9`
-export FC=`which gfortran-5`

--- a/docker/clang-4.0.env
+++ b/docker/clang-4.0.env
@@ -4,4 +4,4 @@ export build_dir=/root/build/clang-4.0
 export install_dir=/root/opt/clang-4.0
 export CC=`which clang-4.0`
 export CXX=`which clang++-4.0`
-export FC=`which gfortran-5`
+export FC=`which gfortran-7`

--- a/docker/clang-5.0.env
+++ b/docker/clang-5.0.env
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+export build_dir=/root/build/clang-5.0
+export install_dir=/root/opt/clang-5.0
+export CC=`which clang-5.0`
+export CXX=`which clang++-5.0`
+export FC=`which gfortran-7`

--- a/docker/gcc-4.4.env
+++ b/docker/gcc-4.4.env
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-export build_dir=/root/build/gcc-4.4
-export install_dir=/root/opt/gcc-4.4
-export CC=`which gcc-4.4`
-export CXX=`which g++-4.4`
-export FC=`which gfortran-4.4`

--- a/docker/gcc-4.6.env
+++ b/docker/gcc-4.6.env
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-export build_dir=/root/build/gcc-4.6
-export install_dir=/root/opt/gcc-4.6
-export CC=`which gcc-4.6`
-export CXX=`which g++-4.6`
-export FC=`which gfortran-4.6`

--- a/docker/gcc-4.7.env
+++ b/docker/gcc-4.7.env
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-export build_dir=/root/build/gcc-4.7
-export install_dir=/root/opt/gcc-4.7
-export CC=`which gcc-4.7`
-export CXX=`which g++-4.7`
-export FC=`which gfortran-4.7`

--- a/docker/gcc-4.9.env
+++ b/docker/gcc-4.9.env
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-export build_dir=/root/build/gcc-4.9
-export install_dir=/root/opt/gcc-4.9
-export CC=`which gcc-4.9`
-export CXX=`which g++-4.9`
-export FC=`which gfortran-4.9`

--- a/docker/gcc-7.env
+++ b/docker/gcc-7.env
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+export build_dir=/root/build/gcc-7
+export install_dir=/root/opt/gcc-7
+export CC=`which gcc-7`
+export CXX=`which g++-7`
+export FC=`which gfortran-7`

--- a/docker/run_tests.sh
+++ b/docker/run_tests.sh
@@ -41,7 +41,10 @@ cd ${DAGMC_dir}/tests
 ./dagmc_pointinvol_test
 ./dagmc_rayfire_test
 ./dagmc_simple_test
-./dagsolid_unit_tests
+# not every CI run builds dagsolid
+if [ -f dagsolid_unit_tests ]; then
+  ./dagsolid_unit_tests
+fi
 #./fludag_unit_tests  # no fludag yet
 ./test_CellTally
 ./test_KDEKernel

--- a/docker/run_tests.sh
+++ b/docker/run_tests.sh
@@ -23,17 +23,22 @@ export LD_LIBRARY_PATH=${install_dir}/geant4-${geant4_version}/lib:${LD_LIBRARY_
 export LD_LIBRARY_PATH=${DAGMC_dir}/lib:${LD_LIBRARY_PATH}
 
 # Run astyle to see if there are any differences
-${DAGMC_dir}/tools/astyle --options=${DAGMC_dir}/tools/google.ini \
-                          --exclude=gtest \
-                          --exclude=tools/astyle \
-                          --exclude=mcnp/mcnp5/Source \
-                          --exclude=mcnp/mcnp6/Source \
-                          --ignore-exclude-errors \
-                          --recursive \
-                          --verbose \
-                          --formatted \
-                          "*.cc" "*.cpp" "*.h" "*.hh" "*.hpp"
-git diff --exit-code  # Exit if astyle found diffs
+astyle_deb=astyle_3.0.1-1ubuntu1_amd64.deb
+wget http://archive.ubuntu.com/ubuntu/pool/universe/a/astyle/${astyle_deb}
+dpkg -i ${astyle_deb}
+rm -f ${astyle_deb}
+astyle --options=tools/astyle/file/google.ini \
+       --exclude=gtest \
+       --exclude=tools/astyle \
+       --exclude=mcnp/mcnp5/Source \
+       --exclude=mcnp/mcnp6/Source \
+       --ignore-exclude-errors \
+       --recursive \
+       --verbose \
+       --formatted \
+       "*.cc" "*.cpp" "*.h" "*.hh" "*.hpp"
+# Exit if astyle found diffs
+git diff --exit-code
 
 # Run the tests
 cd ${DAGMC_dir}/tests

--- a/docker/run_tests.sh
+++ b/docker/run_tests.sh
@@ -1,25 +1,24 @@
 #!/bin/bash
 
-# $1: compiler (gcc-4.8, gcc-4.9, gcc-5, gcc-6, clang-3.8, clang-3.9, clang-4.0)
+# $1: compiler (gcc-4.8, gcc-5, gcc-6, gcc-7, clang-4.0, clang-5.0)
 # $2: moab version (5.0, master)
-# $3: geant4 version (10.01.p03, 10.02.p03, 10.03.p01)
+# $3: build Dag-Geant4 (OFF, ON)
 
 set -e
 
 source /root/etc/$1.env
-hdf5_version=1.8.13
 moab_version=$2
-geant4_version=$3
+build_daggeant4=$3
+hdf5_version=1.8.13
+geant4_version=10.04
 
 DAGMC_dir=${install_dir}/DAGMC-moab-${moab_version}
 
 export PATH=${install_dir}/hdf5-${hdf5_version}/bin:${PATH}
 export PATH=${install_dir}/moab-${moab_version}/bin:${PATH}
-export PATH=${install_dir}/geant4-${geant4_version}/bin:${PATH}
 export PATH=${DAGMC_dir}/bin:${PATH}
 export LD_LIBRARY_PATH=${install_dir}/hdf5-${hdf5_version}/lib
 export LD_LIBRARY_PATH=${install_dir}/moab-${moab_version}/lib:${LD_LIBRARY_PATH}
-export LD_LIBRARY_PATH=${install_dir}/geant4-${geant4_version}/lib:${LD_LIBRARY_PATH}
 export LD_LIBRARY_PATH=${DAGMC_dir}/lib:${LD_LIBRARY_PATH}
 
 # Run astyle to see if there are any differences
@@ -46,8 +45,9 @@ cd ${DAGMC_dir}/tests
 ./dagmc_pointinvol_test
 ./dagmc_rayfire_test
 ./dagmc_simple_test
-# not every CI run builds dagsolid
-if [ -f dagsolid_unit_tests ]; then
+if [ "$build_daggeant4" == "ON" ]; then
+  PATH=${install_dir}/geant4-${geant4_version}/bin:${PATH}
+  LD_LIBRARY_PATH=${install_dir}/geant4-${geant4_version}/lib:${LD_LIBRARY_PATH}
   ./dagsolid_unit_tests
 fi
 #./fludag_unit_tests  # no fludag yet


### PR DESCRIPTION
This PR updates the docker image similarly to what I did in #535. Once this is merged, I will update #535 to not include these changes anymore.

Here are the important changes this makes:
* Add gcc-7 and clang-5.0 to supported compilers, remove gcc-4.9, clang-3.8, and clang-3.9 from supported compilers
* Only build and test Geant4 with gcc-7 and clang-5.0; this really helps cut down on the size of the docker image