### PR TITLE
Remove mangling

### DIFF
--- a/doc/install/dag-mcnp.rst
+++ b/doc/install/dag-mcnp.rst
@@ -16,21 +16,21 @@ RSICC_.
 If you are building |DAG-Code|, you will need to copy the MCNP source code from
 the DVD into the DAGMC repository and apply a patch so it can be used with
 DAGMC. The patch you use must correspond to your version of MCNP. Currently
-supported versions of MCNP5 are 5.1.40, 5.1.51, 5.1.60
+supported versions of MCNP5 are 5.1.40, 5.1.51, 5.1.60.
 ::
 
-    $ cd mcnp/mcnp5
+    $ cd src/mcnp/mcnp5
     $ cp -r <path_to_dvd>/MCNP5/Source .
     $ chmod -R u+rw Source
-    $ patch -p0 < patch/dagmc.5.1.60.patch
+    $ patch -p0 < patch/mcnp516.patch
 
 Currently supported versions of MCNP6 are 6_beta2, 6.1, and 6.1.1beta.
 ::
 
-    $ cd mcnp/mcnp6
+    $ cd src/mcnp/mcnp6
     $ cp -r <path_to_dvd>/MCNP6/Source .
     $ chmod -R u+rw Source
-    $ patch -p0 < patch/dagmc.6.1.1beta.patch
+    $ patch -p0 < patch/mcnp611.patch
 
 Assuming the patch or patches were succesfully applied, i.e. there were no
 warnings or errors, you are now ready to configure DAGMC to produce the desired

--- a/news/PR-0556.rst
+++ b/news/PR-0556.rst
@@ -3,6 +3,7 @@
 **Changed:**
 
 * Use bind(c) in fmesh_mod.F90 to avoid the need for name mangling on the C++ side
+* Rename MCNP patch files to mcnpXXX.patch, where XXX is the version turned into a 3-digit number
 
 **Deprecated:** None
 

--- a/news/PR-0556.rst
+++ b/news/PR-0556.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:**
+
+* Use bind(c) in fmesh_mod.F90 to avoid the need for name mangling on the C++ side
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/src/mcnp/mcnp5/patch/mcnp514.patch
+++ b/src/mcnp/mcnp5/patch/mcnp514.patch
@@ -386,7 +386,7 @@ diff -rN '--unified=0' Source/src/fmesh_mod.F90 Source_dagmc/src/fmesh_mod.F90
 +  ! This interface specification ensures that the calls to these functions
 +  ! (which are implemented in C) are made with the correct types
 +  interface
-+    subroutine dagmc_fmesh_get_tally_data( fm_id, fref )
++    subroutine dagmc_fmesh_get_tally_data( fm_id, fref ) bind(c)
 +      implicit none
 +      integer :: fm_id
 +      ! The dknd parameter is unavailable in this scope for some reason,
@@ -394,13 +394,13 @@ diff -rN '--unified=0' Source/src/fmesh_mod.F90 Source_dagmc/src/fmesh_mod.F90
 +      real(selected_real_kind(15,307)) , dimension(:), pointer :: fref
 +    end subroutine dagmc_fmesh_get_tally_data
 +
-+    subroutine dagmc_fmesh_get_error_data( fm_id, fref )
++    subroutine dagmc_fmesh_get_error_data( fm_id, fref ) bind(c)
 +      implicit none
 +      integer :: fm_id
 +      real(selected_real_kind(15,307)) , dimension(:), pointer :: fref
 +    end subroutine dagmc_fmesh_get_error_data
 +
-+    subroutine dagmc_fmesh_get_scratch_data( fm_id, fref )
++    subroutine dagmc_fmesh_get_scratch_data( fm_id, fref ) bind(c)
 +      implicit none
 +      integer :: fm_id
 +      real(selected_real_kind(15,307)), dimension(:), pointer:: fref
@@ -410,7 +410,7 @@ diff -rN '--unified=0' Source/src/fmesh_mod.F90 Source_dagmc/src/fmesh_mod.F90
 +
 @@ -128,0 +161,60 @@
 +  ! DAGMC: Helper function - create a valid Fortran pointer from a C array and a length 
-+  subroutine dagmc_make_fortran_pointer( fref, carray, size )
++  subroutine dagmc_make_fortran_pointer( fref, carray, size ) bind(c)
 +    implicit none
 +
 +    integer :: size ! The size (in doubles) of the array in C

--- a/src/mcnp/mcnp5/patch/mcnp515.patch
+++ b/src/mcnp/mcnp5/patch/mcnp515.patch
@@ -386,7 +386,7 @@ diff -rN '--unified=0' Source/src/fmesh_mod.F90 Source_dagmc/src/fmesh_mod.F90
 +  ! This interface specification ensures that the calls to these functions
 +  ! (which are implemented in C) are made with the correct types
 +  interface
-+    subroutine dagmc_fmesh_get_tally_data( fm_id, fref )
++    subroutine dagmc_fmesh_get_tally_data( fm_id, fref ) bind(c)
 +      implicit none
 +      integer :: fm_id
 +      ! The dknd parameter is unavailable in this scope for some reason,
@@ -394,13 +394,13 @@ diff -rN '--unified=0' Source/src/fmesh_mod.F90 Source_dagmc/src/fmesh_mod.F90
 +      real(selected_real_kind(15,307)) , dimension(:), pointer :: fref
 +    end subroutine dagmc_fmesh_get_tally_data
 +
-+    subroutine dagmc_fmesh_get_error_data( fm_id, fref )
++    subroutine dagmc_fmesh_get_error_data( fm_id, fref ) bind(c)
 +      implicit none
 +      integer :: fm_id
 +      real(selected_real_kind(15,307)) , dimension(:), pointer :: fref
 +    end subroutine dagmc_fmesh_get_error_data
 +
-+    subroutine dagmc_fmesh_get_scratch_data( fm_id, fref )
++    subroutine dagmc_fmesh_get_scratch_data( fm_id, fref ) bind(c)
 +      implicit none
 +      integer :: fm_id
 +      real(selected_real_kind(15,307)), dimension(:), pointer:: fref
@@ -410,7 +410,7 @@ diff -rN '--unified=0' Source/src/fmesh_mod.F90 Source_dagmc/src/fmesh_mod.F90
 +
 @@ -129,0 +162,60 @@
 +  ! DAGMC: Helper function - create a valid Fortran pointer from a C array and a length 
-+  subroutine dagmc_make_fortran_pointer( fref, carray, size )
++  subroutine dagmc_make_fortran_pointer( fref, carray, size ) bind(c)
 +    implicit none
 +
 +    integer :: size ! The size (in doubles) of the array in C

--- a/src/mcnp/mcnp5/patch/mcnp516.patch
+++ b/src/mcnp/mcnp5/patch/mcnp516.patch
@@ -386,7 +386,7 @@ diff -rN '--unified=0' Source/src/fmesh_mod.F90 Source_dagmc/src/fmesh_mod.F90
 +  ! This interface specification ensures that the calls to these functions
 +  ! (which are implemented in C) are made with the correct types
 +  interface
-+    subroutine dagmc_fmesh_get_tally_data( fm_id, fref )
++    subroutine dagmc_fmesh_get_tally_data( fm_id, fref ) bind(c)
 +      implicit none
 +      integer :: fm_id
 +      ! The dknd parameter is unavailable in this scope for some reason,
@@ -394,13 +394,13 @@ diff -rN '--unified=0' Source/src/fmesh_mod.F90 Source_dagmc/src/fmesh_mod.F90
 +      real(selected_real_kind(15,307)) , dimension(:), pointer :: fref
 +    end subroutine dagmc_fmesh_get_tally_data
 +
-+    subroutine dagmc_fmesh_get_error_data( fm_id, fref )
++    subroutine dagmc_fmesh_get_error_data( fm_id, fref ) bind(c)
 +      implicit none
 +      integer :: fm_id
 +      real(selected_real_kind(15,307)) , dimension(:), pointer :: fref
 +    end subroutine dagmc_fmesh_get_error_data
 +
-+    subroutine dagmc_fmesh_get_scratch_data( fm_id, fref )
++    subroutine dagmc_fmesh_get_scratch_data( fm_id, fref ) bind(c)
 +      implicit none
 +      integer :: fm_id
 +      real(selected_real_kind(15,307)), dimension(:), pointer:: fref
@@ -410,7 +410,7 @@ diff -rN '--unified=0' Source/src/fmesh_mod.F90 Source_dagmc/src/fmesh_mod.F90
 +
 @@ -130,0 +163,60 @@
 +  ! DAGMC: Helper function - create a valid Fortran pointer from a C array and a length 
-+  subroutine dagmc_make_fortran_pointer( fref, carray, size )
++  subroutine dagmc_make_fortran_pointer( fref, carray, size ) bind(c)
 +    implicit none
 +
 +    integer :: size ! The size (in doubles) of the array in C

--- a/src/mcnp/mcnp6/patch/mcnp602.patch
+++ b/src/mcnp/mcnp6/patch/mcnp602.patch
@@ -26,23 +26,23 @@ diff -rN '--unified=0' Source/src/angl.F90 Source_dagmc/src/angl.F90
 diff -rN '--unified=0' Source/src/bankit.F90 Source_dagmc/src/bankit.F90
 --- Source/src/bankit.F90
 +++ Source_dagmc/src/bankit.F90
-@@ -67,0 +68 @@
+@@ -69,0 +70 @@
 +    use dagmc_mod, only : isdgmc
-@@ -105,0 +107,5 @@
+@@ -101,0 +103,5 @@
 +    ! DAGMC:
 +    if ( isdgmc == 1 ) then
 +      call dagmc_bank_push( nbnk )
 +    endif
 +
-@@ -277,0 +284 @@
+@@ -280,0 +287 @@
 +    use dagmc_mod, only : isdgmc
-@@ -288,0 +296,5 @@
+@@ -291,0 +299,5 @@
 +  ! DAGMC:
 +    if ( isdgmc == 1 ) then
 +      call dagmc_bank_usetop()
 +    endif
 +
-@@ -391,0 +404,4 @@
+@@ -398,0 +411,4 @@
 +      ! DAGMC:
 +      if ( isdgmc == 1 ) then
 +        call dagmc_bank_pop( nbnk )
@@ -52,7 +52,7 @@ diff -rN '--unified=0' Source/src/celsrf.F90 Source_dagmc/src/celsrf.F90
 +++ Source_dagmc/src/celsrf.F90
 @@ -25,0 +26 @@
 +  use dagmc_mod, only : isdgmc
-@@ -449 +450,6 @@
+@@ -445 +446,6 @@
 -    write(iuo,460) js,j1,hq,hl,ht,surface_card(k)%symbol,(tpp(i),i=1,n)
 +    ! DAGMC: surface_card(k)%symbol returns null characters in DAGMC mode
 +    if (isdgmc == 1) then
@@ -60,22 +60,10 @@ diff -rN '--unified=0' Source/src/celsrf.F90 Source_dagmc/src/celsrf.F90
 +    else
 +      write(iuo,460) js,j1,hq,hl,ht,surface_card(k)%symbol,(tpp(i),i=1,n)
 +    endif
-@@ -505,0 +512,3 @@
+@@ -501,0 +508,3 @@
 +    ! DAGMC: Skip this loop if in CAD mode
 +    if (isdgmc == 1) exit
 +
-diff -rN '--unified=0' Source/src/charged_particle_history.F90 Source_dagmc/src/charged_particle_history.F90
---- Source/src/charged_particle_history.F90
-+++ Source_dagmc/src/charged_particle_history.F90
-@@ -326,0 +327,5 @@
-+
-+        ! DAGMC: if minimum distance to next event is exactly zero, skip the
-+        ! charged particle physics and go directly to the surface crossing
-+        if( d_step_inter_decay_surf == zero ) goto 100
-+
-@@ -627,0 +633,2 @@
-+
-+100     continue  ! DAGMC jump target
 diff -rN '--unified=0' Source/src/check_binary_expire.F90 Source_dagmc/src/check_binary_expire.F90
 --- Source/src/check_binary_expire.F90
 +++ Source_dagmc/src/check_binary_expire.F90
@@ -87,7 +75,7 @@ diff -rN '--unified=0' Source/src/chkcel.F90 Source_dagmc/src/chkcel.F90
 +++ Source_dagmc/src/chkcel.F90
 @@ -28,0 +29 @@
 +  use dagmc_mod,    only : isdgmc
-@@ -60,0 +62,6 @@
+@@ -58,0 +60,6 @@
 +
 +  ! DAGMC: In CAD mode, circumvent this function and call DAGMC version instead
 +  if ( isdgmc == 1 .and. (m == 0 .or. m == 2) ) then
@@ -325,12 +313,12 @@ diff -rN '--unified=0' Source/src/dagmc_mod.F90 Source_dagmc/src/dagmc_mod.F90
 diff -rN '--unified=0' Source/src/dbmin.F90 Source_dagmc/src/dbmin.F90
 --- Source/src/dbmin.F90
 +++ Source_dagmc/src/dbmin.F90
-@@ -20,0 +21 @@
+@@ -17,0 +18 @@
 +  use dagmc_mod,    only : isdgmc
-@@ -33,0 +35,10 @@
+@@ -30,0 +32,10 @@
 +
 +  ! DAGMC: Explicitly declare variable for return value for inter-language call
-+  real(dknd) :: dbmin_retval = zero
++  real(dknd) :: dbmin_retval = 0
 +
 +  ! DAGMC: In CAD mode, call MOAB version instead
 +  if ( isdgmc == 1 ) then
@@ -357,7 +345,7 @@ diff -rN '--unified=0' Source/src/electr.F90 Source_dagmc/src/electr.F90
 +++ Source_dagmc/src/electr.F90
 @@ -38,0 +39 @@
 +  use dagmc_mod, only : isdgmc
-@@ -145,0 +147,6 @@
+@@ -131,0 +133,6 @@
 +        endif
 +
 +        ! DAGMC: In DAGMC mode, use the known physics distance to limit geometry search
@@ -367,34 +355,34 @@ diff -rN '--unified=0' Source/src/electr.F90 Source_dagmc/src/electr.F90
 diff -rN '--unified=0' Source/src/exemes.F90 Source_dagmc/src/exemes.F90
 --- Source/src/exemes.F90
 +++ Source_dagmc/src/exemes.F90
-@@ -273 +273 @@
+@@ -275 +275 @@
 -      select case( hm(js) )
 +      select case( trim(hm(js)) )
 diff -rN '--unified=0' Source/src/fmesh_mod.F90 Source_dagmc/src/fmesh_mod.F90
 --- Source/src/fmesh_mod.F90
 +++ Source_dagmc/src/fmesh_mod.F90
-@@ -41,0 +42,3 @@
-+  public ::  dagmc_make_fortran_pointer  ! DAGMC
-+  public ::  dagmc_setup_mesh_tally      ! DAGMC
+@@ -22,0 +23,3 @@
++  ! DAGMC
++  public :: dagmc_make_fortran_pointer, dagmc_setup_mesh_tally
 +
-@@ -44,0 +48,4 @@
+@@ -25,0 +29,4 @@
 +  logical, public :: enable_dag_tallies           = .false. ! DAGMC: Indicate any dagmc tally
 +  logical, public :: enable_dag_collision_tallies = .false. ! DAGMC: Indicate a collision tally
 +  logical, public :: enable_dag_track_tallies     = .false. ! DAGMC: Indicate a track tally
 +
-@@ -76 +83 @@
+@@ -56 +63 @@
 -  integer, parameter, public :: nfmesh_keyword_results = 15
 +  integer, parameter, public :: nfmesh_keyword_results = 16
-@@ -81 +88,2 @@
--  &     'yes       ','no        ','flux      ','source    ','none      ' /)
+@@ -61 +68,2 @@
+-  &     'yes       ','no        ','flux      ','source    ','none      ' /) 
 +  &     'yes       ','no        ','flux      ','source    ','none      ',   &
 +  &     'dag       ' /)
-@@ -200,0 +209,26 @@
+@@ -180,0 +189,26 @@
 +  ! DAGMC: These helper functions must be called with non-dereferenced Fortran pointers.
 +  ! This interface specification ensures that the calls to these functions
 +  ! (which are implemented in C) are made with the correct types
 +  interface
-+    subroutine dagmc_fmesh_get_tally_data( fm_id, fref )
++    subroutine dagmc_fmesh_get_tally_data( fm_id, fref ) bind(c)
 +      implicit none
 +      integer :: fm_id
 +      ! The dknd parameter is unavailable in this scope for some reason,
@@ -402,13 +390,13 @@ diff -rN '--unified=0' Source/src/fmesh_mod.F90 Source_dagmc/src/fmesh_mod.F90
 +      real(selected_real_kind(15,307)) , dimension(:), pointer :: fref
 +    end subroutine dagmc_fmesh_get_tally_data
 +
-+    subroutine dagmc_fmesh_get_error_data( fm_id, fref )
++    subroutine dagmc_fmesh_get_error_data( fm_id, fref ) bind(c)
 +      implicit none
 +      integer :: fm_id
 +      real(selected_real_kind(15,307)) , dimension(:), pointer :: fref
 +    end subroutine dagmc_fmesh_get_error_data
 +
-+    subroutine dagmc_fmesh_get_scratch_data( fm_id, fref )
++    subroutine dagmc_fmesh_get_scratch_data( fm_id, fref ) bind(c)
 +      implicit none
 +      integer :: fm_id
 +      real(selected_real_kind(15,307)), dimension(:), pointer:: fref
@@ -416,9 +404,9 @@ diff -rN '--unified=0' Source/src/fmesh_mod.F90 Source_dagmc/src/fmesh_mod.F90
 +
 +  end interface
 +
-@@ -204,0 +239,60 @@
+@@ -184,0 +219,60 @@
 +  ! DAGMC: Helper function - create a valid Fortran pointer from a C array and a length
-+  subroutine dagmc_make_fortran_pointer( fref, carray, size )
++  subroutine dagmc_make_fortran_pointer( fref, carray, size ) bind(c)
 +    implicit none
 +
 +    integer :: size ! The size (in doubles) of the array in C
@@ -477,11 +465,11 @@ diff -rN '--unified=0' Source/src/fmesh_mod.F90 Source_dagmc/src/fmesh_mod.F90
 +
 +  !-----------------------------------------------------------------------------------------
 +
-@@ -218,0 +313,3 @@
+@@ -198,0 +293,3 @@
 +    ! DAGMC
 +    real(dknd), dimension(:), pointer :: dagmc_runtpe_data
 +
-@@ -270,0 +368,8 @@
+@@ -250,0 +348,8 @@
 +      ! DAGMC:
 +      if ( fm(i)%icrd == 3 ) then
 +        ! Get pointer to mesh's working data and fill runtpe with those contents
@@ -490,11 +478,11 @@ diff -rN '--unified=0' Source/src/fmesh_mod.F90 Source_dagmc/src/fmesh_mod.F90
 +        call dagmc_fmesh_get_error_data( fm(i)%id, dagmc_runtpe_data )
 +        write(iu) dagmc_runtpe_data
 +      endif
-@@ -299,0 +405,3 @@
+@@ -279,0 +385,3 @@
 +    ! DAGMC
 +    real(dknd), dimension(:), pointer :: dagmc_runtpe_data
 +
-@@ -474,0 +583,11 @@
+@@ -462,0 +571,11 @@
 +
 +      ! DAGMC:
 +      if ( fm(i)%icrd == 3 ) then
@@ -506,103 +494,113 @@ diff -rN '--unified=0' Source/src/fmesh_mod.F90 Source_dagmc/src/fmesh_mod.F90
 +        read(iu) dagmc_runtpe_data
 +      endif
 +
-@@ -1043 +1162,2 @@
--    integer   :: i, ix, iy, iz, it, ie, is
-+    integer   :: i, ix, iy, iz, it, ie, is, j
+@@ -1008 +1127 @@
+-    integer :: i
++    integer :: i, j
+@@ -1070,0 +1190,9 @@
++      ! DAGMC: send comment contents if this is a dagmc mesh
++      if( fm(i)%icrd == 3 ) then
++        call msg_put( fm(i)%n_comment_lines )
 +
-@@ -1150,0 +1271,16 @@
-+      ! DAGMC: broadcast comment contents if this is a dagmc mesh
-+      if ( fm(i)%icrd == 3 ) then
-+        call msg_bcast(mynum, fm(i)%n_comment_lines)
-+
-+        if ( mynum > 0 ) then
-+          allocate( fm(i)%comment( fm(i)%n_comment_lines ), stat=is )
-+          if ( is /= 0 ) then
-+            call erprnt(1,1,0,0,0,0,0,1,' "mesh tally memory allocation failure"')
-+          endif
-+        endif
-+
-+        do j = 1, fm(i)%n_comment_lines
-+          call msg_bcast(mynum, fm(i)%comment(j))
++        do j=1,fm(i)%n_comment_lines
++          call msg_put( fm(i)%comment(j) )
 +        enddo
 +      endif
 +
-@@ -1198,0 +1335,7 @@
+@@ -1092 +1220 @@
+-    integer :: i,ix,iy,iz,it,ie,is
++    integer :: i,ix,iy,iz,it,ie,is,j
+@@ -1195,0 +1324,13 @@
++      ! DAGMC: receive comment contents if this is a dagmc mesh
++      if( fm(i)%icrd == 3 ) then
++        call msg_get( fm(i)%n_comment_lines )
 +
-+      ! DAGMC:
-+      do i = 1, nmesh
-+        if( fm(i)%icrd == 3 ) then
-+          call dagmc_setup_mesh_tally(i)
-+        endif
-+      enddo
-@@ -1218,0 +1362,3 @@
-+    ! DAGMC
++        allocate( fm(i)%comment( fm(i)%n_comment_lines ), stat=is )
++        if(is/=0) call erprnt(1,1,0,0,0,0,0,1,' "mesh tally memory allocation failure"')
++
++        do j=1,fm(i)%n_comment_lines
++          call msg_get( fm(i)%comment(j) )
++        enddo
++
++      endif
++
+@@ -1240,0 +1382,7 @@
++    ! DAGMC:
++    do i = 1,nmesh
++      if( fm(i)%icrd == 3 ) then
++        call dagmc_setup_mesh_tally( i )
++      endif
++    enddo
++
+@@ -1334,0 +1483 @@
 +    real(dknd), dimension(:), pointer :: dagmc_mpi_data
-+
-@@ -1243 +1389,2 @@
+@@ -1360 +1509,18 @@
 -      isize = ix*iy*iz*it*ie
 +      if( fm(i)%icrd /= 3 ) then
 +        isize = ix*iy*iz*it*ie
-@@ -1245,7 +1392,15 @@
--      ! use matching tag=555 in fmesh_msgtsk
--      call msg_recv( islave,555, fmtal(i)%tally(:,1,1,1,1,1), isize )
--      fm(i)%fmarry(:,:,:,:,:,1) = fm(i)%fmarry(:,:,:,:,:,1) + fmtal(i)%tally(:,:,:,:,:,1)
--
--      ! use matching tag=556 in fmesh_msgtsk
--      call msg_recv( islave,556, fmtal(i)%tally(:,1,1,1,1,2), isize )
--      fm(i)%fmerr( :,:,:,:,:,1) = fm(i)%fmerr( :,:,:,:,:,1) + fmtal(i)%tally(:,:,:,:,:,2)
-+        ! use matching tag=555 in fmesh_msgtsk
-+        call msg_recv( islave,555, fmtal(i)%tally(:,1,1,1,1,1), isize )
-+        fm(i)%fmarry(:,:,:,:,:,1) = fm(i)%fmarry(:,:,:,:,:,1) + fmtal(i)%tally(:,:,:,:,:,1)
 +
-+        ! use matching tag=556 in fmesh_msgtsk
-+        call msg_recv( islave,556, fmtal(i)%tally(:,1,1,1,1,2), isize )
-+        fm(i)%fmerr( :,:,:,:,:,1) = fm(i)%fmerr( :,:,:,:,:,1) + fmtal(i)%tally(:,:,:,:,:,2)
++        call msg_get(fmtal(i)%tally,  num_items =  isize)
++        fm(i)%fmarry(:,:,:,:,:,1) = fm(i)%fmarry(:,:,:,:,:,1)+  &
++          &   fmtal(i)%tally(:,:,:,:,:,1)
++
++        call msg_get(fmtal(i)%tally,  num_items =  isize)
++        fm(i)%fmerr(:,:,:,:,:,1) = fm(i)%fmerr(:,:,:,:,:,1)+  &
++          &   fmtal(i)%tally(:,:,:,:,:,1)
 +      else
 +        ! DAGMC
-+        call dagmc_fmesh_get_scratch_data(fm(i)%id, dagmc_mpi_data)
-+        call msg_recv(islave, 557, dagmc_mpi_data, size(dagmc_mpi_data))
-+        call dagmc_fmesh_add_scratch_to_tally(fm(i)%id)
-+        call msg_recv(islave, 558, dagmc_mpi_data, size(dagmc_mpi_data))
-+        call dagmc_fmesh_add_scratch_to_error(fm(i)%id)
++        call dagmc_fmesh_get_scratch_data( fm(i)%id, dagmc_mpi_data )
++        call msg_get( dagmc_mpi_data, 1, size(dagmc_mpi_data) )
++        call dagmc_fmesh_add_scratch_to_tally( fm(i)%id )
++        call msg_get( dagmc_mpi_data, 1, size(dagmc_mpi_data) )
++        call dagmc_fmesh_add_scratch_to_error( fm(i)%id )
 +      endif
-@@ -1269,0 +1425,3 @@
-+    ! DAGMC
+@@ -1362,7 +1527,0 @@
+-      call msg_get(fmtal(i)%tally,  num_items =  isize)
+-      fm(i)%fmarry(:,:,:,:,:,1) = fm(i)%fmarry(:,:,:,:,:,1)+  &
+-        &   fmtal(i)%tally(:,:,:,:,:,1)
+-
+-      call msg_get(fmtal(i)%tally,  num_items =  isize)
+-      fm(i)%fmerr(:,:,:,:,:,1) = fm(i)%fmerr(:,:,:,:,:,1)+  &
+-        &   fmtal(i)%tally(:,:,:,:,:,1)
+@@ -1387,0 +1547 @@
 +    real(dknd), dimension(:), pointer :: dagmc_mpi_data
-+
-@@ -1285 +1443,2 @@
+@@ -1404 +1564,2 @@
 -      isize = ix*iy*iz*it*ie
 +      if( fm(i)%icrd /= 3 ) then
 +        isize = ix*iy*iz*it*ie
-@@ -1287,7 +1446,14 @@
--      ! use matching tag=555 & tag=556 in fmesh_msgcon
--      call msg_send( 0,555, fm(i)%fmarry(:,1,1,1,1,1), isize )
--      call msg_send( 0,556, fm(i)%fmerr( :,1,1,1,1,1), isize )
--
--      ! zero arrays
--      fm(i)%fmarry(:,:,:,:,:,1) = zero
--      fm(i)%fmerr( :,:,:,:,:,1) = zero
-+        ! use matching tag=555 & tag=556 in fmesh_msgcon
-+        call msg_send( 0,555, fm(i)%fmarry(:,1,1,1,1,1), isize )
-+        call msg_send( 0,556, fm(i)%fmerr( :,1,1,1,1,1), isize )
+@@ -1406,2 +1567,13 @@
+-      call msg_put(fm(i)%fmarry,  num_items =  isize)
+-      call msg_put(fm(i)%fmerr,  num_items =  isize)
++        call msg_put(fm(i)%fmarry,  num_items =  isize)
++        call msg_put(fm(i)%fmerr,  num_items =  isize)
 +
 +        ! zero arrays
 +        fm(i)%fmarry(:,:,:,:,:,1) = zero
-+        fm(i)%fmerr( :,:,:,:,:,1) = zero
++        fm(i)%fmerr(:,:,:,:,:,1) = zero
 +      else
 +        ! DAGMC
-+        call dagmc_fmesh_get_tally_data(fm(i)%id, dagmc_mpi_data)
-+        call msg_send(0, 557, dagmc_mpi_data, size(dagmc_mpi_data))
-+        call dagmc_fmesh_get_error_data(fm(i)%id, dagmc_mpi_data)
-+        call msg_send(0, 558, dagmc_mpi_data, size(dagmc_mpi_data))
++        call dagmc_fmesh_get_tally_data( fm(i)%id, dagmc_mpi_data )
++        call msg_put( dagmc_mpi_data, 1, size(dagmc_mpi_data) )
++        call dagmc_fmesh_get_error_data( fm(i)%id, dagmc_mpi_data )
++        call msg_put( dagmc_mpi_data, 1, size(dagmc_mpi_data) )
 +      endif
-@@ -1313,0 +1480,5 @@
+@@ -1409,3 +1580,0 @@
+-      ! zero arrays
+-      fm(i)%fmarry(:,:,:,:,:,1) = zero
+-      fm(i)%fmerr(:,:,:,:,:,1) = zero
+@@ -1413,0 +1583,5 @@
++    ! DAGMC
++    if( enable_dag_tallies ) then
++      call dagmc_fmesh_clear_data()
++    endif
++
+@@ -1431,0 +1606,5 @@
 +    ! DAGMC: perform end of history tasks for all dagmc mesh tallies
 +    if ( enable_dag_tallies ) then
 +      call dagmc_fmesh_end_history()
 +    endif
 +
-@@ -1390,0 +1562,27 @@
+@@ -1508,0 +1688,27 @@
 +  subroutine dagmc_get_multiplier( i, erg, multiplier )
 +
 +    use mcnp_params, only : dknd
@@ -630,12 +628,12 @@ diff -rN '--unified=0' Source/src/fmesh_mod.F90 Source_dagmc/src/fmesh_mod.F90
 +
 +  !-----------------------------------------------------------------------------------------
 +
-@@ -1422,0 +1621,4 @@
+@@ -1539,0 +1746,4 @@
 +
 +    ! DAGMC
 +    real(dknd) :: dagmc_multiplier
 +
-@@ -1435,0 +1638,13 @@
+@@ -1552,0 +1763,13 @@
 +    ! DAGMC: update multipliers if any dagmc mesh tallies exist
 +    if ( enable_dag_tallies ) then
 +      do i = 1, nmesh
@@ -649,25 +647,25 @@ diff -rN '--unified=0' Source/src/fmesh_mod.F90 Source_dagmc/src/fmesh_mod.F90
 +       call dagmc_fmesh_score(ipt, x, y, z, u, v, w, erg, wgt, d, pbl%i%icl)
 +    endif
 +
-@@ -1444,0 +1660,5 @@
+@@ -1561,0 +1785,5 @@
 +      ! DAGMC: skip iteration if dagmc mesh tally
 +      if ( fm(i)%icrd == 3 ) then
 +        cycle
 +      endif
 +
-@@ -2792,0 +3013,5 @@
+@@ -2727,0 +2956,5 @@
 +    ! DAGMC: write data to file for all dagmc mesh tallies
 +    if ( enable_dag_tallies ) then
 +      call dagmc_fmesh_print(sp_norm)
 +    endif
 +
-@@ -2794,0 +3020,5 @@
+@@ -2729,0 +2963,5 @@
 +      ! DAGMC: skip iteration if dagmc mesh tally
 +      if( fm(j)%icrd == 3 ) then
 +        cycle
 +      endif
 +
-@@ -4000,0 +4231,7 @@
+@@ -3909,0 +4148,7 @@
 +
 +    ! DAGMC: setup up dagmc mesh tallies based on fmesh index i
 +    do i = 1,nmesh
@@ -678,36 +676,36 @@ diff -rN '--unified=0' Source/src/fmesh_mod.F90 Source_dagmc/src/fmesh_mod.F90
 diff -rN '--unified=0' Source/src/history_neutral_high.F90 Source_dagmc/src/history_neutral_high.F90
 --- Source/src/history_neutral_high.F90
 +++ Source_dagmc/src/history_neutral_high.F90
-@@ -156 +156,2 @@
--      if( D <= zero ) then  !  Review the need for this test.
+@@ -119 +119,2 @@
+-      if( d <= zero ) then  !  Review the need for this test.
 +      ! DAGMC: use < instead of <=
-+      if( D < zero ) then  !  Review the need for this test.
++      if( d < zero ) then  !  Review the need for this test.
 diff -rN '--unified=0' Source/src/hstory.F90 Source_dagmc/src/hstory.F90
 --- Source/src/hstory.F90
 +++ Source_dagmc/src/hstory.F90
-@@ -13 +13 @@
--  use fmesh_mod, only: nmesh
-+  use fmesh_mod, only: nmesh, enable_dag_collision_tallies
-@@ -24,0 +25 @@
-+  use dagmc_mod, only: isdgmc
-@@ -135 +136,2 @@
--        if( lca(pbl%i%icl) < 0 ) then
+@@ -16 +16 @@
+-  use fmesh_mod, only : mesh_score, nmesh, FMESH_CALL_HISTORY
++  use fmesh_mod, only : mesh_score, nmesh, FMESH_CALL_HISTORY, enable_dag_collision_tallies
+@@ -30,0 +31 @@
++  use dagmc_mod, only : isdgmc
+@@ -130 +131,2 @@
+-        if( lca(pbl%i%icl) < 0 )then
 +        ! DAGMC: only do this when running in non-CAD mode
 +        if( ( lca(pbl%i%icl) < 0 ) .and. (isdgmc == 0 ) ) then
-@@ -171 +173,2 @@
+@@ -167 +169,2 @@
 -            call track(pbl%i%icl)
 +            ! DAGMC: only call track here if in normal mode (NOT in CAD mode)
 +            if ( isdgmc == 0 ) call track(pbl%i%icl)
-@@ -249,0 +253,8 @@
-+                  ! DAGMC: In CAD mode, call DAGMC before forcing collision
-+                  if ( isdgmc == 1 ) then
-+                    if ( lca(pbl%i%icl) < 0 ) call chkcel(pbl%i%icl, 3, j)
-+                    call dagmc_setdis(huge_float)
-+                    call track(pbl%i%icl)
-+                    if ( kdb /= 0 ) exit HISTORY_LOOP
-+                  endif
+@@ -228,0 +232,8 @@
++                ! DAGMC: In CAD mode, call DAGMC before forcing collision
++                if ( isdgmc == 1 ) then
++                  if ( lca(pbl%i%icl) < 0 ) call chkcel(pbl%i%icl, 3, j)
++                  call dagmc_setdis(huge_float)
++                  call track(pbl%i%icl)
++                  if ( kdb /= 0 ) exit HISTORY_LOOP
++                endif
 +
-@@ -327,0 +339,9 @@
+@@ -282,0 +294,9 @@
 +          ! DAGMC: In CAD mode, get particle information
 +          if ( isdgmc == 1 ) then
 +            if ( lca(pbl%i%icl) < 0 ) call chkcel(pbl%i%icl, 3, j)
@@ -717,15 +715,16 @@ diff -rN '--unified=0' Source/src/hstory.F90 Source_dagmc/src/hstory.F90
 +            if ( kdb /= 0 ) exit HISTORY_LOOP
 +          endif
 +
-@@ -816,0 +837,5 @@
-+    ! DAGMC: Collision Tally
-+    if ( enable_dag_collision_tallies ) then
-+      call dagmc_collision_score(pbl%i%ipt, pbl%r%x, pbl%r%y, pbl%r%z, &
-+                                 pbl%r%erg, pbl%r%wgt, ple, pbl%i%icl)
-+    endif
-@@ -838,0 +864,3 @@
-+          ! DAGMC
-+          if( isdgmc == 1 ) call dagmc_particle_terminate()
+@@ -529,0 +550,6 @@
++            ! DAGMC: Collision Tally
++            if ( enable_dag_collision_tallies ) then
++              call dagmc_collision_score(pbl%i%ipt, pbl%r%x, pbl%r%y, pbl%r%z, &
++                                         pbl%r%erg, pbl%r%wgt, ple, pbl%i%icl)
++            endif
++
+@@ -555,0 +582,3 @@
++                  ! DAGMC
++                  if( isdgmc == 1 ) call dagmc_particle_terminate()
 +
 diff -rN '--unified=0' Source/src/igeom.F90 Source_dagmc/src/igeom.F90
 --- Source/src/igeom.F90
@@ -739,9 +738,9 @@ diff -rN '--unified=0' Source/src/igeom.F90 Source_dagmc/src/igeom.F90
 diff -rN '--unified=0' Source/src/imcn.F90 Source_dagmc/src/imcn.F90
 --- Source/src/imcn.F90
 +++ Source_dagmc/src/imcn.F90
-@@ -29,0 +30 @@
+@@ -27,0 +28 @@
 +  use dagmc_mod, only : isdgmc, dagmc_distlimit, dagmc_usecad, dagmc_overlap_thickness, dagmc_srcmode
-@@ -1667,0 +1669,5 @@
+@@ -1492,0 +1494,5 @@
 +
 +    ! Initialize DAGMC
 +    if ( isdgmc == 1 ) then  ! set DAGMC parameters from idum & rdum
@@ -752,7 +751,7 @@ diff -rN '--unified=0' Source/src/itally.F90 Source_dagmc/src/itally.F90
 +++ Source_dagmc/src/itally.F90
 @@ -31,0 +32 @@
 +  use dagmc_mod, only : isdgmc
-@@ -206,0 +208,7 @@
+@@ -205,0 +207,7 @@
 +
 +        ! DAGMC: If in CAD mode, skip up until line prior to marker 40
 +        if ( isdgmc == 1 ) then
@@ -766,16 +765,16 @@ diff -rN '--unified=0' Source/src/main.F90 Source_dagmc/src/main.F90
 @@ -58 +58 @@
 -    & msub, outp
 +    & msub, outp, gcad, lcad, fcad, ftol
-@@ -62,0 +63 @@
+@@ -62 +62,2 @@
+-    
 +  use dagmc_mod, only : isdgmc, dagmc_geom_file_mode, DGFM_READ
-@@ -65 +66 @@
++
+@@ -64 +65 @@
 -  use mcnp_env, only : HDPTH0, KOD, LODDAT, VER
 +  use mcnp_env, only : hdpth0, kod, loddat, ver
 @@ -78,0 +80 @@
-+  use dagmc_mod,           only: init_dagmc, dagmc_version_heading
-@@ -98,0 +101 @@
-+
-@@ -196,0 +200,18 @@
++  use dagmc_mod, only : init_dagmc, dagmc_version_heading
+@@ -199,0 +202,18 @@
 +
 +  ! DAGMC: initialize a DAGMC run if specified
 +  if ( gcad /= ' ' ) then
@@ -794,13 +793,13 @@ diff -rN '--unified=0' Source/src/main.F90 Source_dagmc/src/main.F90
 +    endif
 +  endif
 +
-@@ -246,0 +268,5 @@
+@@ -247,0 +268,5 @@
 +  ! DAGMC
 +  if ( isdgmc == 1 ) then
 +    call init_dagmc
 +  endif
 +
-@@ -262,0 +289,3 @@
+@@ -263,0 +289,3 @@
 +
 +  ! DAGMC
 +  if (isdgmc == 1) call dagmc_version_heading( iuo )
@@ -819,45 +818,44 @@ diff -rN '--unified=0' Source/src/mcnp_env.F90 Source_dagmc/src/mcnp_env.F90
 +    character(len=20),parameter ::  thread         = THREAD
 +    character(len=20),parameter ::  thread_version = TVERS
 +    character(len=8), parameter ::  loddat         = LODDAT
-+    character(len=*), parameter ::  hdpth0         = DPATH
++    character(len=80),parameter ::  hdpth0         = DPATH
 +
 +  end module mcnp_env
 diff -rN '--unified=0' Source/src/mcnp_input.F90 Source_dagmc/src/mcnp_input.F90
 --- Source/src/mcnp_input.F90
 +++ Source_dagmc/src/mcnp_input.F90
-@@ -38 +38 @@
--  integer,parameter, public :: nkcd = 152       != Number of different types of input cards.
-+  integer,parameter, public :: nkcd = 153       != Number of different types of input cards.
-@@ -273,0 +274,5 @@
-+
+@@ -25 +25 @@
+-  integer,parameter, public :: nkcd   = 149     != Number of different types of input cards.
++  integer,parameter, public :: nkcd   = 150     != Number of different types of input cards.
+@@ -226,0 +227,4 @@
 +  ! DAGMC card keywords, input values
 +    character(len=18), dimension(4), parameter, public :: &
 +      & hdagmc = (/ 'check_src_cell    ', 'usecad            ', &
 +      &             'distlimit         ', 'overlap_thickness ' /)
-@@ -447,0 +453,2 @@
+@@ -389,0 +394,2 @@
 +  ! DAGMC cards
-+  data cnm(153),(krq(i,153),i=1,7)/ 'dagmc',0,0, 0,0, 0,              12,0 /
++  data cnm(150),(krq(i,150),i=1,7)/ 'dagmc',0,0, 0,0, 0,              12,0 /
 diff -rN '--unified=0' Source/src/mcnp_iofiles.F90 Source_dagmc/src/mcnp_iofiles.F90
 --- Source/src/mcnp_iofiles.F90
 +++ Source_dagmc/src/mcnp_iofiles.F90
-@@ -49 +49,5 @@
+@@ -48 +48,5 @@
 -    &  dumn2
 +    &  dumn2,  &
 +    &  gcad,   &     ! gcad    - DAGMC geometry input file (CAD or facets)
 +    &  lcad,   &     ! lcad    - DAGMC input log file
 +    &  fcad,   &     ! fcad    - DAGMC facets output file
 +    &  ftol          ! ftol    - DAGMC faceting tolerance
-@@ -99,0 +104,4 @@
+@@ -97,0 +102,4 @@
 +    gcad    = isub(26)  ! DAGMC
 +    lcad    = isub(27)  ! DAGMC
 +    fcad    = isub(28)  ! DAGMC
 +    ftol    = isub(29)  ! DAGMC
-@@ -132,0 +141,4 @@
+@@ -129,0 +138,4 @@
 +      gcad(i:i)   = ' '  ! DAGMC
 +      lcad(i:i)   = ' '  ! DAGMC
 +      fcad(i:i)   = ' '  ! DAGMC
 +      ftol(i:i)   = ' '  ! DAGMC
-@@ -163,0 +176,4 @@
+@@ -159,0 +172,4 @@
 +    msub(26)(1:8) = 'gcad    '  ! DAGMC
 +    msub(27)(1:8) = 'lcad    '  ! DAGMC
 +    msub(28)(1:8) = 'fcad    '  ! DAGMC
@@ -865,14 +863,14 @@ diff -rN '--unified=0' Source/src/mcnp_iofiles.F90 Source_dagmc/src/mcnp_iofiles
 diff -rN '--unified=0' Source/src/mcnp_params.F90 Source_dagmc/src/mcnp_params.F90
 --- Source/src/mcnp_params.F90
 +++ Source_dagmc/src/mcnp_params.F90
-@@ -242,0 +243 @@
+@@ -216,0 +217 @@
 +  integer, parameter, public :: iulc    = 79  != I/O unit for DAGMC log file
 diff -rN '--unified=0' Source/src/msgcon.F90 Source_dagmc/src/msgcon.F90
 --- Source/src/msgcon.F90
 +++ Source_dagmc/src/msgcon.F90
-@@ -79,0 +80 @@
+@@ -77,0 +78 @@
 +  use dagmc_mod,           only: dagmc_msgbcast
-@@ -278,0 +280,4 @@
+@@ -298,0 +300,4 @@
 +
 +  ! DAGMC
 +  write(jtty,*) "master sending DAGMC information..."
@@ -880,12 +878,13 @@ diff -rN '--unified=0' Source/src/msgcon.F90 Source_dagmc/src/msgcon.F90
 diff -rN '--unified=0' Source/src/msgtsk.F90 Source_dagmc/src/msgtsk.F90
 --- Source/src/msgtsk.F90
 +++ Source_dagmc/src/msgtsk.F90
-@@ -72,0 +73 @@
+@@ -71,0 +72 @@
 +  use dagmc_mod,         only: dagmc_msgbcast
-@@ -222,0 +224,3 @@
+@@ -249,0 +251,4 @@
 +
 +  ! DAGMC
 +  call dagmc_msgbcast
++
 diff -rN '--unified=0' Source/src/namchg.F90 Source_dagmc/src/namchg.F90
 --- Source/src/namchg.F90
 +++ Source_dagmc/src/namchg.F90
@@ -913,7 +912,7 @@ diff -rN '--unified=0' Source/src/newcel.F90 Source_dagmc/src/newcel.F90
 +    if ( mxa == -1 ) kdb = 1
 +  endif
 +
-@@ -239 +247,4 @@
+@@ -237 +245,4 @@
 -      call expirx(1,'newcel','the surface crossed is not a surface of this cell.')
 +      ! DAGMC: Only check this if running normally, (NOT in CAD mode)
 +      if (isdgmc == 0) then
@@ -922,18 +921,18 @@ diff -rN '--unified=0' Source/src/newcel.F90 Source_dagmc/src/newcel.F90
 diff -rN '--unified=0' Source/src/nextit.F90 Source_dagmc/src/nextit.F90
 --- Source/src/nextit.F90
 +++ Source_dagmc/src/nextit.F90
-@@ -56 +56 @@
+@@ -57 +57 @@
 -    & surface_card, NUM_SURFACE_TYPES, length_spf
 +    & surface_card, NUM_SURFACE_TYPES, length_spf, hdagmc
-@@ -65,0 +66 @@
+@@ -66,0 +67 @@
 +  use dagmc_mod, only: dagmc_srcmode, dagmc_usecad, dagmc_distlimit, dagmc_overlap_thickness
-@@ -2409,0 +2411,3 @@
+@@ -2293,0 +2295,3 @@
 +              ! DAGMC
 +              elseif( hitm(1:3) == 'dag' ) then
 +                fm(nmesh)%icrd=3
-@@ -3077,0 +3082,21 @@
+@@ -2934,0 +2939,21 @@
 +
-+      case( 153 )
++      case( 'dagmc' )
 +        !  >>>>>  DAGMC parameters                                                                dagmc
 +        !  Modeled after RAND (99)
 +        !  m1c=index of current dagmc keyword.
@@ -958,15 +957,15 @@ diff -rN '--unified=0' Source/src/oldcrd.F90 Source_dagmc/src/oldcrd.F90
 +++ Source_dagmc/src/oldcrd.F90
 @@ -28,0 +29 @@
 +  use dagmc_mod, only : isdgmc
-@@ -71 +72,2 @@
+@@ -70 +71,2 @@
 -      if( lca(mxa) == nlja + 1 ) then
 +      ! DAGMC: In CAD mode, cells should have no surfaces
 +      if( ( lca(mxa)==nlja + 1 ) .and. ( isdgmc == 0 ) ) then
-@@ -81,0 +84,3 @@
+@@ -80,0 +83,3 @@
 +    ! DAGMC: Break out of subroutine here in CAD mode
 +    if ( isdgmc == 1 ) return
 +
-@@ -1407,0 +1413,7 @@
+@@ -1401,0 +1407,7 @@
 +
 +        ! DAGMC: skip handling imesh/jmesh/kmesh/orig when geom=DAG; check emesh before jump
 +        if( ifmsh(13) == 0 ) then
@@ -974,7 +973,7 @@ diff -rN '--unified=0' Source/src/oldcrd.F90 Source_dagmc/src/oldcrd.F90
 +        endif
 +        if( fm(nmesh)%icrd==3 ) goto 4900
 +
-@@ -1420,3 +1432,4 @@
+@@ -1414,3 +1426,4 @@
 -        if( ifmsh(13) == 0 ) then
 -          ientmp(1:ifmsh(12)) = 1
 -        endif
@@ -982,7 +981,7 @@ diff -rN '--unified=0' Source/src/oldcrd.F90 Source_dagmc/src/oldcrd.F90
 +        ! if( ifmsh(13) == 0 ) then
 +        !   ientmp(1:ifmsh(12)) = 1
 +        ! endif
-@@ -1591,0 +1605 @@
+@@ -1585,0 +1599 @@
 +4900 continue ! DAGMC jump target
 diff -rN '--unified=0' Source/src/pass0.F90 Source_dagmc/src/pass0.F90
 --- Source/src/pass0.F90
@@ -996,17 +995,17 @@ diff -rN '--unified=0' Source/src/pass0.F90 Source_dagmc/src/pass0.F90
 diff -rN '--unified=0' Source/src/pblcom.F90 Source_dagmc/src/pblcom.F90
 --- Source/src/pblcom.F90
 +++ Source_dagmc/src/pblcom.F90
-@@ -197,0 +198 @@
+@@ -189,0 +190 @@
 +    use dagmc_mod, only : isdgmc
-@@ -222,0 +224,5 @@
+@@ -214,0 +216,5 @@
 +    ! DAGMC: save this particle's ray history
 +    if (isdgmc == 1) then
 +      call dagmc_savpar(n)
 +    endif
 +
-@@ -390,0 +397 @@
+@@ -382,0 +389 @@
 +    use dagmc_mod, only : isdgmc
-@@ -406,0 +414,5 @@
+@@ -398,0 +406,5 @@
 +
 +    ! DAGMC: Restore the ray history associated with this particle
 +    if ( isdgmc == 1 ) then
@@ -1026,7 +1025,7 @@ diff -rN '--unified=0' Source/src/sourcb.F90 Source_dagmc/src/sourcb.F90
 +++ Source_dagmc/src/sourcb.F90
 @@ -21,0 +22 @@
 +  use dagmc_mod, only : isdgmc, dagmc_srcmode
-@@ -746 +747,8 @@
+@@ -742 +743,8 @@
 -          call chkcel(ji,0,j)
 +
 +          ! DAGMC: if dagmc_srcmode is on, skip chkcel and assume particle is in user-specified cell
@@ -1039,9 +1038,9 @@ diff -rN '--unified=0' Source/src/sourcb.F90 Source_dagmc/src/sourcb.F90
 diff -rN '--unified=0' Source/src/startp.F90 Source_dagmc/src/startp.F90
 --- Source/src/startp.F90
 +++ Source_dagmc/src/startp.F90
-@@ -56,0 +57 @@
-+  use dagmc_mod, only: isdgmc
-@@ -127,0 +129,6 @@
+@@ -54,0 +55 @@
++  use dagmc_mod, only : isdgmc
+@@ -124,0 +126,6 @@
 +
 +  ! DAGMC: nbnk = 0
 +  if ( isdgmc == 1 ) then
@@ -1053,7 +1052,7 @@ diff -rN '--unified=0' Source/src/tally.F90 Source_dagmc/src/tally.F90
 +++ Source_dagmc/src/tally.F90
 @@ -36,0 +37 @@
 +  use dagmc_mod, only : isdgmc
-@@ -512,0 +514,4 @@
+@@ -426,0 +428,4 @@
 +
 +    ! DAGMC: If in CAD mode, make sure distance to physics collision is initialized
 +    if ( isdgmc == 1 ) call dagmc_setdis(huge_float)
@@ -1061,10 +1060,10 @@ diff -rN '--unified=0' Source/src/tally.F90 Source_dagmc/src/tally.F90
 diff -rN '--unified=0' Source/src/track.F90 Source_dagmc/src/track.F90
 --- Source/src/track.F90
 +++ Source_dagmc/src/track.F90
-@@ -19,0 +20,2 @@
+@@ -20,0 +21,2 @@
 +  use varcom, only : nps
 +  use dagmc_mod, only : isdgmc
-@@ -63,0 +66,8 @@
+@@ -61,0 +64,8 @@
 +  endif
 +
 +  ! DAGMC: If in CAD mode, call DAGMC version of track instead
@@ -1082,12 +1081,6 @@ diff -rN '--unified=0' Source/src/transm.F90 Source_dagmc/src/transm.F90
 +
 +    ! DAGMC: If in CAD mode, call dagmc_setdis first
 +    if ( isdgmc == 1 ) call dagmc_setdis( dd - sd )
-diff -rN '--unified=0' Source/src/trfsrf.F90 Source_dagmc/src/trfsrf.F90
---- Source/src/trfsrf.F90
-+++ Source_dagmc/src/trfsrf.F90
-@@ -200 +200 @@
--  scf(l+1:l+3) = scf(l+1:l+3) - trf(2:3,jt)
-+  scf(l+1:l+3) = scf(l+1:l+3) - trf(2:4,jt)
 diff -rN '--unified=0' Source/src/volume.F90 Source_dagmc/src/volume.F90
 --- Source/src/volume.F90
 +++ Source_dagmc/src/volume.F90

--- a/src/mcnp/mcnp6/patch/mcnp610.patch
+++ b/src/mcnp/mcnp6/patch/mcnp610.patch
@@ -15,36 +15,34 @@ diff -rN '--unified=0' Source/src/angl.F90 Source_dagmc/src/angl.F90
 +++ Source_dagmc/src/angl.F90
 @@ -15,0 +16 @@
 +  use dagmc_mod,   only : isdgmc
-@@ -28 +29,8 @@
-- 
-+
+@@ -29,0 +31,7 @@
 +  ! DAGMC: In CAD mode, circumvent entire function and call DAGMC version instead
 +  if (isdgmc == 1) then
-+    call dagmcangl(pbl%i%jsu, pbl%r%x, pbl%r%y, pbl%r%z, sur_norm)
-+    cos_theta = max(-one, min(one, sur_norm(1)*pbl%r%u + sur_norm(2)*pbl%r%v + sur_norm(3)*pbl%r%w))
++    call dagmcangl(pbl%i%jsu, pbl%r%x, pbl%r%y, pbl%r%z, ang)
++    angl = max(-one, min(one, ang(1)*pbl%r%u + ang(2)*pbl%r%v + ang(3)*pbl%r%w))
 +    return
 +  endif
 +
 diff -rN '--unified=0' Source/src/bankit.F90 Source_dagmc/src/bankit.F90
 --- Source/src/bankit.F90
 +++ Source_dagmc/src/bankit.F90
-@@ -70,0 +71 @@
+@@ -67,0 +68 @@
 +    use dagmc_mod, only : isdgmc
-@@ -112,0 +114,5 @@
+@@ -105,0 +107,5 @@
 +    ! DAGMC:
 +    if ( isdgmc == 1 ) then
 +      call dagmc_bank_push( nbnk )
 +    endif
 +
-@@ -284,0 +291 @@
+@@ -277,0 +284 @@
 +    use dagmc_mod, only : isdgmc
-@@ -295,0 +303,5 @@
+@@ -288,0 +296,5 @@
 +  ! DAGMC:
 +    if ( isdgmc == 1 ) then
 +      call dagmc_bank_usetop()
 +    endif
 +
-@@ -398,0 +411,4 @@
+@@ -391,0 +404,4 @@
 +      ! DAGMC:
 +      if ( isdgmc == 1 ) then
 +        call dagmc_bank_pop( nbnk )
@@ -54,7 +52,7 @@ diff -rN '--unified=0' Source/src/celsrf.F90 Source_dagmc/src/celsrf.F90
 +++ Source_dagmc/src/celsrf.F90
 @@ -25,0 +26 @@
 +  use dagmc_mod, only : isdgmc
-@@ -453 +454,6 @@
+@@ -449 +450,6 @@
 -    write(iuo,460) js,j1,hq,hl,ht,surface_card(k)%symbol,(tpp(i),i=1,n)
 +    ! DAGMC: surface_card(k)%symbol returns null characters in DAGMC mode
 +    if (isdgmc == 1) then
@@ -62,30 +60,20 @@ diff -rN '--unified=0' Source/src/celsrf.F90 Source_dagmc/src/celsrf.F90
 +    else
 +      write(iuo,460) js,j1,hq,hl,ht,surface_card(k)%symbol,(tpp(i),i=1,n)
 +    endif
-@@ -509,0 +516,3 @@
+@@ -505,0 +512,3 @@
 +    ! DAGMC: Skip this loop if in CAD mode
 +    if (isdgmc == 1) exit
 +
-diff -rN '--unified=0' Source/src/cgm_interface.F90 Source_dagmc/src/cgm_interface.F90
---- Source/src/cgm_interface.F90
-+++ Source_dagmc/src/cgm_interface.F90
-@@ -28,0 +29,4 @@
-+#if __INTEL_COMPILER >= 1600
-+      import :: c_funptr
-+      type(c_funptr), value :: rngfunc
-+#else
-@@ -30,0 +35 @@
-+#endif
 diff -rN '--unified=0' Source/src/charged_particle_history.F90 Source_dagmc/src/charged_particle_history.F90
 --- Source/src/charged_particle_history.F90
 +++ Source_dagmc/src/charged_particle_history.F90
-@@ -331,0 +332,5 @@
+@@ -326,0 +327,5 @@
 +
 +        ! DAGMC: if minimum distance to next event is exactly zero, skip the
 +        ! charged particle physics and go directly to the surface crossing
 +        if( d_step_inter_decay_surf == zero ) goto 100
 +
-@@ -642,0 +648,2 @@
+@@ -627,0 +633,2 @@
 +
 +100     continue  ! DAGMC jump target
 diff -rN '--unified=0' Source/src/check_binary_expire.F90 Source_dagmc/src/check_binary_expire.F90
@@ -97,13 +85,13 @@ diff -rN '--unified=0' Source/src/check_binary_expire.F90 Source_dagmc/src/check
 diff -rN '--unified=0' Source/src/chkcel.F90 Source_dagmc/src/chkcel.F90
 --- Source/src/chkcel.F90
 +++ Source_dagmc/src/chkcel.F90
-@@ -34,0 +35 @@
-+  use dagmc_mod,    only: isdgmc
-@@ -62,0 +64,6 @@
+@@ -28,0 +29 @@
++  use dagmc_mod,    only : isdgmc
+@@ -60,0 +62,6 @@
 +
 +  ! DAGMC: In CAD mode, circumvent this function and call DAGMC version instead
 +  if ( isdgmc == 1 .and. (m == 0 .or. m == 2) ) then
-+    call dagmcchkcel(pbl%r%u, pbl%r%v, pbl%r%w, pbl%r%x, pbl%r%y, pbl%r%z, icell, jresult)
++    call dagmcchkcel(pbl%r%u, pbl%r%v, pbl%r%w, pbl%r%x, pbl%r%y, pbl%r%z, i1, j)
 +    return
 +  endif
 diff -rN '--unified=0' Source/src/dagmc_mod.F90 Source_dagmc/src/dagmc_mod.F90
@@ -367,9 +355,9 @@ diff -rN '--unified=0' Source/src/echkcl.F90 Source_dagmc/src/echkcl.F90
 diff -rN '--unified=0' Source/src/electr.F90 Source_dagmc/src/electr.F90
 --- Source/src/electr.F90
 +++ Source_dagmc/src/electr.F90
-@@ -39,0 +40 @@
+@@ -38,0 +39 @@
 +  use dagmc_mod, only : isdgmc
-@@ -146,0 +148,6 @@
+@@ -145,0 +147,6 @@
 +        endif
 +
 +        ! DAGMC: In DAGMC mode, use the known physics distance to limit geometry search
@@ -406,7 +394,7 @@ diff -rN '--unified=0' Source/src/fmesh_mod.F90 Source_dagmc/src/fmesh_mod.F90
 +  ! This interface specification ensures that the calls to these functions
 +  ! (which are implemented in C) are made with the correct types
 +  interface
-+    subroutine dagmc_fmesh_get_tally_data( fm_id, fref )
++    subroutine dagmc_fmesh_get_tally_data( fm_id, fref ) bind(c)
 +      implicit none
 +      integer :: fm_id
 +      ! The dknd parameter is unavailable in this scope for some reason,
@@ -414,13 +402,13 @@ diff -rN '--unified=0' Source/src/fmesh_mod.F90 Source_dagmc/src/fmesh_mod.F90
 +      real(selected_real_kind(15,307)) , dimension(:), pointer :: fref
 +    end subroutine dagmc_fmesh_get_tally_data
 +
-+    subroutine dagmc_fmesh_get_error_data( fm_id, fref )
++    subroutine dagmc_fmesh_get_error_data( fm_id, fref ) bind(c)
 +      implicit none
 +      integer :: fm_id
 +      real(selected_real_kind(15,307)) , dimension(:), pointer :: fref
 +    end subroutine dagmc_fmesh_get_error_data
 +
-+    subroutine dagmc_fmesh_get_scratch_data( fm_id, fref )
++    subroutine dagmc_fmesh_get_scratch_data( fm_id, fref ) bind(c)
 +      implicit none
 +      integer :: fm_id
 +      real(selected_real_kind(15,307)), dimension(:), pointer:: fref
@@ -430,7 +418,7 @@ diff -rN '--unified=0' Source/src/fmesh_mod.F90 Source_dagmc/src/fmesh_mod.F90
 +
 @@ -204,0 +239,60 @@
 +  ! DAGMC: Helper function - create a valid Fortran pointer from a C array and a length
-+  subroutine dagmc_make_fortran_pointer( fref, carray, size )
++  subroutine dagmc_make_fortran_pointer( fref, carray, size ) bind(c)
 +    implicit none
 +
 +    integer :: size ! The size (in doubles) of the array in C
@@ -518,10 +506,11 @@ diff -rN '--unified=0' Source/src/fmesh_mod.F90 Source_dagmc/src/fmesh_mod.F90
 +        read(iu) dagmc_runtpe_data
 +      endif
 +
-@@ -1050 +1169 @@
+@@ -1043 +1162,2 @@
 -    integer   :: i, ix, iy, iz, it, ie, is
 +    integer   :: i, ix, iy, iz, it, ie, is, j
-@@ -1157,0 +1277,16 @@
++
+@@ -1150,0 +1271,16 @@
 +      ! DAGMC: broadcast comment contents if this is a dagmc mesh
 +      if ( fm(i)%icrd == 3 ) then
 +        call msg_bcast(mynum, fm(i)%n_comment_lines)
@@ -538,7 +527,7 @@ diff -rN '--unified=0' Source/src/fmesh_mod.F90 Source_dagmc/src/fmesh_mod.F90
 +        enddo
 +      endif
 +
-@@ -1205,0 +1341,8 @@
+@@ -1198,0 +1335,7 @@
 +
 +      ! DAGMC:
 +      do i = 1, nmesh
@@ -546,16 +535,15 @@ diff -rN '--unified=0' Source/src/fmesh_mod.F90 Source_dagmc/src/fmesh_mod.F90
 +          call dagmc_setup_mesh_tally(i)
 +        endif
 +      enddo
-+
-@@ -1225,0 +1369,3 @@
+@@ -1218,0 +1362,3 @@
 +    ! DAGMC
 +    real(dknd), dimension(:), pointer :: dagmc_mpi_data
 +
-@@ -1250 +1396,2 @@
+@@ -1243 +1389,2 @@
 -      isize = ix*iy*iz*it*ie
 +      if( fm(i)%icrd /= 3 ) then
 +        isize = ix*iy*iz*it*ie
-@@ -1252,7 +1399,15 @@
+@@ -1245,7 +1392,15 @@
 -      ! use matching tag=555 in fmesh_msgtsk
 -      call msg_recv( islave,555, fmtal(i)%tally(:,1,1,1,1,1), isize )
 -      fm(i)%fmarry(:,:,:,:,:,1) = fm(i)%fmarry(:,:,:,:,:,1) + fmtal(i)%tally(:,:,:,:,:,1)
@@ -578,15 +566,15 @@ diff -rN '--unified=0' Source/src/fmesh_mod.F90 Source_dagmc/src/fmesh_mod.F90
 +        call msg_recv(islave, 558, dagmc_mpi_data, size(dagmc_mpi_data))
 +        call dagmc_fmesh_add_scratch_to_error(fm(i)%id)
 +      endif
-@@ -1276,0 +1432,3 @@
+@@ -1269,0 +1425,3 @@
 +    ! DAGMC
 +    real(dknd), dimension(:), pointer :: dagmc_mpi_data
 +
-@@ -1292 +1450,2 @@
+@@ -1285 +1443,2 @@
 -      isize = ix*iy*iz*it*ie
 +      if( fm(i)%icrd /= 3 ) then
 +        isize = ix*iy*iz*it*ie
-@@ -1294,7 +1453,14 @@
+@@ -1287,7 +1446,14 @@
 -      ! use matching tag=555 & tag=556 in fmesh_msgcon
 -      call msg_send( 0,555, fm(i)%fmarry(:,1,1,1,1,1), isize )
 -      call msg_send( 0,556, fm(i)%fmerr( :,1,1,1,1,1), isize )
@@ -608,13 +596,13 @@ diff -rN '--unified=0' Source/src/fmesh_mod.F90 Source_dagmc/src/fmesh_mod.F90
 +        call dagmc_fmesh_get_error_data(fm(i)%id, dagmc_mpi_data)
 +        call msg_send(0, 558, dagmc_mpi_data, size(dagmc_mpi_data))
 +      endif
-@@ -1320,0 +1487,5 @@
+@@ -1313,0 +1480,5 @@
 +    ! DAGMC: perform end of history tasks for all dagmc mesh tallies
 +    if ( enable_dag_tallies ) then
 +      call dagmc_fmesh_end_history()
 +    endif
 +
-@@ -1397,0 +1569,27 @@
+@@ -1390,0 +1562,27 @@
 +  subroutine dagmc_get_multiplier( i, erg, multiplier )
 +
 +    use mcnp_params, only : dknd
@@ -642,12 +630,12 @@ diff -rN '--unified=0' Source/src/fmesh_mod.F90 Source_dagmc/src/fmesh_mod.F90
 +
 +  !-----------------------------------------------------------------------------------------
 +
-@@ -1429,0 +1628,4 @@
+@@ -1422,0 +1621,4 @@
 +
 +    ! DAGMC
 +    real(dknd) :: dagmc_multiplier
 +
-@@ -1442,0 +1645,13 @@
+@@ -1435,0 +1638,13 @@
 +    ! DAGMC: update multipliers if any dagmc mesh tallies exist
 +    if ( enable_dag_tallies ) then
 +      do i = 1, nmesh
@@ -661,25 +649,25 @@ diff -rN '--unified=0' Source/src/fmesh_mod.F90 Source_dagmc/src/fmesh_mod.F90
 +       call dagmc_fmesh_score(ipt, x, y, z, u, v, w, erg, wgt, d, pbl%i%icl)
 +    endif
 +
-@@ -1451,0 +1667,5 @@
+@@ -1444,0 +1660,5 @@
 +      ! DAGMC: skip iteration if dagmc mesh tally
 +      if ( fm(i)%icrd == 3 ) then
 +        cycle
 +      endif
 +
-@@ -2808,0 +3029,5 @@
+@@ -2792,0 +3013,5 @@
 +    ! DAGMC: write data to file for all dagmc mesh tallies
 +    if ( enable_dag_tallies ) then
 +      call dagmc_fmesh_print(sp_norm)
 +    endif
 +
-@@ -2810,0 +3036,5 @@
+@@ -2794,0 +3020,5 @@
 +      ! DAGMC: skip iteration if dagmc mesh tally
 +      if( fm(j)%icrd == 3 ) then
 +        cycle
 +      endif
 +
-@@ -4016,0 +4247,7 @@
+@@ -4000,0 +4231,7 @@
 +
 +    ! DAGMC: setup up dagmc mesh tallies based on fmesh index i
 +    do i = 1,nmesh
@@ -690,7 +678,7 @@ diff -rN '--unified=0' Source/src/fmesh_mod.F90 Source_dagmc/src/fmesh_mod.F90
 diff -rN '--unified=0' Source/src/history_neutral_high.F90 Source_dagmc/src/history_neutral_high.F90
 --- Source/src/history_neutral_high.F90
 +++ Source_dagmc/src/history_neutral_high.F90
-@@ -161 +161,2 @@
+@@ -156 +156,2 @@
 -      if( D <= zero ) then  !  Review the need for this test.
 +      ! DAGMC: use < instead of <=
 +      if( D < zero ) then  !  Review the need for this test.
@@ -700,26 +688,26 @@ diff -rN '--unified=0' Source/src/hstory.F90 Source_dagmc/src/hstory.F90
 @@ -13 +13 @@
 -  use fmesh_mod, only: nmesh
 +  use fmesh_mod, only: nmesh, enable_dag_collision_tallies
-@@ -26,0 +27 @@
+@@ -24,0 +25 @@
 +  use dagmc_mod, only: isdgmc
-@@ -152 +153,2 @@
+@@ -135 +136,2 @@
 -        if( lca(pbl%i%icl) < 0 ) then
 +        ! DAGMC: only do this when running in non-CAD mode
 +        if( ( lca(pbl%i%icl) < 0 ) .and. (isdgmc == 0 ) ) then
-@@ -190 +192,2 @@
+@@ -171 +173,2 @@
 -            call track(pbl%i%icl)
 +            ! DAGMC: only call track here if in normal mode (NOT in CAD mode)
 +            if ( isdgmc == 0 ) call track(pbl%i%icl)
-@@ -292,0 +296,8 @@
-+                    ! DAGMC: In CAD mode, call DAGMC before forcing collision
-+                    if ( isdgmc == 1 ) then
-+                      if ( lca(pbl%i%icl) < 0 ) call chkcel(pbl%i%icl, 3, j)
-+                      call dagmc_setdis(huge_float)
-+                      call track(pbl%i%icl)
-+                      if ( kdb /= 0 ) exit HISTORY_LOOP
-+                    endif
+@@ -249,0 +253,8 @@
++                  ! DAGMC: In CAD mode, call DAGMC before forcing collision
++                  if ( isdgmc == 1 ) then
++                    if ( lca(pbl%i%icl) < 0 ) call chkcel(pbl%i%icl, 3, j)
++                    call dagmc_setdis(huge_float)
++                    call track(pbl%i%icl)
++                    if ( kdb /= 0 ) exit HISTORY_LOOP
++                  endif
 +
-@@ -376,0 +388,9 @@
+@@ -327,0 +339,9 @@
 +          ! DAGMC: In CAD mode, get particle information
 +          if ( isdgmc == 1 ) then
 +            if ( lca(pbl%i%icl) < 0 ) call chkcel(pbl%i%icl, 3, j)
@@ -729,20 +717,20 @@ diff -rN '--unified=0' Source/src/hstory.F90 Source_dagmc/src/hstory.F90
 +            if ( kdb /= 0 ) exit HISTORY_LOOP
 +          endif
 +
-@@ -872,0 +893,5 @@
+@@ -816,0 +837,5 @@
 +    ! DAGMC: Collision Tally
 +    if ( enable_dag_collision_tallies ) then
 +      call dagmc_collision_score(pbl%i%ipt, pbl%r%x, pbl%r%y, pbl%r%z, &
 +                                 pbl%r%erg, pbl%r%wgt, ple, pbl%i%icl)
 +    endif
-@@ -894,0 +920,3 @@
+@@ -838,0 +864,3 @@
 +          ! DAGMC
 +          if( isdgmc == 1 ) call dagmc_particle_terminate()
 +
 diff -rN '--unified=0' Source/src/igeom.F90 Source_dagmc/src/igeom.F90
 --- Source/src/igeom.F90
 +++ Source_dagmc/src/igeom.F90
-@@ -14,0 +15 @@
+@@ -13,0 +14 @@
 +  use dagmc_mod, only : isdgmc
 @@ -117,0 +119,3 @@
 +  ! DAGMC: only call this when running in normal (non-CAD) mode
@@ -753,36 +741,18 @@ diff -rN '--unified=0' Source/src/imcn.F90 Source_dagmc/src/imcn.F90
 +++ Source_dagmc/src/imcn.F90
 @@ -29,0 +30 @@
 +  use dagmc_mod, only : isdgmc, dagmc_distlimit, dagmc_usecad, dagmc_overlap_thickness, dagmc_srcmode
-@@ -36,0 +38,3 @@
-+#if __INTEL_COMPILER >= 1600
-+  use, intrinsic :: iso_c_binding
-+#endif
-@@ -1823,0 +1828,5 @@
+@@ -1667,0 +1669,5 @@
++
 +    ! Initialize DAGMC
 +    if ( isdgmc == 1 ) then  ! set DAGMC parameters from idum & rdum
 +      call dagmc_set_settings(dagmc_distlimit, dagmc_usecad, dagmc_overlap_thickness, dagmc_srcmode)
 +    endif
-+
-@@ -2033 +2042,5 @@
--      call setrngcgm(rang)          
-+#if __INTEL_COMPILER >= 1600
-+      call setrngcgm(c_funloc(rang))
-+#else
-+      call setrngcgm(rang)
-+#endif
-@@ -2299 +2312,5 @@
--      call setrngcgm(rang)          
-+#if __INTEL_COMPILER >= 1600
-+      call setrngcgm(c_funloc(rang))
-+#else
-+      call setrngcgm(rang)
-+#endif
 diff -rN '--unified=0' Source/src/itally.F90 Source_dagmc/src/itally.F90
 --- Source/src/itally.F90
 +++ Source_dagmc/src/itally.F90
 @@ -31,0 +32 @@
 +  use dagmc_mod, only : isdgmc
-@@ -207,0 +209,7 @@
+@@ -206,0 +208,7 @@
 +
 +        ! DAGMC: If in CAD mode, skip up until line prior to marker 40
 +        if ( isdgmc == 1 ) then
@@ -796,14 +766,16 @@ diff -rN '--unified=0' Source/src/main.F90 Source_dagmc/src/main.F90
 @@ -58 +58 @@
 -    & msub, outp
 +    & msub, outp, gcad, lcad, fcad, ftol
-@@ -61,0 +62 @@
+@@ -62,0 +63 @@
 +  use dagmc_mod, only : isdgmc, dagmc_geom_file_mode, DGFM_READ
-@@ -64 +65 @@
+@@ -65 +66 @@
 -  use mcnp_env, only : HDPTH0, KOD, LODDAT, VER
 +  use mcnp_env, only : hdpth0, kod, loddat, ver
-@@ -77,0 +79 @@
+@@ -78,0 +80 @@
 +  use dagmc_mod,           only: init_dagmc, dagmc_version_heading
-@@ -184,0 +187,18 @@
+@@ -98,0 +101 @@
++
+@@ -196,0 +200,18 @@
 +
 +  ! DAGMC: initialize a DAGMC run if specified
 +  if ( gcad /= ' ' ) then
@@ -822,20 +794,20 @@ diff -rN '--unified=0' Source/src/main.F90 Source_dagmc/src/main.F90
 +    endif
 +  endif
 +
-@@ -234,0 +255,5 @@
+@@ -246,0 +268,5 @@
 +  ! DAGMC
 +  if ( isdgmc == 1 ) then
 +    call init_dagmc
 +  endif
 +
-@@ -250,0 +276,3 @@
+@@ -262,0 +289,3 @@
 +
 +  ! DAGMC
 +  if (isdgmc == 1) call dagmc_version_heading( iuo )
 diff -rN '--unified=0' Source/src/mcnp_env.F90 Source_dagmc/src/mcnp_env.F90
 --- Source/src/mcnp_env.F90
 +++ Source_dagmc/src/mcnp_env.F90
-@@ -0,0 +1,78 @@
+@@ -0,0 +1,14 @@
 +
 +  module mcnp_env
 +    !
@@ -849,86 +821,22 @@ diff -rN '--unified=0' Source/src/mcnp_env.F90 Source_dagmc/src/mcnp_env.F90
 +    character(len=8), parameter ::  loddat         = LODDAT
 +    character(len=*), parameter ::  hdpth0         = DPATH
 +
-+    public ::  print_build_info
-+  CONTAINS
-+    subroutine print_build_info( iunit )
-+      integer, intent(in) :: iunit
-+
-+      write(iunit,*) '  +-----------------------------------------------------------'
-+      write(iunit,*) '  | mcnp6 build information:'
-+      write(iunit,*) '  |'
-+      write(iunit,*) '  | This executable was built with a custom CMake build, not'
-+      write(iunit,*) '  | the build system from the discs supplied by RSICC. See'
-+      write(iunit,*) '  | https://github.com/svalinn/DAGMC for more information.'
-+      write(iunit,*) '  |'
-+      write(iunit,*) '  |   user          = ', ENV_USER
-+      write(iunit,*) '  |   host          = ', ENV_HOST
-+      write(iunit,*) '  |   OS            = ', ENV_OS
-+      write(iunit,*) '  |   date          = ', ENV_DATE
-+      write(iunit,*) '  |   time          = ', ENV_TIME
-+      write(iunit,*) '  |'
-+      write(iunit,*) '  |   cc            = ', ENV_CC
-+      write(iunit,*) '  |   cxx           = ', ENV_CXX
-+      write(iunit,*) '  |   f90           = ', ENV_F90
-+#ifdef OMP
-+      write(iunit,*) '  |   OpenMP        = yes'
-+#else
-+      write(iunit,*) '  |   OpenMP        = no'
-+#endif
-+#ifdef MPI
-+      write(iunit,*) '  |   MPI           = yes'
-+      write(iunit,*) '  |   MPI_ROOT      = ', ENV_MPI_ROOT
-+#else
-+      write(iunit,*) '  |   MPI           = no'
-+#endif
-+      write(iunit,*) '  |'
-+      write(iunit,*) '  |   code          = ', KODE
-+      write(iunit,*) '  |   version       = ', VERS
-+      write(iunit,*) '  |'
-+      write(iunit,*) '  |   thread name   = ', THREAD
-+      write(iunit,*) '  |   thread number = ', TVERS
-+      write(iunit,*) '  |'
-+      write(iunit,*) '  |   datapath      = ', DPATH
-+      write(iunit,*) '  |'
-+      write(iunit,*) '  |   fpp defs      = '
-+      write(iunit,*) '  |                   ', COMPDEF_0
-+      write(iunit,*) '  |                   ', COMPDEF_1
-+      write(iunit,*) '  |                   ', COMPDEF_2
-+      write(iunit,*) '  |                   ', COMPDEF_3
-+      write(iunit,*) '  |                   ', COMPDEF_4
-+      write(iunit,*) '  |                   ', COMPDEF_5
-+      write(iunit,*) '  |                   ', COMPDEF_6
-+      write(iunit,*) '  |                   ', COMPDEF_7
-+      write(iunit,*) '  |                   ', COMPDEF_8
-+      write(iunit,*) '  |                   ', COMPDEF_9
-+      write(iunit,*) '  |                   ', COMPDEF_10
-+      write(iunit,*) '  |                   ', COMPDEF_11
-+      write(iunit,*) '  |                   ', COMPDEF_12
-+      write(iunit,*) '  |                   ', COMPDEF_13
-+      write(iunit,*) '  |                   ', COMPDEF_14
-+      write(iunit,*) '  |                   ', COMPDEF_15
-+      write(iunit,*) '  |                   ', COMPDEF_16
-+      write(iunit,*) '  |                   ', COMPDEF_17
-+      write(iunit,*) '  |                   ', COMPDEF_18
-+      write(iunit,*) '  |                   ', COMPDEF_19
-+      write(iunit,*) '  +-----------------------------------------------------------'
-+    end subroutine print_build_info
 +  end module mcnp_env
 diff -rN '--unified=0' Source/src/mcnp_input.F90 Source_dagmc/src/mcnp_input.F90
 --- Source/src/mcnp_input.F90
 +++ Source_dagmc/src/mcnp_input.F90
-@@ -40 +40 @@
--  integer,parameter, public :: nkcd = 153       != Number of different types of input cards.
-+  integer,parameter, public :: nkcd = 154       != Number of different types of input cards.
-@@ -285,0 +286,5 @@
+@@ -38 +38 @@
+-  integer,parameter, public :: nkcd = 152       != Number of different types of input cards.
++  integer,parameter, public :: nkcd = 153       != Number of different types of input cards.
+@@ -273,0 +274,5 @@
 +
 +  ! DAGMC card keywords, input values
 +    character(len=18), dimension(4), parameter, public :: &
 +      & hdagmc = (/ 'check_src_cell    ', 'usecad            ', &
 +      &             'distlimit         ', 'overlap_thickness ' /)
-@@ -460,0 +466,2 @@
+@@ -447,0 +453,2 @@
 +  ! DAGMC cards
-+  data cnm(154),(krq(i,154),i=1,7)/ 'dagmc',0,0, 0,0, 0,              12,0 /
++  data cnm(153),(krq(i,153),i=1,7)/ 'dagmc',0,0, 0,0, 0,              12,0 /
 diff -rN '--unified=0' Source/src/mcnp_iofiles.F90 Source_dagmc/src/mcnp_iofiles.F90
 --- Source/src/mcnp_iofiles.F90
 +++ Source_dagmc/src/mcnp_iofiles.F90
@@ -957,14 +865,14 @@ diff -rN '--unified=0' Source/src/mcnp_iofiles.F90 Source_dagmc/src/mcnp_iofiles
 diff -rN '--unified=0' Source/src/mcnp_params.F90 Source_dagmc/src/mcnp_params.F90
 --- Source/src/mcnp_params.F90
 +++ Source_dagmc/src/mcnp_params.F90
-@@ -243,0 +244 @@
+@@ -242,0 +243 @@
 +  integer, parameter, public :: iulc    = 79  != I/O unit for DAGMC log file
 diff -rN '--unified=0' Source/src/msgcon.F90 Source_dagmc/src/msgcon.F90
 --- Source/src/msgcon.F90
 +++ Source_dagmc/src/msgcon.F90
-@@ -80,0 +81 @@
+@@ -79,0 +80 @@
 +  use dagmc_mod,           only: dagmc_msgbcast
-@@ -281,0 +283,4 @@
+@@ -278,0 +280,4 @@
 +
 +  ! DAGMC
 +  write(jtty,*) "master sending DAGMC information..."
@@ -972,23 +880,12 @@ diff -rN '--unified=0' Source/src/msgcon.F90 Source_dagmc/src/msgcon.F90
 diff -rN '--unified=0' Source/src/msgtsk.F90 Source_dagmc/src/msgtsk.F90
 --- Source/src/msgtsk.F90
 +++ Source_dagmc/src/msgtsk.F90
-@@ -74,0 +75 @@
+@@ -72,0 +73 @@
 +  use dagmc_mod,         only: dagmc_msgbcast
-@@ -80,0 +82,3 @@
-+#if __INTEL_COMPILER >= 1600
-+  use, intrinsic :: iso_c_binding
-+#endif
-@@ -231,0 +236,3 @@
+@@ -222,0 +224,3 @@
++
 +  ! DAGMC
 +  call dagmc_msgbcast
-+
-@@ -308 +315,5 @@
--    call setrngcgm(rang) 
-+#if __INTEL_COMPILER >= 1600
-+    call setrngcgm(c_funloc(rang))
-+#else
-+    call setrngcgm(rang)
-+#endif
 diff -rN '--unified=0' Source/src/namchg.F90 Source_dagmc/src/namchg.F90
 --- Source/src/namchg.F90
 +++ Source_dagmc/src/namchg.F90
@@ -1011,7 +908,7 @@ diff -rN '--unified=0' Source/src/newcel.F90 Source_dagmc/src/newcel.F90
 @@ -52,0 +54,7 @@
 +  ! DAGMC: In CAD mode, call MOAB version of this
 +  if ( isdgmc == 1 ) then
-+    if ( cs /= 0 ) call angl( cs, ang )
++    if ( cs /= 0 ) cs = angl()
 +    call dagmcnewcel(pbl%i%jsu, pbl%i%icl, pbl%i%iap)
 +    if ( mxa == -1 ) kdb = 1
 +  endif
@@ -1025,18 +922,18 @@ diff -rN '--unified=0' Source/src/newcel.F90 Source_dagmc/src/newcel.F90
 diff -rN '--unified=0' Source/src/nextit.F90 Source_dagmc/src/nextit.F90
 --- Source/src/nextit.F90
 +++ Source_dagmc/src/nextit.F90
-@@ -55 +55 @@
--    & ri_mopt, ric_mopt, ris_mopt
-+    & ri_mopt, ric_mopt, ris_mopt, hdagmc
-@@ -64,0 +65 @@
+@@ -56 +56 @@
+-    & surface_card, NUM_SURFACE_TYPES, length_spf
++    & surface_card, NUM_SURFACE_TYPES, length_spf, hdagmc
+@@ -65,0 +66 @@
 +  use dagmc_mod, only: dagmc_srcmode, dagmc_usecad, dagmc_distlimit, dagmc_overlap_thickness
-@@ -2596,0 +2598,3 @@
+@@ -2409,0 +2411,3 @@
 +              ! DAGMC
 +              elseif( hitm(1:3) == 'dag' ) then
 +                fm(nmesh)%icrd=3
-@@ -3348,0 +3353,21 @@
+@@ -3077,0 +3082,21 @@
 +
-+      case( 154 )
++      case( 153 )
 +        !  >>>>>  DAGMC parameters                                                                dagmc
 +        !  Modeled after RAND (99)
 +        !  m1c=index of current dagmc keyword.
@@ -1069,7 +966,7 @@ diff -rN '--unified=0' Source/src/oldcrd.F90 Source_dagmc/src/oldcrd.F90
 +    ! DAGMC: Break out of subroutine here in CAD mode
 +    if ( isdgmc == 1 ) return
 +
-@@ -1429,0 +1435,7 @@
+@@ -1407,0 +1413,7 @@
 +
 +        ! DAGMC: skip handling imesh/jmesh/kmesh/orig when geom=DAG; check emesh before jump
 +        if( ifmsh(13) == 0 ) then
@@ -1077,7 +974,7 @@ diff -rN '--unified=0' Source/src/oldcrd.F90 Source_dagmc/src/oldcrd.F90
 +        endif
 +        if( fm(nmesh)%icrd==3 ) goto 4900
 +
-@@ -1442,3 +1454,4 @@
+@@ -1420,3 +1432,4 @@
 -        if( ifmsh(13) == 0 ) then
 -          ientmp(1:ifmsh(12)) = 1
 -        endif
@@ -1085,7 +982,7 @@ diff -rN '--unified=0' Source/src/oldcrd.F90 Source_dagmc/src/oldcrd.F90
 +        ! if( ifmsh(13) == 0 ) then
 +        !   ientmp(1:ifmsh(12)) = 1
 +        ! endif
-@@ -1620,0 +1634 @@
+@@ -1591,0 +1605 @@
 +4900 continue ! DAGMC jump target
 diff -rN '--unified=0' Source/src/pass0.F90 Source_dagmc/src/pass0.F90
 --- Source/src/pass0.F90
@@ -1099,28 +996,17 @@ diff -rN '--unified=0' Source/src/pass0.F90 Source_dagmc/src/pass0.F90
 diff -rN '--unified=0' Source/src/pblcom.F90 Source_dagmc/src/pblcom.F90
 --- Source/src/pblcom.F90
 +++ Source_dagmc/src/pblcom.F90
-@@ -178,4 +178,6 @@
--  common /pblcom_thread/ pbl, pbl_src, pbl_stack
--  common /pblcom_thread/ udt, udt_stack
--  common /pblcom_thread/ pbl_in_use, udt_in_use, is_uncollided_part
--  !$OMP THREADPRIVATE( /pblcom_thread/ )
-+  common /pblcom_thread1/ pbl, pbl_src, pbl_stack
-+  common /pblcom_thread2/ udt, udt_stack
-+  common /pblcom_thread3/ pbl_in_use, udt_in_use, is_uncollided_part
-+  !$OMP THREADPRIVATE( /pblcom_thread1/ )
-+  !$OMP THREADPRIVATE( /pblcom_thread2/ )
-+  !$OMP THREADPRIVATE( /pblcom_thread3/ )
-@@ -315,0 +318 @@
+@@ -197,0 +198 @@
 +    use dagmc_mod, only : isdgmc
-@@ -340,0 +344,5 @@
+@@ -222,0 +224,5 @@
 +    ! DAGMC: save this particle's ray history
 +    if (isdgmc == 1) then
 +      call dagmc_savpar(n)
 +    endif
 +
-@@ -508,0 +517 @@
+@@ -390,0 +397 @@
 +    use dagmc_mod, only : isdgmc
-@@ -524,0 +534,5 @@
+@@ -406,0 +414,5 @@
 +
 +    ! DAGMC: Restore the ray history associated with this particle
 +    if ( isdgmc == 1 ) then
@@ -1140,7 +1026,7 @@ diff -rN '--unified=0' Source/src/sourcb.F90 Source_dagmc/src/sourcb.F90
 +++ Source_dagmc/src/sourcb.F90
 @@ -21,0 +22 @@
 +  use dagmc_mod, only : isdgmc, dagmc_srcmode
-@@ -753 +754,8 @@
+@@ -746 +747,8 @@
 -          call chkcel(ji,0,j)
 +
 +          ! DAGMC: if dagmc_srcmode is on, skip chkcel and assume particle is in user-specified cell
@@ -1153,9 +1039,9 @@ diff -rN '--unified=0' Source/src/sourcb.F90 Source_dagmc/src/sourcb.F90
 diff -rN '--unified=0' Source/src/startp.F90 Source_dagmc/src/startp.F90
 --- Source/src/startp.F90
 +++ Source_dagmc/src/startp.F90
-@@ -51,0 +52 @@
-+  use dagmc_mod,      only: isdgmc
-@@ -117,0 +119,6 @@
+@@ -56,0 +57 @@
++  use dagmc_mod, only: isdgmc
+@@ -127,0 +129,6 @@
 +
 +  ! DAGMC: nbnk = 0
 +  if ( isdgmc == 1 ) then
@@ -1167,7 +1053,7 @@ diff -rN '--unified=0' Source/src/tally.F90 Source_dagmc/src/tally.F90
 +++ Source_dagmc/src/tally.F90
 @@ -36,0 +37 @@
 +  use dagmc_mod, only : isdgmc
-@@ -516,0 +518,4 @@
+@@ -512,0 +514,4 @@
 +
 +    ! DAGMC: If in CAD mode, make sure distance to physics collision is initialized
 +    if ( isdgmc == 1 ) call dagmc_setdis(huge_float)
@@ -1176,28 +1062,32 @@ diff -rN '--unified=0' Source/src/track.F90 Source_dagmc/src/track.F90
 --- Source/src/track.F90
 +++ Source_dagmc/src/track.F90
 @@ -19,0 +20,2 @@
-+  use varcom,         only : nps
-+  use dagmc_mod,      only : isdgmc
-@@ -31,0 +34 @@
-+
-@@ -69,0 +73,8 @@
++  use varcom, only : nps
++  use dagmc_mod, only : isdgmc
+@@ -63,0 +66,8 @@
 +  endif
 +
 +  ! DAGMC: If in CAD mode, call DAGMC version of track instead
 +  if ( isdgmc == 1 ) then
-+    call dagmctrack(icell, pbl%r%u, pbl%r%v, pbl%r%w, pbl%r%x, pbl%r%y, pbl%r%z, &
++    call dagmctrack(ih, pbl%r%u, pbl%r%v, pbl%r%w, pbl%r%x, pbl%r%y, pbl%r%z, &
 +     &              huge_float, pbl%r%dls, jap, pbl%i%jsu, nps)
 +    if ( pbl%r%dls == huge_float ) kdb = 2
 +    return
 diff -rN '--unified=0' Source/src/transm.F90 Source_dagmc/src/transm.F90
 --- Source/src/transm.F90
 +++ Source_dagmc/src/transm.F90
-@@ -17,0 +18 @@
+@@ -16,0 +17 @@
 +  use dagmc_mod, only : isdgmc
-@@ -105,0 +107,3 @@
+@@ -88,0 +90,3 @@
 +
 +    ! DAGMC: If in CAD mode, call dagmc_setdis first
 +    if ( isdgmc == 1 ) call dagmc_setdis( dd - sd )
+diff -rN '--unified=0' Source/src/trfsrf.F90 Source_dagmc/src/trfsrf.F90
+--- Source/src/trfsrf.F90
++++ Source_dagmc/src/trfsrf.F90
+@@ -200 +200 @@
+-  scf(l+1:l+3) = scf(l+1:l+3) - trf(2:3,jt)
++  scf(l+1:l+3) = scf(l+1:l+3) - trf(2:4,jt)
 diff -rN '--unified=0' Source/src/volume.F90 Source_dagmc/src/volume.F90
 --- Source/src/volume.F90
 +++ Source_dagmc/src/volume.F90

--- a/src/mcnp/mcnp6/patch/mcnp611.patch
+++ b/src/mcnp/mcnp6/patch/mcnp611.patch
@@ -15,28 +15,30 @@ diff -rN '--unified=0' Source/src/angl.F90 Source_dagmc/src/angl.F90
 +++ Source_dagmc/src/angl.F90
 @@ -15,0 +16 @@
 +  use dagmc_mod,   only : isdgmc
-@@ -29,0 +31,7 @@
+@@ -28 +29,8 @@
+- 
++
 +  ! DAGMC: In CAD mode, circumvent entire function and call DAGMC version instead
 +  if (isdgmc == 1) then
-+    call dagmcangl(pbl%i%jsu, pbl%r%x, pbl%r%y, pbl%r%z, ang)
-+    angl = max(-one, min(one, ang(1)*pbl%r%u + ang(2)*pbl%r%v + ang(3)*pbl%r%w))
++    call dagmcangl(pbl%i%jsu, pbl%r%x, pbl%r%y, pbl%r%z, sur_norm)
++    cos_theta = max(-one, min(one, sur_norm(1)*pbl%r%u + sur_norm(2)*pbl%r%v + sur_norm(3)*pbl%r%w))
 +    return
 +  endif
 +
 diff -rN '--unified=0' Source/src/bankit.F90 Source_dagmc/src/bankit.F90
 --- Source/src/bankit.F90
 +++ Source_dagmc/src/bankit.F90
-@@ -69,0 +70 @@
+@@ -70,0 +71 @@
 +    use dagmc_mod, only : isdgmc
-@@ -101,0 +103,5 @@
+@@ -112,0 +114,5 @@
 +    ! DAGMC:
 +    if ( isdgmc == 1 ) then
 +      call dagmc_bank_push( nbnk )
 +    endif
 +
-@@ -280,0 +287 @@
+@@ -284,0 +291 @@
 +    use dagmc_mod, only : isdgmc
-@@ -291,0 +299,5 @@
+@@ -295,0 +303,5 @@
 +  ! DAGMC:
 +    if ( isdgmc == 1 ) then
 +      call dagmc_bank_usetop()
@@ -52,7 +54,7 @@ diff -rN '--unified=0' Source/src/celsrf.F90 Source_dagmc/src/celsrf.F90
 +++ Source_dagmc/src/celsrf.F90
 @@ -25,0 +26 @@
 +  use dagmc_mod, only : isdgmc
-@@ -445 +446,6 @@
+@@ -453 +454,6 @@
 -    write(iuo,460) js,j1,hq,hl,ht,surface_card(k)%symbol,(tpp(i),i=1,n)
 +    ! DAGMC: surface_card(k)%symbol returns null characters in DAGMC mode
 +    if (isdgmc == 1) then
@@ -60,10 +62,32 @@ diff -rN '--unified=0' Source/src/celsrf.F90 Source_dagmc/src/celsrf.F90
 +    else
 +      write(iuo,460) js,j1,hq,hl,ht,surface_card(k)%symbol,(tpp(i),i=1,n)
 +    endif
-@@ -501,0 +508,3 @@
+@@ -509,0 +516,3 @@
 +    ! DAGMC: Skip this loop if in CAD mode
 +    if (isdgmc == 1) exit
 +
+diff -rN '--unified=0' Source/src/cgm_interface.F90 Source_dagmc/src/cgm_interface.F90
+--- Source/src/cgm_interface.F90
++++ Source_dagmc/src/cgm_interface.F90
+@@ -28,0 +29,4 @@
++#if __INTEL_COMPILER >= 1600
++      import :: c_funptr
++      type(c_funptr), value :: rngfunc
++#else
+@@ -30,0 +35 @@
++#endif
+diff -rN '--unified=0' Source/src/charged_particle_history.F90 Source_dagmc/src/charged_particle_history.F90
+--- Source/src/charged_particle_history.F90
++++ Source_dagmc/src/charged_particle_history.F90
+@@ -331,0 +332,5 @@
++
++        ! DAGMC: if minimum distance to next event is exactly zero, skip the
++        ! charged particle physics and go directly to the surface crossing
++        if( d_step_inter_decay_surf == zero ) goto 100
++
+@@ -642,0 +648,2 @@
++
++100     continue  ! DAGMC jump target
 diff -rN '--unified=0' Source/src/check_binary_expire.F90 Source_dagmc/src/check_binary_expire.F90
 --- Source/src/check_binary_expire.F90
 +++ Source_dagmc/src/check_binary_expire.F90
@@ -73,13 +97,13 @@ diff -rN '--unified=0' Source/src/check_binary_expire.F90 Source_dagmc/src/check
 diff -rN '--unified=0' Source/src/chkcel.F90 Source_dagmc/src/chkcel.F90
 --- Source/src/chkcel.F90
 +++ Source_dagmc/src/chkcel.F90
-@@ -28,0 +29 @@
-+  use dagmc_mod,    only : isdgmc
-@@ -58,0 +60,6 @@
+@@ -34,0 +35 @@
++  use dagmc_mod,    only: isdgmc
+@@ -62,0 +64,6 @@
 +
 +  ! DAGMC: In CAD mode, circumvent this function and call DAGMC version instead
 +  if ( isdgmc == 1 .and. (m == 0 .or. m == 2) ) then
-+    call dagmcchkcel(pbl%r%u, pbl%r%v, pbl%r%w, pbl%r%x, pbl%r%y, pbl%r%z, i1, j)
++    call dagmcchkcel(pbl%r%u, pbl%r%v, pbl%r%w, pbl%r%x, pbl%r%y, pbl%r%z, icell, jresult)
 +    return
 +  endif
 diff -rN '--unified=0' Source/src/dagmc_mod.F90 Source_dagmc/src/dagmc_mod.F90
@@ -313,12 +337,12 @@ diff -rN '--unified=0' Source/src/dagmc_mod.F90 Source_dagmc/src/dagmc_mod.F90
 diff -rN '--unified=0' Source/src/dbmin.F90 Source_dagmc/src/dbmin.F90
 --- Source/src/dbmin.F90
 +++ Source_dagmc/src/dbmin.F90
-@@ -17,0 +18 @@
+@@ -20,0 +21 @@
 +  use dagmc_mod,    only : isdgmc
-@@ -30,0 +32,10 @@
+@@ -33,0 +35,10 @@
 +
 +  ! DAGMC: Explicitly declare variable for return value for inter-language call
-+  real(dknd) :: dbmin_retval = 0
++  real(dknd) :: dbmin_retval = zero
 +
 +  ! DAGMC: In CAD mode, call MOAB version instead
 +  if ( isdgmc == 1 ) then
@@ -343,9 +367,9 @@ diff -rN '--unified=0' Source/src/echkcl.F90 Source_dagmc/src/echkcl.F90
 diff -rN '--unified=0' Source/src/electr.F90 Source_dagmc/src/electr.F90
 --- Source/src/electr.F90
 +++ Source_dagmc/src/electr.F90
-@@ -38,0 +39 @@
+@@ -39,0 +40 @@
 +  use dagmc_mod, only : isdgmc
-@@ -131,0 +133,6 @@
+@@ -146,0 +148,6 @@
 +        endif
 +
 +        ! DAGMC: In DAGMC mode, use the known physics distance to limit geometry search
@@ -355,34 +379,34 @@ diff -rN '--unified=0' Source/src/electr.F90 Source_dagmc/src/electr.F90
 diff -rN '--unified=0' Source/src/exemes.F90 Source_dagmc/src/exemes.F90
 --- Source/src/exemes.F90
 +++ Source_dagmc/src/exemes.F90
-@@ -275 +275 @@
+@@ -273 +273 @@
 -      select case( hm(js) )
 +      select case( trim(hm(js)) )
 diff -rN '--unified=0' Source/src/fmesh_mod.F90 Source_dagmc/src/fmesh_mod.F90
 --- Source/src/fmesh_mod.F90
 +++ Source_dagmc/src/fmesh_mod.F90
-@@ -22,0 +23,3 @@
-+  ! DAGMC
-+  public :: dagmc_make_fortran_pointer, dagmc_setup_mesh_tally
+@@ -41,0 +42,3 @@
++  public ::  dagmc_make_fortran_pointer  ! DAGMC
++  public ::  dagmc_setup_mesh_tally      ! DAGMC
 +
-@@ -25,0 +29,4 @@
+@@ -44,0 +48,4 @@
 +  logical, public :: enable_dag_tallies           = .false. ! DAGMC: Indicate any dagmc tally
 +  logical, public :: enable_dag_collision_tallies = .false. ! DAGMC: Indicate a collision tally
 +  logical, public :: enable_dag_track_tallies     = .false. ! DAGMC: Indicate a track tally
 +
-@@ -56 +63 @@
+@@ -76 +83 @@
 -  integer, parameter, public :: nfmesh_keyword_results = 15
 +  integer, parameter, public :: nfmesh_keyword_results = 16
-@@ -61 +68,2 @@
--  &     'yes       ','no        ','flux      ','source    ','none      ' /) 
+@@ -81 +88,2 @@
+-  &     'yes       ','no        ','flux      ','source    ','none      ' /)
 +  &     'yes       ','no        ','flux      ','source    ','none      ',   &
 +  &     'dag       ' /)
-@@ -180,0 +189,26 @@
+@@ -200,0 +209,26 @@
 +  ! DAGMC: These helper functions must be called with non-dereferenced Fortran pointers.
 +  ! This interface specification ensures that the calls to these functions
 +  ! (which are implemented in C) are made with the correct types
 +  interface
-+    subroutine dagmc_fmesh_get_tally_data( fm_id, fref )
++    subroutine dagmc_fmesh_get_tally_data( fm_id, fref ) bind(c)
 +      implicit none
 +      integer :: fm_id
 +      ! The dknd parameter is unavailable in this scope for some reason,
@@ -390,13 +414,13 @@ diff -rN '--unified=0' Source/src/fmesh_mod.F90 Source_dagmc/src/fmesh_mod.F90
 +      real(selected_real_kind(15,307)) , dimension(:), pointer :: fref
 +    end subroutine dagmc_fmesh_get_tally_data
 +
-+    subroutine dagmc_fmesh_get_error_data( fm_id, fref )
++    subroutine dagmc_fmesh_get_error_data( fm_id, fref ) bind(c)
 +      implicit none
 +      integer :: fm_id
 +      real(selected_real_kind(15,307)) , dimension(:), pointer :: fref
 +    end subroutine dagmc_fmesh_get_error_data
 +
-+    subroutine dagmc_fmesh_get_scratch_data( fm_id, fref )
++    subroutine dagmc_fmesh_get_scratch_data( fm_id, fref ) bind(c)
 +      implicit none
 +      integer :: fm_id
 +      real(selected_real_kind(15,307)), dimension(:), pointer:: fref
@@ -404,9 +428,9 @@ diff -rN '--unified=0' Source/src/fmesh_mod.F90 Source_dagmc/src/fmesh_mod.F90
 +
 +  end interface
 +
-@@ -184,0 +219,60 @@
+@@ -204,0 +239,60 @@
 +  ! DAGMC: Helper function - create a valid Fortran pointer from a C array and a length
-+  subroutine dagmc_make_fortran_pointer( fref, carray, size )
++  subroutine dagmc_make_fortran_pointer( fref, carray, size ) bind(c)
 +    implicit none
 +
 +    integer :: size ! The size (in doubles) of the array in C
@@ -465,11 +489,11 @@ diff -rN '--unified=0' Source/src/fmesh_mod.F90 Source_dagmc/src/fmesh_mod.F90
 +
 +  !-----------------------------------------------------------------------------------------
 +
-@@ -198,0 +293,3 @@
+@@ -218,0 +313,3 @@
 +    ! DAGMC
 +    real(dknd), dimension(:), pointer :: dagmc_runtpe_data
 +
-@@ -250,0 +348,8 @@
+@@ -270,0 +368,8 @@
 +      ! DAGMC:
 +      if ( fm(i)%icrd == 3 ) then
 +        ! Get pointer to mesh's working data and fill runtpe with those contents
@@ -478,11 +502,11 @@ diff -rN '--unified=0' Source/src/fmesh_mod.F90 Source_dagmc/src/fmesh_mod.F90
 +        call dagmc_fmesh_get_error_data( fm(i)%id, dagmc_runtpe_data )
 +        write(iu) dagmc_runtpe_data
 +      endif
-@@ -279,0 +385,3 @@
+@@ -299,0 +405,3 @@
 +    ! DAGMC
 +    real(dknd), dimension(:), pointer :: dagmc_runtpe_data
 +
-@@ -462,0 +571,11 @@
+@@ -474,0 +583,11 @@
 +
 +      ! DAGMC:
 +      if ( fm(i)%icrd == 3 ) then
@@ -494,113 +518,103 @@ diff -rN '--unified=0' Source/src/fmesh_mod.F90 Source_dagmc/src/fmesh_mod.F90
 +        read(iu) dagmc_runtpe_data
 +      endif
 +
-@@ -1008 +1127 @@
--    integer :: i
-+    integer :: i, j
-@@ -1070,0 +1190,9 @@
-+      ! DAGMC: send comment contents if this is a dagmc mesh
-+      if( fm(i)%icrd == 3 ) then
-+        call msg_put( fm(i)%n_comment_lines )
+@@ -1050 +1169 @@
+-    integer   :: i, ix, iy, iz, it, ie, is
++    integer   :: i, ix, iy, iz, it, ie, is, j
+@@ -1157,0 +1277,16 @@
++      ! DAGMC: broadcast comment contents if this is a dagmc mesh
++      if ( fm(i)%icrd == 3 ) then
++        call msg_bcast(mynum, fm(i)%n_comment_lines)
 +
-+        do j=1,fm(i)%n_comment_lines
-+          call msg_put( fm(i)%comment(j) )
++        if ( mynum > 0 ) then
++          allocate( fm(i)%comment( fm(i)%n_comment_lines ), stat=is )
++          if ( is /= 0 ) then
++            call erprnt(1,1,0,0,0,0,0,1,' "mesh tally memory allocation failure"')
++          endif
++        endif
++
++        do j = 1, fm(i)%n_comment_lines
++          call msg_bcast(mynum, fm(i)%comment(j))
 +        enddo
 +      endif
 +
-@@ -1092 +1220 @@
--    integer :: i,ix,iy,iz,it,ie,is
-+    integer :: i,ix,iy,iz,it,ie,is,j
-@@ -1195,0 +1324,13 @@
-+      ! DAGMC: receive comment contents if this is a dagmc mesh
-+      if( fm(i)%icrd == 3 ) then
-+        call msg_get( fm(i)%n_comment_lines )
+@@ -1205,0 +1341,8 @@
 +
-+        allocate( fm(i)%comment( fm(i)%n_comment_lines ), stat=is )
-+        if(is/=0) call erprnt(1,1,0,0,0,0,0,1,' "mesh tally memory allocation failure"')
++      ! DAGMC:
++      do i = 1, nmesh
++        if( fm(i)%icrd == 3 ) then
++          call dagmc_setup_mesh_tally(i)
++        endif
++      enddo
 +
-+        do j=1,fm(i)%n_comment_lines
-+          call msg_get( fm(i)%comment(j) )
-+        enddo
-+
-+      endif
-+
-@@ -1240,0 +1382,7 @@
-+    ! DAGMC:
-+    do i = 1,nmesh
-+      if( fm(i)%icrd == 3 ) then
-+        call dagmc_setup_mesh_tally( i )
-+      endif
-+    enddo
-+
-@@ -1334,0 +1483 @@
+@@ -1225,0 +1369,3 @@
++    ! DAGMC
 +    real(dknd), dimension(:), pointer :: dagmc_mpi_data
-@@ -1360 +1509,18 @@
++
+@@ -1250 +1396,2 @@
 -      isize = ix*iy*iz*it*ie
 +      if( fm(i)%icrd /= 3 ) then
 +        isize = ix*iy*iz*it*ie
+@@ -1252,7 +1399,15 @@
+-      ! use matching tag=555 in fmesh_msgtsk
+-      call msg_recv( islave,555, fmtal(i)%tally(:,1,1,1,1,1), isize )
+-      fm(i)%fmarry(:,:,:,:,:,1) = fm(i)%fmarry(:,:,:,:,:,1) + fmtal(i)%tally(:,:,:,:,:,1)
+-
+-      ! use matching tag=556 in fmesh_msgtsk
+-      call msg_recv( islave,556, fmtal(i)%tally(:,1,1,1,1,2), isize )
+-      fm(i)%fmerr( :,:,:,:,:,1) = fm(i)%fmerr( :,:,:,:,:,1) + fmtal(i)%tally(:,:,:,:,:,2)
++        ! use matching tag=555 in fmesh_msgtsk
++        call msg_recv( islave,555, fmtal(i)%tally(:,1,1,1,1,1), isize )
++        fm(i)%fmarry(:,:,:,:,:,1) = fm(i)%fmarry(:,:,:,:,:,1) + fmtal(i)%tally(:,:,:,:,:,1)
 +
-+        call msg_get(fmtal(i)%tally,  num_items =  isize)
-+        fm(i)%fmarry(:,:,:,:,:,1) = fm(i)%fmarry(:,:,:,:,:,1)+  &
-+          &   fmtal(i)%tally(:,:,:,:,:,1)
-+
-+        call msg_get(fmtal(i)%tally,  num_items =  isize)
-+        fm(i)%fmerr(:,:,:,:,:,1) = fm(i)%fmerr(:,:,:,:,:,1)+  &
-+          &   fmtal(i)%tally(:,:,:,:,:,1)
++        ! use matching tag=556 in fmesh_msgtsk
++        call msg_recv( islave,556, fmtal(i)%tally(:,1,1,1,1,2), isize )
++        fm(i)%fmerr( :,:,:,:,:,1) = fm(i)%fmerr( :,:,:,:,:,1) + fmtal(i)%tally(:,:,:,:,:,2)
 +      else
 +        ! DAGMC
-+        call dagmc_fmesh_get_scratch_data( fm(i)%id, dagmc_mpi_data )
-+        call msg_get( dagmc_mpi_data, 1, size(dagmc_mpi_data) )
-+        call dagmc_fmesh_add_scratch_to_tally( fm(i)%id )
-+        call msg_get( dagmc_mpi_data, 1, size(dagmc_mpi_data) )
-+        call dagmc_fmesh_add_scratch_to_error( fm(i)%id )
++        call dagmc_fmesh_get_scratch_data(fm(i)%id, dagmc_mpi_data)
++        call msg_recv(islave, 557, dagmc_mpi_data, size(dagmc_mpi_data))
++        call dagmc_fmesh_add_scratch_to_tally(fm(i)%id)
++        call msg_recv(islave, 558, dagmc_mpi_data, size(dagmc_mpi_data))
++        call dagmc_fmesh_add_scratch_to_error(fm(i)%id)
 +      endif
-@@ -1362,7 +1527,0 @@
--      call msg_get(fmtal(i)%tally,  num_items =  isize)
--      fm(i)%fmarry(:,:,:,:,:,1) = fm(i)%fmarry(:,:,:,:,:,1)+  &
--        &   fmtal(i)%tally(:,:,:,:,:,1)
--
--      call msg_get(fmtal(i)%tally,  num_items =  isize)
--      fm(i)%fmerr(:,:,:,:,:,1) = fm(i)%fmerr(:,:,:,:,:,1)+  &
--        &   fmtal(i)%tally(:,:,:,:,:,1)
-@@ -1387,0 +1547 @@
+@@ -1276,0 +1432,3 @@
++    ! DAGMC
 +    real(dknd), dimension(:), pointer :: dagmc_mpi_data
-@@ -1404 +1564,2 @@
++
+@@ -1292 +1450,2 @@
 -      isize = ix*iy*iz*it*ie
 +      if( fm(i)%icrd /= 3 ) then
 +        isize = ix*iy*iz*it*ie
-@@ -1406,2 +1567,13 @@
--      call msg_put(fm(i)%fmarry,  num_items =  isize)
--      call msg_put(fm(i)%fmerr,  num_items =  isize)
-+        call msg_put(fm(i)%fmarry,  num_items =  isize)
-+        call msg_put(fm(i)%fmerr,  num_items =  isize)
+@@ -1294,7 +1453,14 @@
+-      ! use matching tag=555 & tag=556 in fmesh_msgcon
+-      call msg_send( 0,555, fm(i)%fmarry(:,1,1,1,1,1), isize )
+-      call msg_send( 0,556, fm(i)%fmerr( :,1,1,1,1,1), isize )
+-
+-      ! zero arrays
+-      fm(i)%fmarry(:,:,:,:,:,1) = zero
+-      fm(i)%fmerr( :,:,:,:,:,1) = zero
++        ! use matching tag=555 & tag=556 in fmesh_msgcon
++        call msg_send( 0,555, fm(i)%fmarry(:,1,1,1,1,1), isize )
++        call msg_send( 0,556, fm(i)%fmerr( :,1,1,1,1,1), isize )
 +
 +        ! zero arrays
 +        fm(i)%fmarry(:,:,:,:,:,1) = zero
-+        fm(i)%fmerr(:,:,:,:,:,1) = zero
++        fm(i)%fmerr( :,:,:,:,:,1) = zero
 +      else
 +        ! DAGMC
-+        call dagmc_fmesh_get_tally_data( fm(i)%id, dagmc_mpi_data )
-+        call msg_put( dagmc_mpi_data, 1, size(dagmc_mpi_data) )
-+        call dagmc_fmesh_get_error_data( fm(i)%id, dagmc_mpi_data )
-+        call msg_put( dagmc_mpi_data, 1, size(dagmc_mpi_data) )
++        call dagmc_fmesh_get_tally_data(fm(i)%id, dagmc_mpi_data)
++        call msg_send(0, 557, dagmc_mpi_data, size(dagmc_mpi_data))
++        call dagmc_fmesh_get_error_data(fm(i)%id, dagmc_mpi_data)
++        call msg_send(0, 558, dagmc_mpi_data, size(dagmc_mpi_data))
 +      endif
-@@ -1409,3 +1580,0 @@
--      ! zero arrays
--      fm(i)%fmarry(:,:,:,:,:,1) = zero
--      fm(i)%fmerr(:,:,:,:,:,1) = zero
-@@ -1413,0 +1583,5 @@
-+    ! DAGMC
-+    if( enable_dag_tallies ) then
-+      call dagmc_fmesh_clear_data()
-+    endif
-+
-@@ -1431,0 +1606,5 @@
+@@ -1320,0 +1487,5 @@
 +    ! DAGMC: perform end of history tasks for all dagmc mesh tallies
 +    if ( enable_dag_tallies ) then
 +      call dagmc_fmesh_end_history()
 +    endif
 +
-@@ -1508,0 +1688,27 @@
+@@ -1397,0 +1569,27 @@
 +  subroutine dagmc_get_multiplier( i, erg, multiplier )
 +
 +    use mcnp_params, only : dknd
@@ -628,12 +642,12 @@ diff -rN '--unified=0' Source/src/fmesh_mod.F90 Source_dagmc/src/fmesh_mod.F90
 +
 +  !-----------------------------------------------------------------------------------------
 +
-@@ -1539,0 +1746,4 @@
+@@ -1429,0 +1628,4 @@
 +
 +    ! DAGMC
 +    real(dknd) :: dagmc_multiplier
 +
-@@ -1552,0 +1763,13 @@
+@@ -1442,0 +1645,13 @@
 +    ! DAGMC: update multipliers if any dagmc mesh tallies exist
 +    if ( enable_dag_tallies ) then
 +      do i = 1, nmesh
@@ -647,25 +661,25 @@ diff -rN '--unified=0' Source/src/fmesh_mod.F90 Source_dagmc/src/fmesh_mod.F90
 +       call dagmc_fmesh_score(ipt, x, y, z, u, v, w, erg, wgt, d, pbl%i%icl)
 +    endif
 +
-@@ -1561,0 +1785,5 @@
+@@ -1451,0 +1667,5 @@
 +      ! DAGMC: skip iteration if dagmc mesh tally
 +      if ( fm(i)%icrd == 3 ) then
 +        cycle
 +      endif
 +
-@@ -2727,0 +2956,5 @@
+@@ -2808,0 +3029,5 @@
 +    ! DAGMC: write data to file for all dagmc mesh tallies
 +    if ( enable_dag_tallies ) then
 +      call dagmc_fmesh_print(sp_norm)
 +    endif
 +
-@@ -2729,0 +2963,5 @@
+@@ -2810,0 +3036,5 @@
 +      ! DAGMC: skip iteration if dagmc mesh tally
 +      if( fm(j)%icrd == 3 ) then
 +        cycle
 +      endif
 +
-@@ -3909,0 +4148,7 @@
+@@ -4016,0 +4247,7 @@
 +
 +    ! DAGMC: setup up dagmc mesh tallies based on fmesh index i
 +    do i = 1,nmesh
@@ -676,36 +690,36 @@ diff -rN '--unified=0' Source/src/fmesh_mod.F90 Source_dagmc/src/fmesh_mod.F90
 diff -rN '--unified=0' Source/src/history_neutral_high.F90 Source_dagmc/src/history_neutral_high.F90
 --- Source/src/history_neutral_high.F90
 +++ Source_dagmc/src/history_neutral_high.F90
-@@ -119 +119,2 @@
--      if( d <= zero ) then  !  Review the need for this test.
+@@ -161 +161,2 @@
+-      if( D <= zero ) then  !  Review the need for this test.
 +      ! DAGMC: use < instead of <=
-+      if( d < zero ) then  !  Review the need for this test.
++      if( D < zero ) then  !  Review the need for this test.
 diff -rN '--unified=0' Source/src/hstory.F90 Source_dagmc/src/hstory.F90
 --- Source/src/hstory.F90
 +++ Source_dagmc/src/hstory.F90
-@@ -16 +16 @@
--  use fmesh_mod, only : mesh_score, nmesh, FMESH_CALL_HISTORY
-+  use fmesh_mod, only : mesh_score, nmesh, FMESH_CALL_HISTORY, enable_dag_collision_tallies
-@@ -30,0 +31 @@
-+  use dagmc_mod, only : isdgmc
-@@ -130 +131,2 @@
--        if( lca(pbl%i%icl) < 0 )then
+@@ -13 +13 @@
+-  use fmesh_mod, only: nmesh
++  use fmesh_mod, only: nmesh, enable_dag_collision_tallies
+@@ -26,0 +27 @@
++  use dagmc_mod, only: isdgmc
+@@ -152 +153,2 @@
+-        if( lca(pbl%i%icl) < 0 ) then
 +        ! DAGMC: only do this when running in non-CAD mode
 +        if( ( lca(pbl%i%icl) < 0 ) .and. (isdgmc == 0 ) ) then
-@@ -167 +169,2 @@
+@@ -190 +192,2 @@
 -            call track(pbl%i%icl)
 +            ! DAGMC: only call track here if in normal mode (NOT in CAD mode)
 +            if ( isdgmc == 0 ) call track(pbl%i%icl)
-@@ -228,0 +232,8 @@
-+                ! DAGMC: In CAD mode, call DAGMC before forcing collision
-+                if ( isdgmc == 1 ) then
-+                  if ( lca(pbl%i%icl) < 0 ) call chkcel(pbl%i%icl, 3, j)
-+                  call dagmc_setdis(huge_float)
-+                  call track(pbl%i%icl)
-+                  if ( kdb /= 0 ) exit HISTORY_LOOP
-+                endif
+@@ -292,0 +296,8 @@
++                    ! DAGMC: In CAD mode, call DAGMC before forcing collision
++                    if ( isdgmc == 1 ) then
++                      if ( lca(pbl%i%icl) < 0 ) call chkcel(pbl%i%icl, 3, j)
++                      call dagmc_setdis(huge_float)
++                      call track(pbl%i%icl)
++                      if ( kdb /= 0 ) exit HISTORY_LOOP
++                    endif
 +
-@@ -282,0 +294,9 @@
+@@ -376,0 +388,9 @@
 +          ! DAGMC: In CAD mode, get particle information
 +          if ( isdgmc == 1 ) then
 +            if ( lca(pbl%i%icl) < 0 ) call chkcel(pbl%i%icl, 3, j)
@@ -715,21 +729,20 @@ diff -rN '--unified=0' Source/src/hstory.F90 Source_dagmc/src/hstory.F90
 +            if ( kdb /= 0 ) exit HISTORY_LOOP
 +          endif
 +
-@@ -529,0 +550,6 @@
-+            ! DAGMC: Collision Tally
-+            if ( enable_dag_collision_tallies ) then
-+              call dagmc_collision_score(pbl%i%ipt, pbl%r%x, pbl%r%y, pbl%r%z, &
-+                                         pbl%r%erg, pbl%r%wgt, ple, pbl%i%icl)
-+            endif
-+
-@@ -555,0 +582,3 @@
-+                  ! DAGMC
-+                  if( isdgmc == 1 ) call dagmc_particle_terminate()
+@@ -872,0 +893,5 @@
++    ! DAGMC: Collision Tally
++    if ( enable_dag_collision_tallies ) then
++      call dagmc_collision_score(pbl%i%ipt, pbl%r%x, pbl%r%y, pbl%r%z, &
++                                 pbl%r%erg, pbl%r%wgt, ple, pbl%i%icl)
++    endif
+@@ -894,0 +920,3 @@
++          ! DAGMC
++          if( isdgmc == 1 ) call dagmc_particle_terminate()
 +
 diff -rN '--unified=0' Source/src/igeom.F90 Source_dagmc/src/igeom.F90
 --- Source/src/igeom.F90
 +++ Source_dagmc/src/igeom.F90
-@@ -13,0 +14 @@
+@@ -14,0 +15 @@
 +  use dagmc_mod, only : isdgmc
 @@ -117,0 +119,3 @@
 +  ! DAGMC: only call this when running in normal (non-CAD) mode
@@ -738,20 +751,38 @@ diff -rN '--unified=0' Source/src/igeom.F90 Source_dagmc/src/igeom.F90
 diff -rN '--unified=0' Source/src/imcn.F90 Source_dagmc/src/imcn.F90
 --- Source/src/imcn.F90
 +++ Source_dagmc/src/imcn.F90
-@@ -27,0 +28 @@
+@@ -29,0 +30 @@
 +  use dagmc_mod, only : isdgmc, dagmc_distlimit, dagmc_usecad, dagmc_overlap_thickness, dagmc_srcmode
-@@ -1492,0 +1494,5 @@
-+
+@@ -36,0 +38,3 @@
++#if __INTEL_COMPILER >= 1600
++  use, intrinsic :: iso_c_binding
++#endif
+@@ -1823,0 +1828,5 @@
 +    ! Initialize DAGMC
 +    if ( isdgmc == 1 ) then  ! set DAGMC parameters from idum & rdum
 +      call dagmc_set_settings(dagmc_distlimit, dagmc_usecad, dagmc_overlap_thickness, dagmc_srcmode)
 +    endif
++
+@@ -2033 +2042,5 @@
+-      call setrngcgm(rang)          
++#if __INTEL_COMPILER >= 1600
++      call setrngcgm(c_funloc(rang))
++#else
++      call setrngcgm(rang)
++#endif
+@@ -2299 +2312,5 @@
+-      call setrngcgm(rang)          
++#if __INTEL_COMPILER >= 1600
++      call setrngcgm(c_funloc(rang))
++#else
++      call setrngcgm(rang)
++#endif
 diff -rN '--unified=0' Source/src/itally.F90 Source_dagmc/src/itally.F90
 --- Source/src/itally.F90
 +++ Source_dagmc/src/itally.F90
 @@ -31,0 +32 @@
 +  use dagmc_mod, only : isdgmc
-@@ -205,0 +207,7 @@
+@@ -207,0 +209,7 @@
 +
 +        ! DAGMC: If in CAD mode, skip up until line prior to marker 40
 +        if ( isdgmc == 1 ) then
@@ -765,16 +796,14 @@ diff -rN '--unified=0' Source/src/main.F90 Source_dagmc/src/main.F90
 @@ -58 +58 @@
 -    & msub, outp
 +    & msub, outp, gcad, lcad, fcad, ftol
-@@ -62 +62,2 @@
--    
+@@ -61,0 +62 @@
 +  use dagmc_mod, only : isdgmc, dagmc_geom_file_mode, DGFM_READ
-+
 @@ -64 +65 @@
 -  use mcnp_env, only : HDPTH0, KOD, LODDAT, VER
 +  use mcnp_env, only : hdpth0, kod, loddat, ver
-@@ -78,0 +80 @@
-+  use dagmc_mod, only : init_dagmc, dagmc_version_heading
-@@ -199,0 +202,18 @@
+@@ -77,0 +79 @@
++  use dagmc_mod,           only: init_dagmc, dagmc_version_heading
+@@ -184,0 +187,18 @@
 +
 +  ! DAGMC: initialize a DAGMC run if specified
 +  if ( gcad /= ' ' ) then
@@ -793,20 +822,20 @@ diff -rN '--unified=0' Source/src/main.F90 Source_dagmc/src/main.F90
 +    endif
 +  endif
 +
-@@ -247,0 +268,5 @@
+@@ -234,0 +255,5 @@
 +  ! DAGMC
 +  if ( isdgmc == 1 ) then
 +    call init_dagmc
 +  endif
 +
-@@ -263,0 +289,3 @@
+@@ -250,0 +276,3 @@
 +
 +  ! DAGMC
 +  if (isdgmc == 1) call dagmc_version_heading( iuo )
 diff -rN '--unified=0' Source/src/mcnp_env.F90 Source_dagmc/src/mcnp_env.F90
 --- Source/src/mcnp_env.F90
 +++ Source_dagmc/src/mcnp_env.F90
-@@ -0,0 +1,14 @@
+@@ -0,0 +1,78 @@
 +
 +  module mcnp_env
 +    !
@@ -818,44 +847,109 @@ diff -rN '--unified=0' Source/src/mcnp_env.F90 Source_dagmc/src/mcnp_env.F90
 +    character(len=20),parameter ::  thread         = THREAD
 +    character(len=20),parameter ::  thread_version = TVERS
 +    character(len=8), parameter ::  loddat         = LODDAT
-+    character(len=80),parameter ::  hdpth0         = DPATH
++    character(len=*), parameter ::  hdpth0         = DPATH
 +
++    public ::  print_build_info
++  CONTAINS
++    subroutine print_build_info( iunit )
++      integer, intent(in) :: iunit
++
++      write(iunit,*) '  +-----------------------------------------------------------'
++      write(iunit,*) '  | mcnp6 build information:'
++      write(iunit,*) '  |'
++      write(iunit,*) '  | This executable was built with a custom CMake build, not'
++      write(iunit,*) '  | the build system from the discs supplied by RSICC. See'
++      write(iunit,*) '  | https://github.com/svalinn/DAGMC for more information.'
++      write(iunit,*) '  |'
++      write(iunit,*) '  |   user          = ', ENV_USER
++      write(iunit,*) '  |   host          = ', ENV_HOST
++      write(iunit,*) '  |   OS            = ', ENV_OS
++      write(iunit,*) '  |   date          = ', ENV_DATE
++      write(iunit,*) '  |   time          = ', ENV_TIME
++      write(iunit,*) '  |'
++      write(iunit,*) '  |   cc            = ', ENV_CC
++      write(iunit,*) '  |   cxx           = ', ENV_CXX
++      write(iunit,*) '  |   f90           = ', ENV_F90
++#ifdef OMP
++      write(iunit,*) '  |   OpenMP        = yes'
++#else
++      write(iunit,*) '  |   OpenMP        = no'
++#endif
++#ifdef MPI
++      write(iunit,*) '  |   MPI           = yes'
++      write(iunit,*) '  |   MPI_ROOT      = ', ENV_MPI_ROOT
++#else
++      write(iunit,*) '  |   MPI           = no'
++#endif
++      write(iunit,*) '  |'
++      write(iunit,*) '  |   code          = ', KODE
++      write(iunit,*) '  |   version       = ', VERS
++      write(iunit,*) '  |'
++      write(iunit,*) '  |   thread name   = ', THREAD
++      write(iunit,*) '  |   thread number = ', TVERS
++      write(iunit,*) '  |'
++      write(iunit,*) '  |   datapath      = ', DPATH
++      write(iunit,*) '  |'
++      write(iunit,*) '  |   fpp defs      = '
++      write(iunit,*) '  |                   ', COMPDEF_0
++      write(iunit,*) '  |                   ', COMPDEF_1
++      write(iunit,*) '  |                   ', COMPDEF_2
++      write(iunit,*) '  |                   ', COMPDEF_3
++      write(iunit,*) '  |                   ', COMPDEF_4
++      write(iunit,*) '  |                   ', COMPDEF_5
++      write(iunit,*) '  |                   ', COMPDEF_6
++      write(iunit,*) '  |                   ', COMPDEF_7
++      write(iunit,*) '  |                   ', COMPDEF_8
++      write(iunit,*) '  |                   ', COMPDEF_9
++      write(iunit,*) '  |                   ', COMPDEF_10
++      write(iunit,*) '  |                   ', COMPDEF_11
++      write(iunit,*) '  |                   ', COMPDEF_12
++      write(iunit,*) '  |                   ', COMPDEF_13
++      write(iunit,*) '  |                   ', COMPDEF_14
++      write(iunit,*) '  |                   ', COMPDEF_15
++      write(iunit,*) '  |                   ', COMPDEF_16
++      write(iunit,*) '  |                   ', COMPDEF_17
++      write(iunit,*) '  |                   ', COMPDEF_18
++      write(iunit,*) '  |                   ', COMPDEF_19
++      write(iunit,*) '  +-----------------------------------------------------------'
++    end subroutine print_build_info
 +  end module mcnp_env
 diff -rN '--unified=0' Source/src/mcnp_input.F90 Source_dagmc/src/mcnp_input.F90
 --- Source/src/mcnp_input.F90
 +++ Source_dagmc/src/mcnp_input.F90
-@@ -25 +25 @@
--  integer,parameter, public :: nkcd   = 149     != Number of different types of input cards.
-+  integer,parameter, public :: nkcd   = 150     != Number of different types of input cards.
-@@ -226,0 +227,4 @@
+@@ -40 +40 @@
+-  integer,parameter, public :: nkcd = 153       != Number of different types of input cards.
++  integer,parameter, public :: nkcd = 154       != Number of different types of input cards.
+@@ -285,0 +286,5 @@
++
 +  ! DAGMC card keywords, input values
 +    character(len=18), dimension(4), parameter, public :: &
 +      & hdagmc = (/ 'check_src_cell    ', 'usecad            ', &
 +      &             'distlimit         ', 'overlap_thickness ' /)
-@@ -389,0 +394,2 @@
+@@ -460,0 +466,2 @@
 +  ! DAGMC cards
-+  data cnm(150),(krq(i,150),i=1,7)/ 'dagmc',0,0, 0,0, 0,              12,0 /
++  data cnm(154),(krq(i,154),i=1,7)/ 'dagmc',0,0, 0,0, 0,              12,0 /
 diff -rN '--unified=0' Source/src/mcnp_iofiles.F90 Source_dagmc/src/mcnp_iofiles.F90
 --- Source/src/mcnp_iofiles.F90
 +++ Source_dagmc/src/mcnp_iofiles.F90
-@@ -48 +48,5 @@
+@@ -49 +49,5 @@
 -    &  dumn2
 +    &  dumn2,  &
 +    &  gcad,   &     ! gcad    - DAGMC geometry input file (CAD or facets)
 +    &  lcad,   &     ! lcad    - DAGMC input log file
 +    &  fcad,   &     ! fcad    - DAGMC facets output file
 +    &  ftol          ! ftol    - DAGMC faceting tolerance
-@@ -97,0 +102,4 @@
+@@ -99,0 +104,4 @@
 +    gcad    = isub(26)  ! DAGMC
 +    lcad    = isub(27)  ! DAGMC
 +    fcad    = isub(28)  ! DAGMC
 +    ftol    = isub(29)  ! DAGMC
-@@ -129,0 +138,4 @@
+@@ -132,0 +141,4 @@
 +      gcad(i:i)   = ' '  ! DAGMC
 +      lcad(i:i)   = ' '  ! DAGMC
 +      fcad(i:i)   = ' '  ! DAGMC
 +      ftol(i:i)   = ' '  ! DAGMC
-@@ -159,0 +172,4 @@
+@@ -163,0 +176,4 @@
 +    msub(26)(1:8) = 'gcad    '  ! DAGMC
 +    msub(27)(1:8) = 'lcad    '  ! DAGMC
 +    msub(28)(1:8) = 'fcad    '  ! DAGMC
@@ -863,14 +957,14 @@ diff -rN '--unified=0' Source/src/mcnp_iofiles.F90 Source_dagmc/src/mcnp_iofiles
 diff -rN '--unified=0' Source/src/mcnp_params.F90 Source_dagmc/src/mcnp_params.F90
 --- Source/src/mcnp_params.F90
 +++ Source_dagmc/src/mcnp_params.F90
-@@ -216,0 +217 @@
+@@ -243,0 +244 @@
 +  integer, parameter, public :: iulc    = 79  != I/O unit for DAGMC log file
 diff -rN '--unified=0' Source/src/msgcon.F90 Source_dagmc/src/msgcon.F90
 --- Source/src/msgcon.F90
 +++ Source_dagmc/src/msgcon.F90
-@@ -77,0 +78 @@
+@@ -80,0 +81 @@
 +  use dagmc_mod,           only: dagmc_msgbcast
-@@ -298,0 +300,4 @@
+@@ -281,0 +283,4 @@
 +
 +  ! DAGMC
 +  write(jtty,*) "master sending DAGMC information..."
@@ -878,13 +972,23 @@ diff -rN '--unified=0' Source/src/msgcon.F90 Source_dagmc/src/msgcon.F90
 diff -rN '--unified=0' Source/src/msgtsk.F90 Source_dagmc/src/msgtsk.F90
 --- Source/src/msgtsk.F90
 +++ Source_dagmc/src/msgtsk.F90
-@@ -71,0 +72 @@
+@@ -74,0 +75 @@
 +  use dagmc_mod,         only: dagmc_msgbcast
-@@ -249,0 +251,4 @@
-+
+@@ -80,0 +82,3 @@
++#if __INTEL_COMPILER >= 1600
++  use, intrinsic :: iso_c_binding
++#endif
+@@ -231,0 +236,3 @@
 +  ! DAGMC
 +  call dagmc_msgbcast
 +
+@@ -308 +315,5 @@
+-    call setrngcgm(rang) 
++#if __INTEL_COMPILER >= 1600
++    call setrngcgm(c_funloc(rang))
++#else
++    call setrngcgm(rang)
++#endif
 diff -rN '--unified=0' Source/src/namchg.F90 Source_dagmc/src/namchg.F90
 --- Source/src/namchg.F90
 +++ Source_dagmc/src/namchg.F90
@@ -907,12 +1011,12 @@ diff -rN '--unified=0' Source/src/newcel.F90 Source_dagmc/src/newcel.F90
 @@ -52,0 +54,7 @@
 +  ! DAGMC: In CAD mode, call MOAB version of this
 +  if ( isdgmc == 1 ) then
-+    if ( cs /= 0 ) cs = angl()
++    if ( cs /= 0 ) call angl( cs, ang )
 +    call dagmcnewcel(pbl%i%jsu, pbl%i%icl, pbl%i%iap)
 +    if ( mxa == -1 ) kdb = 1
 +  endif
 +
-@@ -237 +245,4 @@
+@@ -239 +247,4 @@
 -      call expirx(1,'newcel','the surface crossed is not a surface of this cell.')
 +      ! DAGMC: Only check this if running normally, (NOT in CAD mode)
 +      if (isdgmc == 0) then
@@ -921,18 +1025,18 @@ diff -rN '--unified=0' Source/src/newcel.F90 Source_dagmc/src/newcel.F90
 diff -rN '--unified=0' Source/src/nextit.F90 Source_dagmc/src/nextit.F90
 --- Source/src/nextit.F90
 +++ Source_dagmc/src/nextit.F90
-@@ -57 +57 @@
--    & surface_card, NUM_SURFACE_TYPES, length_spf
-+    & surface_card, NUM_SURFACE_TYPES, length_spf, hdagmc
-@@ -66,0 +67 @@
+@@ -55 +55 @@
+-    & ri_mopt, ric_mopt, ris_mopt
++    & ri_mopt, ric_mopt, ris_mopt, hdagmc
+@@ -64,0 +65 @@
 +  use dagmc_mod, only: dagmc_srcmode, dagmc_usecad, dagmc_distlimit, dagmc_overlap_thickness
-@@ -2293,0 +2295,3 @@
+@@ -2596,0 +2598,3 @@
 +              ! DAGMC
 +              elseif( hitm(1:3) == 'dag' ) then
 +                fm(nmesh)%icrd=3
-@@ -2934,0 +2939,21 @@
+@@ -3348,0 +3353,21 @@
 +
-+      case( 'dagmc' )
++      case( 154 )
 +        !  >>>>>  DAGMC parameters                                                                dagmc
 +        !  Modeled after RAND (99)
 +        !  m1c=index of current dagmc keyword.
@@ -957,15 +1061,15 @@ diff -rN '--unified=0' Source/src/oldcrd.F90 Source_dagmc/src/oldcrd.F90
 +++ Source_dagmc/src/oldcrd.F90
 @@ -28,0 +29 @@
 +  use dagmc_mod, only : isdgmc
-@@ -70 +71,2 @@
+@@ -71 +72,2 @@
 -      if( lca(mxa) == nlja + 1 ) then
 +      ! DAGMC: In CAD mode, cells should have no surfaces
 +      if( ( lca(mxa)==nlja + 1 ) .and. ( isdgmc == 0 ) ) then
-@@ -80,0 +83,3 @@
+@@ -81,0 +84,3 @@
 +    ! DAGMC: Break out of subroutine here in CAD mode
 +    if ( isdgmc == 1 ) return
 +
-@@ -1401,0 +1407,7 @@
+@@ -1429,0 +1435,7 @@
 +
 +        ! DAGMC: skip handling imesh/jmesh/kmesh/orig when geom=DAG; check emesh before jump
 +        if( ifmsh(13) == 0 ) then
@@ -973,7 +1077,7 @@ diff -rN '--unified=0' Source/src/oldcrd.F90 Source_dagmc/src/oldcrd.F90
 +        endif
 +        if( fm(nmesh)%icrd==3 ) goto 4900
 +
-@@ -1414,3 +1426,4 @@
+@@ -1442,3 +1454,4 @@
 -        if( ifmsh(13) == 0 ) then
 -          ientmp(1:ifmsh(12)) = 1
 -        endif
@@ -981,7 +1085,7 @@ diff -rN '--unified=0' Source/src/oldcrd.F90 Source_dagmc/src/oldcrd.F90
 +        ! if( ifmsh(13) == 0 ) then
 +        !   ientmp(1:ifmsh(12)) = 1
 +        ! endif
-@@ -1585,0 +1599 @@
+@@ -1620,0 +1634 @@
 +4900 continue ! DAGMC jump target
 diff -rN '--unified=0' Source/src/pass0.F90 Source_dagmc/src/pass0.F90
 --- Source/src/pass0.F90
@@ -995,17 +1099,28 @@ diff -rN '--unified=0' Source/src/pass0.F90 Source_dagmc/src/pass0.F90
 diff -rN '--unified=0' Source/src/pblcom.F90 Source_dagmc/src/pblcom.F90
 --- Source/src/pblcom.F90
 +++ Source_dagmc/src/pblcom.F90
-@@ -189,0 +190 @@
+@@ -178,4 +178,6 @@
+-  common /pblcom_thread/ pbl, pbl_src, pbl_stack
+-  common /pblcom_thread/ udt, udt_stack
+-  common /pblcom_thread/ pbl_in_use, udt_in_use, is_uncollided_part
+-  !$OMP THREADPRIVATE( /pblcom_thread/ )
++  common /pblcom_thread1/ pbl, pbl_src, pbl_stack
++  common /pblcom_thread2/ udt, udt_stack
++  common /pblcom_thread3/ pbl_in_use, udt_in_use, is_uncollided_part
++  !$OMP THREADPRIVATE( /pblcom_thread1/ )
++  !$OMP THREADPRIVATE( /pblcom_thread2/ )
++  !$OMP THREADPRIVATE( /pblcom_thread3/ )
+@@ -315,0 +318 @@
 +    use dagmc_mod, only : isdgmc
-@@ -214,0 +216,5 @@
+@@ -340,0 +344,5 @@
 +    ! DAGMC: save this particle's ray history
 +    if (isdgmc == 1) then
 +      call dagmc_savpar(n)
 +    endif
 +
-@@ -382,0 +389 @@
+@@ -508,0 +517 @@
 +    use dagmc_mod, only : isdgmc
-@@ -398,0 +406,5 @@
+@@ -524,0 +534,5 @@
 +
 +    ! DAGMC: Restore the ray history associated with this particle
 +    if ( isdgmc == 1 ) then
@@ -1025,7 +1140,7 @@ diff -rN '--unified=0' Source/src/sourcb.F90 Source_dagmc/src/sourcb.F90
 +++ Source_dagmc/src/sourcb.F90
 @@ -21,0 +22 @@
 +  use dagmc_mod, only : isdgmc, dagmc_srcmode
-@@ -742 +743,8 @@
+@@ -753 +754,8 @@
 -          call chkcel(ji,0,j)
 +
 +          ! DAGMC: if dagmc_srcmode is on, skip chkcel and assume particle is in user-specified cell
@@ -1038,9 +1153,9 @@ diff -rN '--unified=0' Source/src/sourcb.F90 Source_dagmc/src/sourcb.F90
 diff -rN '--unified=0' Source/src/startp.F90 Source_dagmc/src/startp.F90
 --- Source/src/startp.F90
 +++ Source_dagmc/src/startp.F90
-@@ -54,0 +55 @@
-+  use dagmc_mod, only : isdgmc
-@@ -124,0 +126,6 @@
+@@ -51,0 +52 @@
++  use dagmc_mod,      only: isdgmc
+@@ -117,0 +119,6 @@
 +
 +  ! DAGMC: nbnk = 0
 +  if ( isdgmc == 1 ) then
@@ -1052,7 +1167,7 @@ diff -rN '--unified=0' Source/src/tally.F90 Source_dagmc/src/tally.F90
 +++ Source_dagmc/src/tally.F90
 @@ -36,0 +37 @@
 +  use dagmc_mod, only : isdgmc
-@@ -426,0 +428,4 @@
+@@ -516,0 +518,4 @@
 +
 +    ! DAGMC: If in CAD mode, make sure distance to physics collision is initialized
 +    if ( isdgmc == 1 ) call dagmc_setdis(huge_float)
@@ -1060,24 +1175,26 @@ diff -rN '--unified=0' Source/src/tally.F90 Source_dagmc/src/tally.F90
 diff -rN '--unified=0' Source/src/track.F90 Source_dagmc/src/track.F90
 --- Source/src/track.F90
 +++ Source_dagmc/src/track.F90
-@@ -20,0 +21,2 @@
-+  use varcom, only : nps
-+  use dagmc_mod, only : isdgmc
-@@ -61,0 +64,8 @@
+@@ -19,0 +20,2 @@
++  use varcom,         only : nps
++  use dagmc_mod,      only : isdgmc
+@@ -31,0 +34 @@
++
+@@ -69,0 +73,8 @@
 +  endif
 +
 +  ! DAGMC: If in CAD mode, call DAGMC version of track instead
 +  if ( isdgmc == 1 ) then
-+    call dagmctrack(ih, pbl%r%u, pbl%r%v, pbl%r%w, pbl%r%x, pbl%r%y, pbl%r%z, &
++    call dagmctrack(icell, pbl%r%u, pbl%r%v, pbl%r%w, pbl%r%x, pbl%r%y, pbl%r%z, &
 +     &              huge_float, pbl%r%dls, jap, pbl%i%jsu, nps)
 +    if ( pbl%r%dls == huge_float ) kdb = 2
 +    return
 diff -rN '--unified=0' Source/src/transm.F90 Source_dagmc/src/transm.F90
 --- Source/src/transm.F90
 +++ Source_dagmc/src/transm.F90
-@@ -16,0 +17 @@
+@@ -17,0 +18 @@
 +  use dagmc_mod, only : isdgmc
-@@ -88,0 +90,3 @@
+@@ -105,0 +107,3 @@
 +
 +    ! DAGMC: If in CAD mode, call dagmc_setdis first
 +    if ( isdgmc == 1 ) call dagmc_setdis( dd - sd )

--- a/src/mcnp/meshtal_funcs.cpp
+++ b/src/mcnp/meshtal_funcs.cpp
@@ -192,12 +192,12 @@ void dagmc_fmesh_setup_mesh_(int* fm_ipt, int* id, int* fmesh_idx,
  * Called when the tally data needs to be written or read from a runtpe file
  * or an MPI stream.
  */
-void dagmc_fmesh_get_tally_data_(int* tally_id, void* fortran_data_pointer) {
+void dagmc_fmesh_get_tally_data(int* tally_id, void* fortran_data_pointer) {
   double* data;
   int length;
 
   data = tallyManager.getTallyData(*tally_id, length);
-  FMESH_FUNC(dagmc_make_fortran_pointer)(fortran_data_pointer, data, &length);
+  dagmc_make_fortran_pointer(fortran_data_pointer, data, &length);
 }
 //---------------------------------------------------------------------------//
 /**
@@ -208,12 +208,12 @@ void dagmc_fmesh_get_tally_data_(int* tally_id, void* fortran_data_pointer) {
  * Called when the error data needs to be written or read from a runtpe file
  * or an MPI stream.
  */
-void dagmc_fmesh_get_error_data_(int* tally_id, void* fortran_data_pointer) {
+void dagmc_fmesh_get_error_data(int* tally_id, void* fortran_data_pointer) {
   double* data;
   int length;
 
   data = tallyManager.getErrorData(*tally_id, length);
-  FMESH_FUNC(dagmc_make_fortran_pointer)(fortran_data_pointer, data, &length);
+  dagmc_make_fortran_pointer(fortran_data_pointer, data, &length);
 }
 //---------------------------------------------------------------------------//
 /**
@@ -224,12 +224,12 @@ void dagmc_fmesh_get_error_data_(int* tally_id, void* fortran_data_pointer) {
  * Called when the scratch data needs to be written or read from a runtpe file
  * or an MPI stream.
  */
-void dagmc_fmesh_get_scratch_data_(int* tally_id, void* fortran_data_pointer) {
+void dagmc_fmesh_get_scratch_data(int* tally_id, void* fortran_data_pointer) {
   double* data;
   int length;
 
   data = tallyManager.getScratchData(*tally_id, length);
-  FMESH_FUNC(dagmc_make_fortran_pointer)(fortran_data_pointer, data, &length);
+  dagmc_make_fortran_pointer(fortran_data_pointer, data, &length);
 }
 //---------------------------------------------------------------------------//
 /**

--- a/src/mcnp/meshtal_funcs.h
+++ b/src/mcnp/meshtal_funcs.h
@@ -18,28 +18,8 @@ extern "C" {
  * and should only be called from within meshtal_funcs.cpp
  */
 
-/** FORT_FUNC:
- * Macro to access symbol of fortran function 'func' in module 'mod'
- */
-#ifndef FORT_FUNC
-#if defined INTEL_FORTRAN
-// intel fortran: name mangling is '<module>_mp_<function>_'
-#define FORT_FUNC( mod, func ) mod##_mp_##func##_
-#elif defined GFORTRAN
-// gfortran: name mangling is ___<module>_mod_MOD_<function>
-#define FORT_FUNC( mod, func ) __##mod##_MOD_##func
-#else
-// unknown fortran compiler
-#warning "Unknown fortran compiler with unknown name mangling scheme, \
-proceeding with gfortran's scheme"
-#define FORT_FUNC( mod, func ) __##mod##_MOD_##func
-#endif
-#endif
-
-#define FMESH_FUNC( func ) FORT_FUNC( fmesh_mod, func )
-
 /* Make a valid Fortran pointer to a C array */
-extern void FMESH_FUNC(dagmc_make_fortran_pointer)(void* fort_ref, double* array, int* size);
+extern void dagmc_make_fortran_pointer(void* fort_ref, double* array, int* size);
 
 /**
  * The dagmc_fmesh_*_ functions are called from fortran to drive our advanced mesh tallies,
@@ -67,9 +47,9 @@ void dagmc_collision_score_(int* ipt,
 
 void dagmc_update_multiplier_(int* fmesh_idx, double* value);
 
-void dagmc_fmesh_get_tally_data_(int* tally_id, void* fortran_data_pointer);
-void dagmc_fmesh_get_error_data_(int* tally_id, void* fortran_data_pointer);
-void dagmc_fmesh_get_scratch_data_(int* tally_id, void* fortran_data_pointer);
+void dagmc_fmesh_get_tally_data(int* tally_id, void* fortran_data_pointer);
+void dagmc_fmesh_get_error_data(int* tally_id, void* fortran_data_pointer);
+void dagmc_fmesh_get_scratch_data(int* tally_id, void* fortran_data_pointer);
 void dagmc_fmesh_clear_data_();
 void dagmc_fmesh_add_scratch_to_tally_(int* tally_id);
 void dagmc_fmesh_add_scratch_to_error_(int* tally_id);


### PR DESCRIPTION
This PR removes the need for name mangling in `meshtal_funcs.h` by making use of `bind(c)` in `fmesh_mod.F90`. Previously, there was a macro in `meshtal_funcs.h` that attempted to determine the correct name mangling, but I've found situations where it didn't work properly. This is a much simpler way to do it.

(spoilers)

The real reason I did this is that MCNP6.2 uses Fortran2003, and from what I can tell, Intel's name mangling scheme for Fortran2003 is slightly different than it is for Fortran90. (It could be caused by something else, but regardless, the mangling is different between MCNP6.2 and all other versions of MCNP.) Trying to fix the name mangling macro would be pretty ugly because a different name mangling would need to be used for DAG-MCNP5 (Fortran90) than DAG-MCNP6.2 (Fortran2003) when trying to build both at the same time. This PR completely removes that problem, and it will remove any future problems related to name mangling as well.

I've gotten DAG-MCNP6.2 working (or at least compiling) on top of these changes, but support for that will come in a future PR.