### PR TITLE
Make HDF5 path to material library a runtime options

### DIFF
--- a/src/uwuw/build/uwuw_preproc.cpp
+++ b/src/uwuw/build/uwuw_preproc.cpp
@@ -39,7 +39,7 @@ int main(int argc, char* argv[]) {
 
   if (matlib_hdf5_path == "")
     matlib_hdf5_path = "/materials";
-  
+
   // make new preprocessor
   uwuw_preprocessor* uwuw_preproc = new uwuw_preprocessor(lib_file, dag_file, out_file, matlib_hdf5_path, verbose, fatal_errors);
 

--- a/src/uwuw/build/uwuw_preproc.cpp
+++ b/src/uwuw/build/uwuw_preproc.cpp
@@ -12,6 +12,7 @@ int main(int argc, char* argv[]) {
   std::string lib_file;
   std::string dag_file;
   std::string out_file;
+  std::string matlib_hdf5_path;
 
   po.addOpt<void>("verbose,v", "Verbose output", &verbose);
   po.addOpt<void>("fatal,f", "Fatal errors cause exit", &fatal_errors);
@@ -20,6 +21,8 @@ int main(int argc, char* argv[]) {
   po.addRequiredArg<std::string>("dag_file", "Path to DAGMC file to proccess", &dag_file);
   po.addOpt<std::string>("lib_file,l", "Path to PyNE Material Library file to proccess", &lib_file);
   po.addOpt<std::string>("output,o", "Specify the output filename (default "")", &out_file);
+  po.addOpt<std::string>("matlib_hdf5_path,m", "specify the HDF5 location of the material library (default "")",
+                         &matlib_hdf5_path);
 
   po.addOptionHelpHeading("Options for loading files");
 
@@ -34,8 +37,11 @@ int main(int argc, char* argv[]) {
   if (out_file == "")
     out_file = dag_file;
 
+  if (matlib_hdf5_path == "")
+    matlib_hdf5_path = "/materials";
+  
   // make new preprocessor
-  uwuw_preprocessor* uwuw_preproc = new uwuw_preprocessor(lib_file, dag_file, out_file, verbose, fatal_errors);
+  uwuw_preprocessor* uwuw_preproc = new uwuw_preprocessor(lib_file, dag_file, out_file, matlib_hdf5_path, verbose, fatal_errors);
 
   // process the materials
   uwuw_preproc->process_materials();

--- a/src/uwuw/uwuw_preprocessor.cpp
+++ b/src/uwuw/uwuw_preprocessor.cpp
@@ -2,7 +2,8 @@
 
 // constructor
 uwuw_preprocessor::uwuw_preprocessor(std::string material_library_filename, std::string dagmc_filename,
-                                     std::string output_file,  bool verbosity, bool fatal_errors) {
+                                     std::string output_file,  std::string matlib_hdf5_path,
+                                     bool verbosity, bool fatal_errors) {
   // make new name concatenator class
   ncr = new name_concatenator();
 
@@ -10,7 +11,7 @@ uwuw_preprocessor::uwuw_preprocessor(std::string material_library_filename, std:
   DAG = new moab::DagMC();
 
   // load the materials
-  material_library = mat_lib.load_pyne_materials(material_library_filename, "/materials");
+  material_library = mat_lib.load_pyne_materials(material_library_filename, matlib_hdf5_path);
 
   // load the material objects
   // load the dag file

--- a/src/uwuw/uwuw_preprocessor.hpp
+++ b/src/uwuw/uwuw_preprocessor.hpp
@@ -72,6 +72,8 @@ class uwuw_preprocessor {
    * \param[in]  material_library_filename, a string defining the full path of the material library.
    * \param[in]  dagmc_filename, a string defining the full path of the DAGMC file.
    * \param[in]  output_filename, a string defining the full path of the output file.
+   * \param[in]  matlib_hdf5_path, a string defining where to find the material library within the HDF5 file
+   *             default location is "/materials"
    * \param[in]  verbosity, a boolean value representing if vebrose (true) or non verbose(false) ouput
    *             is required.
    * \param[in]  fatal, a boolean value representing if fatal (true) then we exit on fatal errors, not fatal (false)
@@ -79,7 +81,9 @@ class uwuw_preprocessor {
    */
   uwuw_preprocessor(std::string material_library_filename,
                     std::string dagmc_filename,
-                    std::string output_file, bool verbose = false,
+                    std::string output_file,
+                    std::string matlib_hdf5_path = "/materials",
+                    bool verbose = false,
                     bool fatal = true); // constructor
 
   /**


### PR DESCRIPTION
The material library generated by PyNE can appear in different places inside an HDF5 file.  This allows the user to specify the HDF5 path to find such a material library, with the default location being "/materials".