### PR TITLE
Quick fix to slideshow L/R hover css.

### DIFF
--- a/doc/slideshow.html
+++ b/doc/slideshow.html
@@ -37,6 +37,7 @@
 /* On hover, add a black background color with a little bit see-through */
 .prev:hover, .next:hover {
   background-color: rgba(0,0,0,0.8);
+  text-decoration: none;
 }
 
 /* Caption text */


### PR DESCRIPTION
A quick fix to remove some strange formatting when hovering over the L/R selection buttons in the image slideshow on the main page. 