### PR TITLE
Adding check for DAGMC_ROOT variable in environment.

### DIFF
--- a/cmake/FindDAGMC.cmake
+++ b/cmake/FindDAGMC.cmake
@@ -10,7 +10,7 @@
 message(STATUS ${DAGMC_ROOT})
 
 find_path(DAGMC_CMAKE_CONFIG NAMES DAGMCConfig.cmake
-          HINTS ${DAGMC_ROOT}
+          HINTS ${DAGMC_ROOT} $ENV{DAGMC_ROOT}
           PATHS ENV LD_LIBRARY_PATH
           PATH_SUFFIXES lib Lib cmake lib/cmake/
           NO_DEFAULT_PATH)


### PR DESCRIPTION
This PR adds the option for users to provide a DAGMC install location via the environment variable `DAGMC_ROOT`.