### PR TITLE
Update amalgamated pyne

### DIFF
--- a/cmake/DAGMC_macros.cmake
+++ b/cmake/DAGMC_macros.cmake
@@ -88,6 +88,8 @@ endmacro ()
 macro (dagmc_setup_flags)
   message("")
 
+  set(CMAKE_CXX_STANDARD 11)
+
   if (BUILD_PIC)
     set(CMAKE_POSITION_INDEPENDENT_CODE ON)
   endif ()

--- a/news/PR-0594.rst
+++ b/news/PR-0594.rst
@@ -1,0 +1,14 @@
+**Added:** None
+
+* OpenMC material writing capability for UWUW workflow via updates to the
+  amalgamated PyNE source.
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/src/pyne/CMakeLists.txt
+++ b/src/pyne/CMakeLists.txt
@@ -6,6 +6,8 @@ set(PUB_HEADERS pyne.h)
 set(LINK_LIBS)
 set(LINK_LIBS_EXTERN_NAMES HDF5_LIBRARIES)
 
+set(CMAKE_CXX_FLAGS_RELEASE "-std=c++11")
+
 if (CMAKE_Fortran_COMPILER_ID STREQUAL "Intel")
   set(CMAKE_CXX_FLAGS_RELEASE        "-O0")
   set(CMAKE_CXX_FLAGS_DEBUG          "-O0 -g")

--- a/src/pyne/CMakeLists.txt
+++ b/src/pyne/CMakeLists.txt
@@ -6,8 +6,6 @@ set(PUB_HEADERS pyne.h)
 set(LINK_LIBS)
 set(LINK_LIBS_EXTERN_NAMES HDF5_LIBRARIES)
 
-set(CMAKE_CXX_FLAGS_RELEASE "-std=c++11")
-
 if (CMAKE_Fortran_COMPILER_ID STREQUAL "Intel")
   set(CMAKE_CXX_FLAGS_RELEASE        "-O0")
   set(CMAKE_CXX_FLAGS_DEBUG          "-O0 -g")

--- a/src/pyne/pyne.cpp
+++ b/src/pyne/pyne.cpp
@@ -2423,9 +2423,11 @@ pyne::nucname::name_zz_t pyne::nucname::name_zz = pyne::nucname::get_name_zz();
 
 
 /*** Constructs zz to LL dictionary **/
-pyne::nucname::zzname_t pyne::nucname::get_zz_name() {
+pyne::nucname::zzname_t pyne::nucname::get_zz_name()
+{
   zzname_t zld;
-  for (name_zz_iter i = name_zz.begin(); i != name_zz.end(); i++) {
+  for (name_zz_iter i = name_zz.begin(); i != name_zz.end(); i++)
+  {
     zld[i->second] = i->first;
   }
   return zld;
@@ -2587,9 +2589,11 @@ pyne::nucname::name_zz_t pyne::nucname::fluka_zz = pyne::nucname::get_fluka_zz()
 
 
 /*** Constructs zz to fluka dictionary **/
-pyne::nucname::zzname_t pyne::nucname::get_zz_fluka() {
+pyne::nucname::zzname_t pyne::nucname::get_zz_fluka()
+{
   zzname_t zfd;
-  for (name_zz_iter i = fluka_zz.begin(); i != fluka_zz.end(); i++) {
+  for (name_zz_iter i = fluka_zz.begin(); i != fluka_zz.end(); i++)
+  {
     zfd[i->second] = i->first;
   }
   return zfd;
@@ -2602,7 +2606,8 @@ pyne::nucname::zzname_t pyne::nucname::zz_fluka = pyne::nucname::get_zz_fluka();
 /*** Define useful elemental group sets ***/
 /******************************************/
 
-pyne::nucname::zz_group pyne::nucname::name_to_zz_group(pyne::nucname::name_group eg) {
+pyne::nucname::zz_group pyne::nucname::name_to_zz_group(pyne::nucname::name_group eg)
+{
   zz_group zg;
   for (name_group_iter i = eg.begin(); i != eg.end(); i++)
     zg.insert(name_zz[*i]);
@@ -2611,53 +2616,48 @@ pyne::nucname::zz_group pyne::nucname::name_to_zz_group(pyne::nucname::name_grou
 
 // Lanthanides
 pyne::nucname::name_t pyne::nucname::LAN_array[15] = {"La", "Ce", "Pr", "Nd",
-                                                      "Pm", "Sm", "Eu", "Gd", "Tb", "Dy", "Ho", "Er", "Tm", "Yb", "Lu"
-                                                     };
-pyne::nucname::name_group pyne::nucname::LAN(pyne::nucname::LAN_array,
-                                             pyne::nucname::LAN_array + 15);
+  "Pm", "Sm", "Eu", "Gd", "Tb", "Dy", "Ho", "Er", "Tm", "Yb", "Lu"};
+pyne::nucname::name_group pyne::nucname::LAN (pyne::nucname::LAN_array,
+                                              pyne::nucname::LAN_array+15);
 pyne::nucname::zz_group pyne::nucname::lan = \
-                                             pyne::nucname::name_to_zz_group(pyne::nucname::LAN);
+  pyne::nucname::name_to_zz_group(pyne::nucname::LAN);
 
 // Actinides
 pyne::nucname::name_t pyne::nucname::ACT_array[15] = {"Ac", "Th", "Pa", "U",
-                                                      "Np", "Pu", "Am", "Cm", "Bk", "Cf", "Es", "Fm", "Md", "No", "Lr"
-                                                     };
-pyne::nucname::name_group pyne::nucname::ACT(pyne::nucname::ACT_array, pyne::nucname::ACT_array + 15);
+  "Np", "Pu", "Am", "Cm", "Bk", "Cf", "Es", "Fm", "Md", "No", "Lr"};
+pyne::nucname::name_group pyne::nucname::ACT (pyne::nucname::ACT_array, pyne::nucname::ACT_array+15);
 pyne::nucname::zz_group pyne::nucname::act = pyne::nucname::name_to_zz_group(pyne::nucname::ACT);
 
 // Transuarnics
 pyne::nucname::name_t pyne::nucname::TRU_array[22] = {"Np", "Pu", "Am", "Cm",
-                                                      "Bk", "Cf", "Es", "Fm", "Md", "No", "Lr", "Rf", "Db", "Sg", "Bh", "Hs", "Mt",
-                                                      "Ds", "Rg", "Cn", "Fl", "Lv"
-                                                     };
-pyne::nucname::name_group pyne::nucname::TRU(pyne::nucname::TRU_array,
-                                             pyne::nucname::TRU_array + 22);
+  "Bk", "Cf", "Es", "Fm", "Md", "No", "Lr", "Rf", "Db", "Sg", "Bh", "Hs", "Mt",
+  "Ds", "Rg", "Cn", "Fl", "Lv"};
+pyne::nucname::name_group pyne::nucname::TRU (pyne::nucname::TRU_array,
+                                              pyne::nucname::TRU_array+22);
 pyne::nucname::zz_group pyne::nucname::tru = \
-                                             pyne::nucname::name_to_zz_group(pyne::nucname::TRU);
+  pyne::nucname::name_to_zz_group(pyne::nucname::TRU);
 
 //Minor Actinides
 pyne::nucname::name_t pyne::nucname::MA_array[10] = {"Np", "Am", "Cm", "Bk",
-                                                     "Cf", "Es", "Fm", "Md", "No", "Lr"
-                                                    };
-pyne::nucname::name_group pyne::nucname::MA(pyne::nucname::MA_array,
-                                            pyne::nucname::MA_array + 10);
+  "Cf", "Es", "Fm", "Md", "No", "Lr"};
+pyne::nucname::name_group pyne::nucname::MA (pyne::nucname::MA_array,
+                                             pyne::nucname::MA_array+10);
 pyne::nucname::zz_group pyne::nucname::ma = \
-                                            pyne::nucname::name_to_zz_group(pyne::nucname::MA);
+  pyne::nucname::name_to_zz_group(pyne::nucname::MA);
 
 //Fission Products
 pyne::nucname::name_t pyne::nucname::FP_array[88] = {"Ag", "Al", "Ar", "As",
-                                                     "At", "Au", "B",  "Ba", "Be", "Bi", "Br", "C",  "Ca", "Cd", "Ce", "Cl", "Co",
-                                                     "Cr", "Cs", "Cu", "Dy", "Er", "Eu", "F",  "Fe", "Fr", "Ga", "Gd", "Ge", "H",
-                                                     "He", "Hf", "Hg", "Ho", "I",  "In", "Ir", "K",  "Kr", "La", "Li", "Lu", "Mg",
-                                                     "Mn", "Mo", "N",  "Na", "Nb", "Nd", "Ne", "Ni", "O",  "Os", "P",  "Pb", "Pd",
-                                                     "Pm", "Po", "Pr", "Pt", "Ra", "Rb", "Re", "Rh", "Rn", "Ru", "S",  "Sb", "Sc",
-                                                     "Se", "Si", "Sm", "Sn", "Sr", "Ta", "Tb", "Tc", "Te", "Ti", "Tl", "Tm", "V",
-                                                     "W",  "Xe", "Y",  "Yb", "Zn", "Zr"
-                                                    };
-pyne::nucname::name_group pyne::nucname::FP(pyne::nucname::FP_array,
-                                            pyne::nucname::FP_array + 88);
+  "At", "Au", "B",  "Ba", "Be", "Bi", "Br", "C",  "Ca", "Cd", "Ce", "Cl", "Co",
+  "Cr", "Cs", "Cu", "Dy", "Er", "Eu", "F",  "Fe", "Fr", "Ga", "Gd", "Ge", "H",
+  "He", "Hf", "Hg", "Ho", "I",  "In", "Ir", "K",  "Kr", "La", "Li", "Lu", "Mg",
+  "Mn", "Mo", "N",  "Na", "Nb", "Nd", "Ne", "Ni", "O",  "Os", "P",  "Pb", "Pd",
+  "Pm", "Po", "Pr", "Pt", "Ra", "Rb", "Re", "Rh", "Rn", "Ru", "S",  "Sb", "Sc",
+  "Se", "Si", "Sm", "Sn", "Sr", "Ta", "Tb", "Tc", "Te", "Ti", "Tl", "Tm", "V",
+  "W",  "Xe", "Y",  "Yb", "Zn", "Zr"};
+pyne::nucname::name_group pyne::nucname::FP (pyne::nucname::FP_array,
+                                             pyne::nucname::FP_array+88);
 pyne::nucname::zz_group pyne::nucname::fp = \
-                                            pyne::nucname::name_to_zz_group(pyne::nucname::FP);
+  pyne::nucname::name_to_zz_group(pyne::nucname::FP);
 
 
 /***************************/
@@ -2668,15 +2668,17 @@ bool pyne::nucname::isnuclide(std::string nuc) {
   int n;
   try {
     n = id(nuc);
-  } catch (NotANuclide) {
+  }
+  catch(NotANuclide) {
     return false;
-  } catch (IndeterminateNuclideForm) {
+  }
+  catch(IndeterminateNuclideForm) {
     return false;
   }
   return isnuclide(n);
 }
 
-bool pyne::nucname::isnuclide(const char* nuc) {
+bool pyne::nucname::isnuclide(const char * nuc) {
   return isnuclide(std::string(nuc));
 }
 
@@ -2684,9 +2686,11 @@ bool pyne::nucname::isnuclide(int nuc) {
   int n;
   try {
     n = id(nuc);
-  } catch (NotANuclide) {
+  }
+  catch(NotANuclide) {
     return false;
-  } catch (IndeterminateNuclideForm) {
+  }
+  catch(IndeterminateNuclideForm) {
     return false;
   }
   if (n <= 10000000)
@@ -2717,9 +2721,9 @@ int pyne::nucname::id(int nuc) {
   // Nuclide must already be in id form
   if (0 < zzz && zzz <= aaa && aaa <= zzz * 7) {
     // Normal nuclide
-    if (5 < ssss) {
-      // Unphysical metastable state warning
-      warning("You have indicated a metastable state of " + pyne::to_str(ssss) + ". Metastable state above 5, possibly unphysical. ");
+    if (5 < ssss){
+    // Unphysical metastable state warning
+     warning("You have indicated a metastable state of " + pyne::to_str(ssss) + ". Metastable state above 5, possibly unphysical. ");
     }
     return nuc;
   } else if (aaassss == 0 && 0 < zz_name.count(zzz)) {
@@ -2736,18 +2740,18 @@ int pyne::nucname::id(int nuc) {
   ssss = nuc % 10;       // SSSS ?
   if (zzz <= aaa && aaa <= zzz * 7) {
     // ZZZAAAM nuclide
-    if (5 < ssss) {
-      // Unphysical metastable state warning
+    if (5 < ssss){
+    // Unphysical metastable state warning
       warning("You have indicated a metastable state of " + pyne::to_str(ssss) + ". Metastable state above 5, possibly unphysical. ");
     }
-    return (zzz * 10000000) + (aaa * 10000) + (nuc % 10);
+    return (zzz*10000000) + (aaa*10000) + (nuc%10);
   } else if (aaa <= zzz && zzz <= aaa * 7 && 0 < zz_name.count(aaa)) {
     // Cinder-form (aaazzzm), ie 2350920
-    if (5 < ssss) {
-      // Unphysical metastable state warning
+    if (5 < ssss){
+    // Unphysical metastable state warning
       warning("You have indicated a metastable state of " + pyne::to_str(ssss) + ". Metastable state above 5, possibly unphysical. ");
     }
-    return (aaa * 10000000) + (zzz * 10000) + (nuc % 10);
+    return (aaa*10000000) + (zzz*10000) + (nuc%10);
   }
   //else if (aaassss == 0 && 0 == zz_name.count(nuc/1000) && 0 < zz_name.count(zzz))
   else if (aaassss == 0 && 0 < zz_name.count(zzz)) {
@@ -2755,7 +2759,7 @@ int pyne::nucname::id(int nuc) {
     return zzz * 10000000;
   }
 
-  if (nuc >= 1000000) {
+  if (nuc >= 1000000){
     // From now we assume no metastable info has been given.
     throw IndeterminateNuclideForm(nuc, "");
   }
@@ -2774,9 +2778,9 @@ int pyne::nucname::id(int nuc) {
     } else {
       // Nuclide in MCNP metastable form
       if (nuc == 95642)
-        return (95642 - 400) * 10000; // special case MCNP Am-242
+        return (95642 - 400)*10000;  // special case MCNP Am-242
       nuc = ((nuc - 400) * 10000) + 1;
-      while (3.0 < (float ((nuc / 10000) % 1000) / float (nuc / 10000000)))
+      while (3.0 < (float ((nuc/10000)%1000) / float (nuc/10000000)))
         nuc -= 999999;
       return nuc;
     }
@@ -2793,8 +2797,8 @@ int pyne::nucname::id(int nuc) {
   throw IndeterminateNuclideForm(nuc, "");
 }
 
-int pyne::nucname::id(const char* nuc) {
-  std::string newnuc(nuc);
+int pyne::nucname::id(const char * nuc) {
+  std::string newnuc (nuc);
   return id(newnuc);
 }
 
@@ -2809,16 +2813,16 @@ int pyne::nucname::id(std::string nuc) {
   if (dash1 == npos)
     dash2 = npos;
   else
-    dash2 = nuc.find("-", dash1 + 1);
+    dash2 = nuc.find("-", dash1+1);
 
   // nuc must be at least 4 characters or greater if it is in ZZLLAAAM form.
   if (nuc.length() >= 5 && dash1 != npos && dash2 != npos) {
     // Nuclide most likely in ZZLLAAAM Form, only form that contains two "-"'s.
     std::string zz = nuc.substr(0, dash1);
-    std::string ll = nuc.substr(dash1 + 1, dash2);
+    std::string ll = nuc.substr(dash1+1, dash2);
     int zz_int = to_int(zz);
     // Verifying that the LL and ZZ point to the same element as secondary
-    if (znum(ll) != zz_int)
+    if(znum(ll) != zz_int)
       throw NotANuclide(nuc, "mismatched znum and chemical symbol");
     return zzllaaam_to_id(nuc);
   }
@@ -2829,7 +2833,7 @@ int pyne::nucname::id(std::string nuc) {
   int nuclen = nucstr.length();
 
   if (pyne::contains_substring(pyne::digits, nucstr.substr(0, 1))) {
-    if (pyne::contains_substring(pyne::digits, nucstr.substr(nuclen - 1, nuclen))) {
+    if (pyne::contains_substring(pyne::digits, nucstr.substr(nuclen-1, nuclen))) {
       // Nuclide must actually be an integer that
       // just happens to be living in string form.
       newnuc = pyne::to_int(nucstr);
@@ -2875,7 +2879,7 @@ int pyne::nucname::id(std::string nuc) {
       throw NotANuclide(nucstr, newnuc);
 
     // Add the Z-number
-    elem_name = pyne::remove_characters(nucstr.substr(0, nuclen - 1), pyne::digits);
+    elem_name = pyne::remove_characters(nucstr.substr(0, nuclen-1), pyne::digits);
     elem_name = pyne::capitalize(elem_name);
     if (0 < name_zz.count(elem_name))
       newnuc = (10000000 * name_zz[elem_name]) + newnuc;
@@ -2897,13 +2901,14 @@ bool pyne::nucname::iselement(std::string nuc) {
   int n;
   try {
     n = id(nuc);
-  } catch (NotANuclide) {
+  }
+  catch(NotANuclide) {
     return false;
   }
   return iselement(n);
 }
 
-bool pyne::nucname::iselement(const char* nuc) {
+bool pyne::nucname::iselement(const char * nuc) {
   return iselement(std::string(nuc));
 }
 
@@ -2911,7 +2916,8 @@ bool pyne::nucname::iselement(int nuc) {
   int n;
   try {
     n = id(nuc);
-  } catch (NotANuclide) {
+  }
+  catch(NotANuclide) {
     return false;
   }
 
@@ -2956,8 +2962,8 @@ std::string pyne::nucname::name(int nuc) {
 
 
 
-std::string pyne::nucname::name(const char* nuc) {
-  std::string newnuc(nuc);
+std::string pyne::nucname::name(const char * nuc) {
+  std::string newnuc (nuc);
   return name(newnuc);
 }
 
@@ -2974,7 +2980,7 @@ int pyne::nucname::znum(int nuc) {
   return id(nuc) / 10000000;
 }
 
-int pyne::nucname::znum(const char* nuc) {
+int pyne::nucname::znum(const char * nuc) {
   return id(nuc) / 10000000;
 }
 
@@ -2989,7 +2995,7 @@ int pyne::nucname::anum(int nuc) {
   return (id(nuc) / 10000) % 1000;
 }
 
-int pyne::nucname::anum(const char* nuc) {
+int pyne::nucname::anum(const char * nuc) {
   return (id(nuc) / 10000) % 1000;
 }
 
@@ -3004,7 +3010,7 @@ int pyne::nucname::snum(int nuc) {
   return id(nuc) % 10000;
 }
 
-int pyne::nucname::snum(const char* nuc) {
+int pyne::nucname::snum(const char * nuc) {
   return id(nuc) % 10000;
 }
 
@@ -3021,12 +3027,12 @@ int pyne::nucname::zzaaam(int nuc) {
   int ssss = nucid % 10000;
   if (10 <= ssss)
     ssss = 9;
-  return zzzaaa * 10 + ssss;
+  return zzzaaa*10 + ssss;
 }
 
 
-int pyne::nucname::zzaaam(const char* nuc) {
-  std::string newnuc(nuc);
+int pyne::nucname::zzaaam(const char * nuc) {
+  std::string newnuc (nuc);
   return zzaaam(newnuc);
 }
 
@@ -3037,11 +3043,11 @@ int pyne::nucname::zzaaam(std::string nuc) {
 
 
 int pyne::nucname::zzaaam_to_id(int nuc) {
-  return (nuc / 10) * 10000 + (nuc % 10);
+  return (nuc/10)*10000 + (nuc%10);
 }
 
 
-int pyne::nucname::zzaaam_to_id(const char* nuc) {
+int pyne::nucname::zzaaam_to_id(const char * nuc) {
   return zzaaam_to_id(std::string(nuc));
 }
 
@@ -3055,14 +3061,14 @@ int pyne::nucname::zzaaam_to_id(std::string nuc) {
 /************************/
 int pyne::nucname::zzzaaa(int nuc) {
   int nucid = id(nuc);
-  int zzzaaa = nucid / 10000;
+  int zzzaaa = nucid/10000;
 
   return zzzaaa;
 }
 
 
-int pyne::nucname::zzzaaa(const char* nuc) {
-  std::string newnuc(nuc);
+int pyne::nucname::zzzaaa(const char * nuc) {
+  std::string newnuc (nuc);
   return zzzaaa(newnuc);
 }
 
@@ -3073,11 +3079,11 @@ int pyne::nucname::zzzaaa(std::string nuc) {
 
 
 int pyne::nucname::zzzaaa_to_id(int nuc) {
-  return (nuc) * 10000;
+  return (nuc)*10000;
 }
 
 
-int pyne::nucname::zzzaaa_to_id(const char* nuc) {
+int pyne::nucname::zzzaaa_to_id(const char * nuc) {
   return zzzaaa_to_id(std::string(nuc));
 }
 
@@ -3118,8 +3124,8 @@ std::string pyne::nucname::zzllaaam(int nuc) {
 }
 
 
-std::string pyne::nucname::zzllaaam(const char* nuc) {
-  std::string newnuc(nuc);
+std::string pyne::nucname::zzllaaam(const char * nuc) {
+  std::string newnuc (nuc);
   return zzllaaam(newnuc);
 }
 
@@ -3129,7 +3135,7 @@ std::string pyne::nucname::zzllaaam(std::string nuc) {
 }
 
 
-int pyne::nucname::zzllaaam_to_id(const char* nuc) {
+int pyne::nucname::zzllaaam_to_id(const char * nuc) {
   return zzllaaam_to_id(std::string(nuc));
 }
 
@@ -3145,7 +3151,7 @@ int pyne::nucname::zzllaaam_to_id(std::string nuc) {
   // Removing first two characters (redundant), for 1 digit nuclides, such
   // as 2-He-4, the first slash will be removed, and the second attempt to
   // remove the second slash will do nothing.
-  nucstr.erase(0, 2);
+  nucstr.erase(0,2);
   nucstr = pyne::remove_substring(nucstr, "-");
   // Does nothing if nuclide is short, otherwise removes the second "-" instance
   nucstr = pyne::remove_substring(nucstr, "-");
@@ -3172,7 +3178,7 @@ int pyne::nucname::zzllaaam_to_id(std::string nuc) {
     throw NotANuclide(nucstr, nucid);
 
   // Add the Z-number
-  elem_name = pyne::remove_characters(nucstr.substr(0, nuclen - 1), pyne::digits);
+  elem_name = pyne::remove_characters(nucstr.substr(0, nuclen-1), pyne::digits);
   elem_name = pyne::capitalize(elem_name);
   if (0 < name_zz.count(elem_name))
     nucid = (10000000 * name_zz[elem_name]) + nucid;
@@ -3202,8 +3208,8 @@ int pyne::nucname::mcnp(int nuc) {
 
 
 
-int pyne::nucname::mcnp(const char* nuc) {
-  std::string newnuc(nuc);
+int pyne::nucname::mcnp(const char * nuc) {
+  std::string newnuc (nuc);
   return mcnp(newnuc);
 }
 
@@ -3230,9 +3236,9 @@ int pyne::nucname::mcnp_to_id(int nuc) {
     } else {
       // Nuclide in MCNP metastable form
       if (nuc == 95642)
-        return (95642 - 400) * 10000; // special case MCNP Am-242
+        return (95642 - 400)*10000;  // special case MCNP Am-242
       nuc = ((nuc - 400) * 10000) + 1;
-      while (3.0 < (float ((nuc / 10000) % 1000) / float (nuc / 10000000)))
+      while (3.0 < (float ((nuc/10000)%1000) / float (nuc/10000000)))
         nuc -= 999999;
       return nuc;
     }
@@ -3243,13 +3249,86 @@ int pyne::nucname::mcnp_to_id(int nuc) {
 }
 
 
-int pyne::nucname::mcnp_to_id(const char* nuc) {
+int pyne::nucname::mcnp_to_id(const char * nuc) {
   return mcnp_to_id(std::string(nuc));
 }
 
 
 int pyne::nucname::mcnp_to_id(std::string nuc) {
   return mcnp_to_id(pyne::to_int(nuc));
+}
+
+/************************/
+/*** openmc functions ***/
+/************************/
+std::string pyne::nucname::openmc(int nuc) {
+  std::string nucname = name(nuc);
+
+  // check aaa value
+  if (iselement(nuc)) {
+    nucname.append("0");
+  }
+
+  // format metadata
+  if ('M' == nucname.back()) {
+    nucname.back() = '_';
+    nucname.append("m");
+    int meta_id = snum(nuc);
+    std::string meta_str = std::to_string(meta_id);
+    nucname.append(meta_str);
+  }
+  return nucname;
+}
+
+std::string pyne::nucname::openmc(const char * nuc) {
+  std::string newnuc (nuc);
+  return openmc(newnuc);
+}
+
+std::string pyne::nucname::openmc(std::string nuc) {
+  return openmc(id(nuc));
+}
+
+//
+// OPENMC -> id
+//
+int pyne::nucname::openmc_to_id(const char * nuc) {
+  return openmc_to_id(std::string(nuc));
+}
+
+int pyne::nucname::openmc_to_id(std::string nuc) {
+  std::string nucname;
+  name_zz_t zznames = get_name_zz();
+
+  // first two characters
+  std::string::iterator aaa_start;
+  int zzz = 0;
+  if (zznames.count(nuc.substr(0,2)) == 1) {
+    aaa_start = nuc.begin() + 2;
+    zzz = zznames[nuc.substr(0,2)];
+  }
+  // then try only the first
+  else if (zznames.count(nuc.substr(0,1)) == 1) {
+    aaa_start = nuc.begin() + 1;
+    zzz = zznames[nuc.substr(0,1)];
+  } else {
+    throw NotANuclide(nuc, "Not in the OpenMC format");
+  }
+
+  // set aaa - stop on "-" if the character exists
+  std::string::iterator aaa_end = std::find(nuc.begin(), nuc.end(), '_');
+  int aaa = pyne::to_int(nuc.substr(aaa_start - nuc.begin(), aaa_end - aaa_start));
+
+  // check for metastable state
+  int m = 0;
+  if (aaa_end != nuc.end()) {
+    std::string::iterator m_start = aaa_end + 2; // move forward once to skip "_m" characters
+    m = pyne::to_int(nuc.substr(m_start - nuc.begin(), nuc.end() - m_start));
+  }
+
+  // form integer id and return
+  return (zzz * 10000000) + (aaa * 10000) + m;
+
 }
 
 
@@ -3275,7 +3354,7 @@ int pyne::nucname::fluka_to_id(std::string name) {
   return fluka_zz[name];
 }
 
-int pyne::nucname::fluka_to_id(char* name) {
+int pyne::nucname::fluka_to_id(char * name) {
   return fluka_to_id(std::string(name));
 }
 
@@ -3320,8 +3399,8 @@ std::string pyne::nucname::serpent(int nuc) {
 }
 
 
-std::string pyne::nucname::serpent(const char* nuc) {
-  std::string newnuc(nuc);
+std::string pyne::nucname::serpent(const char * nuc) {
+  std::string newnuc (nuc);
   return serpent(newnuc);
 }
 
@@ -3339,7 +3418,7 @@ std::string pyne::nucname::serpent(std::string nuc) {
 //}
 
 
-int pyne::nucname::serpent_to_id(const char* nuc) {
+int pyne::nucname::serpent_to_id(const char * nuc) {
   return serpent_to_id(std::string(nuc));
 }
 
@@ -3376,7 +3455,7 @@ int pyne::nucname::serpent_to_id(std::string nuc) {
     throw NotANuclide(nucstr, nucid);
 
   // Add the Z-number
-  elem_name = pyne::remove_characters(nucstr.substr(0, nuclen - 1), pyne::digits);
+  elem_name = pyne::remove_characters(nucstr.substr(0, nuclen-1), pyne::digits);
   elem_name = pyne::capitalize(elem_name);
   if (0 < name_zz.count(elem_name))
     nucid = (10000000 * name_zz[elem_name]) + nucid;
@@ -3423,8 +3502,8 @@ std::string pyne::nucname::nist(int nuc) {
 }
 
 
-std::string pyne::nucname::nist(const char* nuc) {
-  std::string newnuc(nuc);
+std::string pyne::nucname::nist(const char * nuc) {
+  std::string newnuc (nuc);
   return nist(newnuc);
 }
 
@@ -3442,7 +3521,7 @@ std::string pyne::nucname::nist(std::string nuc) {
 // NON-EXISTANT
 //};
 
-int pyne::nucname::nist_to_id(const char* nuc) {
+int pyne::nucname::nist_to_id(const char * nuc) {
   return nist_to_id(std::string(nuc));
 }
 
@@ -3488,13 +3567,13 @@ int pyne::nucname::cinder(int nuc) {
   int aaa = aaassss / 10000;
   if (10 <= ssss)
     ssss = 9;
-  return (aaa * 10000) + (zzz * 10) + ssss;
+  return (aaa*10000) + (zzz*10) + ssss;
 }
 
 
 
-int pyne::nucname::cinder(const char* nuc) {
-  std::string newnuc(nuc);
+int pyne::nucname::cinder(const char * nuc) {
+  std::string newnuc (nuc);
   return cinder(newnuc);
 }
 
@@ -3516,7 +3595,7 @@ int pyne::nucname::cinder_to_id(int nuc) {
 }
 
 
-int pyne::nucname::cinder_to_id(const char* nuc) {
+int pyne::nucname::cinder_to_id(const char * nuc) {
   return cinder_to_id(std::string(nuc));
 }
 
@@ -3548,12 +3627,12 @@ std::string pyne::nucname::alara(int nuc) {
   // Add LL, in lower case
   ll += zz_name[zzz];
 
-  for (int i = 0; ll[i] != '\0'; i++)
+  for(int i = 0; ll[i] != '\0'; i++)
     ll[i] = tolower(ll[i]);
   newnuc += ll;
 
   // Add A-number
-  if (0 < aaassss) {
+  if (0 < aaassss){
     newnuc += ":";
     newnuc += pyne::to_str(aaa);
   }
@@ -3563,8 +3642,8 @@ std::string pyne::nucname::alara(int nuc) {
 }
 
 
-std::string pyne::nucname::alara(const char* nuc) {
-  std::string newnuc(nuc);
+std::string pyne::nucname::alara(const char * nuc) {
+  std::string newnuc (nuc);
   return alara(newnuc);
 }
 
@@ -3583,7 +3662,7 @@ std::string pyne::nucname::alara(std::string nuc) {
 //}
 
 
-int pyne::nucname::alara_to_id(const char* nuc) {
+int pyne::nucname::alara_to_id(const char * nuc) {
   return alara_to_id(std::string(nuc));
 }
 
@@ -3631,8 +3710,8 @@ int pyne::nucname::sza(int nuc) {
 }
 
 
-int pyne::nucname::sza(const char* nuc) {
-  std::string newnuc(nuc);
+int pyne::nucname::sza(const char * nuc) {
+  std::string newnuc (nuc);
   return sza(newnuc);
 }
 
@@ -3645,16 +3724,16 @@ int pyne::nucname::sza(std::string nuc) {
 int pyne::nucname::sza_to_id(int nuc) {
   int sss = nuc / 1000000;
   int zzzaaa = nuc % 1000000;
-  if (5 < sss) {
-    // Unphysical metastable state warning
-    warning("You have indicated a metastable state of " + pyne::to_str(sss) + ". Metastable state above 5, possibly unphysical. ");
+  if (5 < sss){
+  // Unphysical metastable state warning
+   warning("You have indicated a metastable state of " + pyne::to_str(sss) + ". Metastable state above 5, possibly unphysical. ");
   }
   return zzzaaa * 10000 + sss;
 }
 
 
-int pyne::nucname::sza_to_id(const char* nuc) {
-  std::string newnuc(nuc);
+int pyne::nucname::sza_to_id(const char * nuc) {
+  std::string newnuc (nuc);
   return sza_to_id(newnuc);
 }
 
@@ -3664,22 +3743,21 @@ int pyne::nucname::sza_to_id(std::string nuc) {
 }
 
 
-void pyne::nucname::_load_state_map() {
-  for (int i = 0; i < TOTAL_STATE_MAPS; ++i) {
-    state_id_map[map_nuc_ids[i]] = map_metastable[i];
-  }
+void pyne::nucname::_load_state_map(){
+    for (int i = 0; i < TOTAL_STATE_MAPS; ++i) {
+       state_id_map[map_nuc_ids[i]] = map_metastable[i];
+    }
 }
 
 int pyne::nucname::state_id_to_id(int state) {
   int zzzaaa = (state / 10000) * 10000;
   int state_number = state % 10000;
-  if (state_number == 0)
-    return state;
+  if (state_number == 0) return state;
   std::map<int, int>::iterator nuc_iter, nuc_end;
 
   nuc_iter = state_id_map.find(state);
   nuc_end = state_id_map.end();
-  if (nuc_iter != nuc_end) {
+  if (nuc_iter != nuc_end){
     int m = (*nuc_iter).second;
     return zzzaaa + m;
   }
@@ -3688,31 +3766,29 @@ int pyne::nucname::state_id_to_id(int state) {
     _load_state_map();
     return state_id_to_id(state);
   }
-  throw IndeterminateNuclideForm(state, "no matching metastable state");
+  return -1;
 }
 
 
 int pyne::nucname::id_to_state_id(int nuc_id) {
   int zzzaaa = (nuc_id / 10000) * 10000;
   int state = nuc_id % 10000;
-  if (state == 0)
-    return nuc_id;
+  if (state == 0) return nuc_id;
   std::map<int, int>::iterator nuc_iter, nuc_end, it;
 
-  nuc_iter = state_id_map.lower_bound(nuc_id);
-  nuc_end = state_id_map.upper_bound(nuc_id + 10000);
-  for (it = nuc_iter; it != nuc_end; ++it) {
+  nuc_iter = state_id_map.lower_bound(zzzaaa);
+  nuc_end = state_id_map.upper_bound(zzzaaa + 9999);
+  for (it = nuc_iter; it!= nuc_end; ++it){
     if (state == it->second) {
       return it->first;
     }
   }
-  int m = (*nuc_iter).second;
 
   if (state_id_map.empty())  {
     _load_state_map();
     return id_to_state_id(nuc_id);
   }
-  throw IndeterminateNuclideForm(state, "no matching state id");
+  return -1;
 }
 
 
@@ -3723,7 +3799,7 @@ int pyne::nucname::id_to_state_id(int nuc_id) {
 // ENSDF  -> Id
 //
 
-int pyne::nucname::ensdf_to_id(const char* nuc) {
+int pyne::nucname::ensdf_to_id(const char * nuc) {
   return ensdf_to_id(std::string(nuc));
 }
 
@@ -3733,7 +3809,7 @@ int pyne::nucname::ensdf_to_id(std::string nuc) {
   } else if (std::isdigit(nuc[3])) {
     int aaa = to_int(nuc.substr(0, 3));
     int zzz;
-    std::string xx_str = nuc.substr(3, 2);
+    std::string xx_str = nuc.substr(3,2);
     zzz = to_int(xx_str) + 100;
     int nid = 10000 * aaa + 10000000 * zzz;
     return nid;
@@ -3742,6 +3818,7 @@ int pyne::nucname::ensdf_to_id(std::string nuc) {
   }
 
 }
+
 
 //
 // end of src/nucname.cpp
@@ -12924,7 +13001,7 @@ std::string valueToString(UInt value) {
 
 std::string valueToString(double value) {
   char buffer[32];
-#if defined(_MSC_VER) && defined(__STDC_SECURE_LIB__) // Use secure version with visual studio 2005 to avoid warning. 
+#if defined(_MSC_VER) && defined(__STDC_SECURE_LIB__) // Use secure version with visual studio 2005 to avoid warning.
   sprintf_s(buffer, sizeof(buffer), "%#.16g", value);
 #else
   sprintf(buffer, "%#.16g", value);
@@ -13807,6 +13884,7 @@ CustomWriter::unindent() {
 #include <stdexcept>
 
 #ifndef PYNE_IS_AMALGAMATED
+#include "transmuters.h"
 #include "material.h"
 #endif
 
@@ -13861,10 +13939,10 @@ void pyne::Material::_load_comp_protocol0(hid_t db, std::string datapath, int ro
   // Iterate over datasets in the group.
   for (int matg = 0; matg < matG; matg++) {
     nuckeylen = 1 + H5Lget_name_by_idx(matgroup, ".", H5_INDEX_NAME, H5_ITER_INC, matg,
-                                       NULL, 0, H5P_DEFAULT);
-    char* nkey = new char[nuckeylen];
+                                        NULL, 0, H5P_DEFAULT);
+    char * nkey = new char[nuckeylen];
     nuckeylen = H5Lget_name_by_idx(matgroup, ".", H5_INDEX_NAME, H5_ITER_INC, matg,
-                                   nkey, nuckeylen, H5P_DEFAULT);
+                                    nkey, nuckeylen, H5P_DEFAULT);
     nuckey = nkey;
     nucset = H5Dopen2(matgroup, nkey, H5P_DEFAULT);
     nucvalue = h5wrap::get_array_index<double>(nucset, row);
@@ -13904,7 +13982,7 @@ void pyne::Material::_load_comp_protocol1(hid_t db, std::string datapath, int ro
   hsize_t nuc_attr_len = nuc_info.data_size;
   hid_t str_attr = H5Tcopy(H5T_C_S1);
   H5Tset_size(str_attr, nuc_attr_len);
-  char* nucpathbuf = new char [nuc_attr_len];
+  char * nucpathbuf = new char [nuc_attr_len];
   H5Aread(nuc_attr, str_attr, nucpathbuf);
   nucpath = std::string(nucpathbuf, nuc_attr_len);
   delete[] nucpathbuf;
@@ -13923,7 +14001,7 @@ void pyne::Material::_load_comp_protocol1(hid_t db, std::string datapath, int ro
   hid_t mem_space = H5Screate_simple(1, data_count, NULL);
 
   // Get material type
-  size_t material_data_size = sizeof(pyne::material_data) + sizeof(double) * (nuc_size - 1);
+  size_t material_data_size = sizeof(pyne::material_data) + sizeof(double)*(nuc_size-1);
   hid_t desc = H5Tcreate(H5T_COMPOUND, material_data_size);
   hid_t comp_values_array_type = H5Tarray_create2(H5T_NATIVE_DOUBLE, 1, nuc_dims);
 
@@ -13936,7 +14014,7 @@ void pyne::Material::_load_comp_protocol1(hid_t db, std::string datapath, int ro
   H5Tinsert(desc, "comp", HOFFSET(pyne::material_data, comp), comp_values_array_type);
 
   // make the data array, have to over-allocate
-  material_data* mat_data = new material_data [material_data_size];
+  material_data * mat_data = new material_data [material_data_size];
 
   // Finally, get data and put in on this instance
   H5Dread(data_set, desc, mem_space, data_hyperslab, H5P_DEFAULT, mat_data);
@@ -13945,7 +14023,7 @@ void pyne::Material::_load_comp_protocol1(hid_t db, std::string datapath, int ro
   density = (*mat_data).density;
   atoms_per_molecule = (*mat_data).atoms_per_mol;
   for (int i = 0; i < nuc_size; i++)
-    comp[nuclides[i]] = (double)(*mat_data).comp[i];
+    comp[nuclides[i]] = (double) (*mat_data).comp[i];
 
   delete[] mat_data;
   H5Tclose(str_attr);
@@ -13973,7 +14051,7 @@ void pyne::Material::_load_comp_protocol1(hid_t db, std::string datapath, int ro
 
   // convert to in-memory JSON
   Json::Reader reader;
-  reader.parse((char*) attrdata[0].p, (char*) attrdata[0].p + attrdata[0].len, metadata, false);
+  reader.parse((char *) attrdata[0].p, (char *) attrdata[0].p+attrdata[0].len, metadata, false);
 
   // close attr data objects
   H5Fflush(db, H5F_SCOPE_GLOBAL);
@@ -13989,9 +14067,9 @@ void pyne::Material::_load_comp_protocol1(hid_t db, std::string datapath, int ro
 
 
 
-void pyne::Material::from_hdf5(char* filename, char* datapath, int row, int protocol) {
-  std::string fname(filename);
-  std::string dpath(datapath);
+void pyne::Material::from_hdf5(char * filename, char * datapath, int row, int protocol) {
+  std::string fname (filename);
+  std::string dpath (datapath);
   from_hdf5(fname, dpath, row, protocol);
 }
 
@@ -14014,7 +14092,7 @@ void pyne::Material::from_hdf5(std::string filename, std::string datapath, int r
   //Set file access properties so it closes cleanly
   hid_t fapl;
   fapl = H5Pcreate(H5P_FILE_ACCESS);
-  H5Pset_fclose_degree(fapl, H5F_CLOSE_STRONG);
+  H5Pset_fclose_degree(fapl,H5F_CLOSE_STRONG);
   // Open the database
   hid_t db = H5Fopen(filename.c_str(), H5F_ACC_RDONLY, fapl);
 
@@ -14044,10 +14122,10 @@ void pyne::Material::from_hdf5(std::string filename, std::string datapath, int r
 
 
 
-void pyne::Material::write_hdf5(char* filename, char* datapath, char* nucpath, float row, int chunksize) {
-  std::string fname(filename);
-  std::string groupname(datapath);
-  std::string nuclist(nucpath);
+void pyne::Material::write_hdf5(char * filename, char * datapath, char * nucpath, float row, int chunksize) {
+  std::string fname (filename);
+  std::string groupname (datapath);
+  std::string nuclist (nucpath);
   write_hdf5(fname, groupname, nuclist, row, chunksize);
 }
 
@@ -14063,7 +14141,7 @@ void pyne::Material::write_hdf5(std::string filename, std::string datapath,
   //Set file access properties so it closes cleanly
   hid_t fapl;
   fapl = H5Pcreate(H5P_FILE_ACCESS);
-  H5Pset_fclose_degree(fapl, H5F_CLOSE_STRONG);
+  H5Pset_fclose_degree(fapl,H5F_CLOSE_STRONG);
   // Create new/open datafile.
   hid_t db;
   if (pyne::file_exists(filename)) {
@@ -14071,7 +14149,8 @@ void pyne::Material::write_hdf5(std::string filename, std::string datapath,
     if (!ish5)
       throw h5wrap::FileNotHDF5(filename);
     db = H5Fopen(filename.c_str(), H5F_ACC_RDWR, fapl);
-  } else
+  }
+  else
     db = H5Fcreate(filename.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, fapl);
 
   //
@@ -14114,7 +14193,7 @@ void pyne::Material::write_hdf5(std::string filename, std::string datapath,
   hsize_t data_max_dims[1] = {H5S_UNLIMITED};
   hsize_t data_offset[1] = {0};
 
-  size_t material_data_size = sizeof(pyne::material_data) + sizeof(double) * (nuc_size - 1);
+  size_t material_data_size = sizeof(pyne::material_data) + sizeof(double)*(nuc_size-1);
   hid_t desc = H5Tcreate(H5T_COMPOUND, material_data_size);
   hid_t comp_values_array_type = H5Tarray_create2(H5T_NATIVE_DOUBLE, 1, nuc_dims);
 
@@ -14127,7 +14206,7 @@ void pyne::Material::write_hdf5(std::string filename, std::string datapath,
   H5Tinsert(desc, "comp", HOFFSET(pyne::material_data, comp),
             comp_values_array_type);
 
-  material_data* mat_data  = new material_data[material_data_size];
+  material_data * mat_data  = new material_data[material_data_size];
   (*mat_data).mass = mass;
   (*mat_data).density = density;
   (*mat_data).atoms_per_mol = atoms_per_molecule;
@@ -14169,7 +14248,7 @@ void pyne::Material::write_hdf5(std::string filename, std::string datapath,
 
     // Create the data set
     data_set = H5Dcreate2(db, datapath.c_str(), desc, data_space, H5P_DEFAULT,
-                          data_set_params, H5P_DEFAULT);
+                            data_set_params, H5P_DEFAULT);
     H5Dset_extent(data_set, data_dims);
 
     // Add attribute pointing to nuc path
@@ -14235,13 +14314,13 @@ void pyne::Material::write_hdf5(std::string filename, std::string datapath,
 
     hvl_t attrfillvalue [1];
     attrfillvalue[0].len = 3;
-    attrfillvalue[0].p = (char*) "{}\n";
+    attrfillvalue[0].p = (char *) "{}\n";
     H5Pset_fill_value(metadataetparams, attrtype, &attrfillvalue);
 
     // make dataset
     metadatapace = H5Screate_simple(1, data_dims, data_max_dims);
     metadataet = H5Dcreate2(db, attrpath.c_str(), attrtype, metadatapace,
-                            H5P_DEFAULT, metadataetparams, H5P_DEFAULT);
+                         H5P_DEFAULT, metadataetparams, H5P_DEFAULT);
     H5Dset_extent(metadataet, data_dims);
     H5Pclose(metadataetparams);
   }
@@ -14250,7 +14329,7 @@ void pyne::Material::write_hdf5(std::string filename, std::string datapath,
   hvl_t attrdata [1];
   Json::FastWriter writer;
   std::string metadatatr = writer.write(metadata);
-  attrdata[0].p = (char*) metadatatr.c_str();
+  attrdata[0].p = (char *) metadatatr.c_str();
   attrdata[0].len = metadatatr.length();
 
   // write the attr
@@ -14272,6 +14351,124 @@ void pyne::Material::write_hdf5(std::string filename, std::string datapath,
   delete[] mat_data;
 }
 
+std::string pyne::Material::openmc(std::string frac_type) {
+  std::ostringstream oss;
+
+  std::set<int> carbon_set; carbon_set.insert(nucname::id("C"));
+  pyne::Material temp_mat = this->expand_elements(carbon_set);
+
+  // vars for consistency
+  std::string new_quote = "\"";
+  std::string end_quote = "\" ";
+  std::string indent = "  ";
+
+  // open the material element
+  oss << "<material id=" ;
+
+  // add the mat number
+  if (temp_mat.metadata.isMember("mat_number")) {
+    int mat_num = temp_mat.metadata["mat_number"].asInt();
+    oss << new_quote << mat_num << end_quote;
+  }
+  // mat numbers are required for openmc
+  else {
+    throw pyne::ValueError("No material number found in metadata. This is not valid for use in OpenMC.");
+    oss << new_quote << "?" << end_quote;
+  }
+
+  // add name if specified
+  if (temp_mat.metadata.isMember("mat_name")) {
+    oss << "name=" << new_quote << temp_mat.metadata["mat_name"].asString() << end_quote;
+  }
+
+  // close the material tag
+  oss << ">";
+  // new line
+  oss << std::endl;
+
+  //indent
+  oss << indent;
+
+  // specify density
+  oss << "<density ";
+    // if density is negtaive, report to user
+  if (temp_mat.density < 0.0) {
+    throw pyne::ValueError("A density < 0.0 was found. This is not valid for use in OpenMC.");
+  }
+  std::string density_str = std::to_string(temp_mat.density);
+  // remove trailing zeros
+  density_str.erase( density_str.find_last_not_of('0') + 1, std::string::npos);
+  oss << "value=" <<  std::fixed << new_quote << density_str << end_quote;
+  oss << "units=" << new_quote << "g/cc" << end_quote << "/>";
+  // new line
+  oss << std::endl;
+
+  std::map<int, double> fracs;
+  std::string frac_attrib;
+  if(frac_type == "atom") {
+    fracs = temp_mat.to_atom_frac();
+    frac_attrib = "ao=";
+  }
+  else {
+    fracs = temp_mat.comp;
+    frac_attrib = "wo=";
+  }
+
+  // add nuclides
+  for(comp_map::iterator f = fracs.begin(); f != fracs.end(); f++) {
+    if (f->second == 0.0) { continue; }
+    //indent
+    oss << "  ";
+    // start a new nuclide element
+    oss << "<nuclide name=" << new_quote;
+    oss << pyne::nucname::openmc(f->first);
+    oss << end_quote;
+    oss << frac_attrib;
+    oss << std::setprecision(4) << std::scientific << new_quote << f->second << end_quote;
+    oss << "/>";
+    // new line
+    oss << std::endl;
+  }
+
+  // other OpenMC material properties
+  if(temp_mat.metadata.isMember("sab")) {
+    oss << indent;
+    oss << "<sab name=";
+    oss << new_quote << temp_mat.metadata["sab"].asString() << end_quote;
+    oss << "/>";
+    oss << std::endl;
+  }
+
+  if(temp_mat.metadata.isMember("temperature")) {
+    oss << indent;
+    oss << "<temperature>";
+    oss << new_quote << temp_mat.metadata["temperature"].asString() << end_quote;
+    oss << "</temperature>";
+    oss << std::endl;
+  }
+
+  if(temp_mat.metadata.isMember("macroscopic")) {
+    oss << indent;
+    oss << "<macroscopic name=";
+    oss << new_quote << temp_mat.metadata["macroscropic"].asString() << end_quote;
+    oss << "/>";
+    oss << std::endl;
+  }
+
+  if(temp_mat.metadata.isMember("isotropic")) {
+    oss << indent;
+    oss << "<isotropic>";
+    oss << new_quote << temp_mat.metadata["isotropic"].asString() << end_quote;
+    oss << "</isotropic>";
+    oss << std::endl;
+  }
+
+  // close the material node
+  oss << "</material>" << std::endl;
+
+  return oss.str();
+}
+
 std::string pyne::Material::mcnp(std::string frac_type) {
   //////////////////// Begin card creation ///////////////////////
   std::ostringstream oss;
@@ -14281,13 +14478,13 @@ std::string pyne::Material::mcnp(std::string frac_type) {
   }
   // 'density'
   if (density != -1.0) {
-    std::stringstream ds;
-    ds << std::setprecision(1) << std::fixed << "C density = " << density << std::endl;
-    oss << ds.str();
+     std::stringstream ds;
+     ds << std::setprecision(1) << std::fixed << "C density = " << density << std::endl;
+     oss << ds.str();
   }
   // 'source'
   if (metadata.isMember("source")) {
-    oss << "C source: " << metadata["source"].asString() << std::endl;
+     oss << "C source: " << metadata["source"].asString() << std::endl;
   }
   // Metadata comments
   if (metadata.isMember("comments")) {
@@ -14295,12 +14492,13 @@ std::string pyne::Material::mcnp(std::string frac_type) {
     // Include as is if short enough
     if (comment_string.length() <= 77) {
       oss << "C " << comment_string << std::endl;
-    } else { // otherwise create a remainder string and iterate/update it
-      oss << "C " << comment_string.substr(0, 77) << std::endl;
+    }
+    else { // otherwise create a remainder string and iterate/update it
+      oss << "C " << comment_string.substr(0,77) << std::endl;
       std::string remainder_string = comment_string.substr(77);
       while (remainder_string.length() > 77) {
-        oss << "C " << remainder_string.substr(0, 77) << std::endl;
-        remainder_string.erase(0, 77);
+        oss << "C " << remainder_string.substr(0,77) << std::endl;
+        remainder_string.erase(0,77);
       }
       if (remainder_string.length() > 0) {
         oss << "C " << remainder_string << std::endl;
@@ -14334,7 +14532,7 @@ std::string pyne::Material::mcnp(std::string frac_type) {
   std::stringstream ss;
   std::string nucmcnp;
   std::string table_item;
-  for (pyne::comp_iter i = fracs.begin(); i != fracs.end(); ++i) {
+  for(pyne::comp_iter i = fracs.begin(); i != fracs.end(); ++i) {
     if (i->second > 0.0) {
       // Clear first
       ss.str(std::string());
@@ -14347,14 +14545,14 @@ std::string pyne::Material::mcnp(std::string frac_type) {
       // Spaces are important for tests
       table_item = metadata["table_ids"][nucmcnp].asString();
       if (!table_item.empty()) {
-        oss << "     " << mcnp_id << "." << table_item << " ";
+	oss << "     " << mcnp_id << "." << table_item << " ";
       } else {
-        oss << "     " << mcnp_id << " ";
+	oss << "     " << mcnp_id << " ";
       }
       // The int needs a little formatting
       std::stringstream fs;
       fs << std::setprecision(4) << std::scientific << frac_sign << i->second \
-         << std::endl;
+	 << std::endl;
       oss << fs.str();
     }
   }
@@ -14365,7 +14563,7 @@ std::string pyne::Material::mcnp(std::string frac_type) {
 ///---------------------------------------------------------------------------//
 /// Create a set out of the static string array.
 std::set<std::string> fluka_builtin(pyne::fluka_mat_strings,
-                                    pyne::fluka_mat_strings + pyne::FLUKA_MAT_NUM);
+                                    pyne::fluka_mat_strings+pyne::FLUKA_MAT_NUM);
 
 ///---------------------------------------------------------------------------//
 /// not_fluka_builtin
@@ -14387,7 +14585,7 @@ std::string pyne::Material::fluka(int id, std::string frac_type) {
   if (comp.size() == 1) {
     rs << fluka_material_str(id);
   } else if (comp.size() > 1) {
-    // Compound
+  // Compound
     rs << fluka_compound_str(id, frac_type);
   } else {
     rs << "There is no nuclide information in the Material Object" << std::endl;
@@ -14415,7 +14613,7 @@ std::string pyne::Material::fluka_material_str(int id) {
   if (metadata.isMember("fluka_name")) {
     fluka_name = metadata["fluka_name"].asString();
   } else {  // Should be elemental
-    if (comp.size() > 1) {
+    if (comp.size() > 1 ) {
       std::cerr << "Error: this mix is a compound, there should be a fluka_name defined."
                 << std::endl;
       return ms.str();
@@ -14439,7 +14637,7 @@ std::string pyne::Material::fluka_material_str(int id) {
 /// This function is not called for a compound, but it is called on the
 /// material-ized components of compounds
 std::string pyne::Material::fluka_material_component(int fid, int nucid,
-                                                     std::string fluka_name) {
+                                               std::string fluka_name) {
   int znum = pyne::nucname::znum(nucid);
 
   double atomic_mass;
@@ -14458,24 +14656,24 @@ std::string pyne::Material::fluka_material_component(int fid, int nucid,
 ///---------------------------------------------------------------------------//
 /// Given all the info, return the Material string
 std::string pyne::Material::fluka_material_line(int znum, double atomic_mass,
-                                                int fid, std::string fluka_name) {
+                                          int fid, std::string fluka_name) {
   std::stringstream ls;
 
-  if (metadata.isMember("comments")) {
-    std::string comment = metadata["comments"].asString();
-    ls << "* " << comment;
-    ls << std::endl;
+  if (metadata.isMember("comments") ) {
+     std::string comment = metadata["comments"].asString();
+     ls << "* " << comment;
+     ls << std::endl;
   }
   ls << std::setw(10) << std::left << "MATERIAL";
   ls << std::setprecision(0) << std::fixed << std::showpoint <<
-     std::setw(10) << std::right << (float)znum;
+        std::setw(10) << std::right << (float)znum;
 
   ls << fluka_format_field(atomic_mass);
   // Note this is the current object density, and may or may not be meaningful
-  ls << fluka_format_field(std::sqrt(density * density));
+  ls << fluka_format_field(std::sqrt(density*density));
 
   ls << std::setprecision(0) << std::fixed << std::showpoint <<
-     std::setw(10) << std::right << (float)fid;
+        std::setw(10) << std::right << (float)fid;
   ls << std::setw(10) << std::right << "";
   ls << std::setw(10) << std::right << "";
   ls << std::setw(10) << std::left << fluka_name << std::endl;
@@ -14494,12 +14692,12 @@ std::string pyne::Material::fluka_material_line(int znum, double atomic_mass,
 std::string pyne::Material::fluka_format_field(float field) {
   std::stringstream ls;
   double intpart;
-  modf(field, &intpart);
+  modf (field, &intpart);
   if (field == intpart) {
     ls << std::setprecision(0) << std::fixed << std::showpoint
        << std::setw(10) << std::right << field;
   } else {
-    // This will print however many digits after the decimal, up to a max of six
+  // This will print however many digits after the decimal, up to a max of six
     ls.unsetf(std::ios::showpoint);
     ls.unsetf(std::ios::floatfield);
     ls.precision(6);
@@ -14585,7 +14783,7 @@ std::string pyne::Material::fluka_compound_str(int id, std::string frac_type) {
     nuc++;
     temp_s.str("");
 
-    if (nuc != comp.end()) {
+    if  (nuc != comp.end()) {
       temp_s << frac_sign << nuc->second;
       ss << std::setw(10) << std::right << temp_s.str();
       ss << std::setw(10) << std::right << nucname::fluka(nuc->first);
@@ -14600,13 +14798,13 @@ std::string pyne::Material::fluka_compound_str(int id, std::string frac_type) {
     ss << std::setw(10) << std::right << "";
     ss << std::setw(10) << std::left << compound_name;
     ss << std::endl;
-  }
+    }
 
   return ss.str();
 }
 
-void pyne::Material::from_text(char* filename) {
-  std::string fname(filename);
+void pyne::Material::from_text(char * filename) {
+  std::string fname (filename);
   from_text(fname);
 }
 
@@ -14624,13 +14822,13 @@ void pyne::Material::from_text(std::string filename) {
   comp.clear();
   std::string keystr, valstr;
 
-  while (!f.eof()) {
-    f >> keystr;
+  f >> keystr;
+  while ( !f.eof() ) {
 
     if (0 == keystr.length())
       continue;
 
-    if (keystr == "Mass") {
+    if (keystr == "Mass"){
       f >> valstr;
       mass = pyne::to_dbl(valstr);
     } else if (keystr == "Density") {
@@ -14642,23 +14840,28 @@ void pyne::Material::from_text(std::string filename) {
     } else if (pyne::nucname::isnuclide(keystr) ||
                pyne::nucname::iselement(keystr)) {
       f >> valstr;
-      comp[pyne::nucname::id(keystr)] = pyne::to_dbl(valstr);
+      if (comp.count(pyne::nucname::id(keystr))>0) {
+        comp[pyne::nucname::id(keystr)] += pyne::to_dbl(valstr);
+      } else {
+        comp[pyne::nucname::id(keystr)] = pyne::to_dbl(valstr);
+      }
     } else {
       getline(f, valstr);
-      valstr = valstr.substr(0, valstr.length() - 1);
-      metadata[keystr] = valstr;
-      continue;
-    }
-  }
+      valstr= valstr.substr(0, valstr.length()-1);
+      metadata[keystr]= valstr;
 
-  f.close();
-  norm_comp();
+    }
+    f >> keystr;
+   }
+
+   f.close();
+   norm_comp();
 }
 
 
 
-void pyne::Material::write_text(char* filename) {
-  std::string fname(filename);
+void pyne::Material::write_text(char * filename) {
+  std::string fname (filename);
   write_text(fname);
 }
 
@@ -14679,13 +14882,13 @@ void pyne::Material::write_text(std::string filename) {
   if (0 <= atoms_per_molecule)
     f << "APerM   " << atoms_per_molecule << "\n";
 
-  for (int i = 0; i < metadata.size(); i = i + 2) {
-    f << metadata.get(obj.at(i), "") << metadata.get(obj.at(i + 1), "");
+  for (int i=0; i < metadata.size(); i=i+2){
+    f <<metadata.get(obj.at(i), "") << metadata.get(obj.at(i+1), "");
   }
 
   std::string nuc_name;
-  for (pyne::comp_iter i = comp.begin(); i != comp.end(); i++) {
-    nuc_name = pyne::nucname::name(i->first) + "  ";
+  for(pyne::comp_iter i = comp.begin(); i != comp.end(); i++) {
+    nuc_name = pyne::nucname::name( i->first ) + "  ";
     while (nuc_name.length() < 8)
       nuc_name += " ";
     f << nuc_name << i->second << "\n";
@@ -14717,15 +14920,15 @@ Json::Value pyne::Material::dump_json() {
   json["density"] = density;
   json["atoms_per_molecule"] = atoms_per_molecule;
   json["metadata"] = metadata;
-  for (comp_iter i = comp.begin(); i != comp.end(); i++)
+  for(comp_iter i = comp.begin(); i != comp.end(); i++)
     jcomp[nucname::name(i->first)] = (i->second);
   json["comp"] = jcomp;
   return json;
 }
 
 
-void pyne::Material::from_json(char* filename) {
-  std::string fname(filename);
+void pyne::Material::from_json(char * filename) {
+  std::string fname (filename);
   from_json(fname);
 }
 
@@ -14733,7 +14936,7 @@ void pyne::Material::from_json(std::string filename) {
   if (!pyne::file_exists(filename))
     throw pyne::FileNotFound(filename);
   std::string s;
-  std::ifstream f(filename.c_str(), std::ios::in | std::ios::binary);
+  std::ifstream f (filename.c_str(), std::ios::in | std::ios::binary);
   f.seekg(0, std::ios::end);
   s.resize(f.tellg());
   f.seekg(0, std::ios::beg);
@@ -14746,8 +14949,8 @@ void pyne::Material::from_json(std::string filename) {
 }
 
 
-void pyne::Material::write_json(char* filename) {
-  std::string fname(filename);
+void pyne::Material::write_json(char * filename) {
+  std::string fname (filename);
   write_json(fname);
 }
 
@@ -14782,7 +14985,7 @@ pyne::Material::Material(pyne::comp_map cm, double m, double d, double apm,
   // Initializes the mass stream based on an isotopic component dictionary.
   comp = cm;
   mass = m;
-  density = d;
+  density=d;
   atoms_per_molecule = apm;
   metadata = attributes;
   if (!comp.empty())
@@ -14791,15 +14994,15 @@ pyne::Material::Material(pyne::comp_map cm, double m, double d, double apm,
 
 
 
-pyne::Material::Material(char* filename, double m, double d, double apm,
+pyne::Material::Material(char * filename, double m, double d, double apm,
                          Json::Value attributes) {
   mass = m;
-  density = d;
+  density=d;
   atoms_per_molecule = apm;
   metadata = attributes;
 
   // Check that the file is there
-  std::string fname(filename);
+  std::string fname (filename);
   if (!pyne::file_exists(fname))
     throw pyne::FileNotFound(fname);
 
@@ -14816,7 +15019,7 @@ pyne::Material::Material(std::string filename, double m, double d, double apm,
                          Json::Value attributes) {
   // Initializes the mass stream based on an isotopic composition file with a string name.
   mass = m;
-  density = d;
+  density=d;
   atoms_per_molecule = apm;
   metadata = attributes;
 
@@ -14845,8 +15048,9 @@ std::ostream& operator<<(std::ostream& os, pyne::Material mat) {
   //print the Mass Stream to stdout
   os << "\tMass: " << mat.mass << "\n";
   os << "\t---------\n";
-  for (pyne::comp_iter i = mat.comp.begin(); i != mat.comp.end(); i++) {
-    os << "\t" << pyne::nucname::name(i->first) << "\t" << i->second << "\n";
+  for(pyne::comp_iter i = mat.comp.begin(); i != mat.comp.end(); i++)
+  {
+    os << "\t" << pyne::nucname::name( i->first ) << "\t" << i->second << "\n";
   }
   return os;
 }
@@ -14856,7 +15060,7 @@ std::ostringstream& operator<<(std::ostringstream& os, pyne::Material mat) {
   return os;
 }
 
-void pyne::Material::normalize() {
+void pyne::Material::normalize () {
   // normalizes the mass
   mass = 1.0;
 }
@@ -14891,9 +15095,9 @@ pyne::comp_map pyne::Material::decay_heat() {
   pyne::comp_map dh;
   double masspermole = mass * pyne::N_A;
   for (pyne::comp_iter i = comp.begin(); i != comp.end(); ++i) {
-    dh[i->first] = pyne::MeV_per_MJ * masspermole * (i->second) * \
+    dh[i->first] = masspermole * (i->second) * \
                    decay_const(i->first) * q_val(i->first) / \
-                   atomic_mass(i->first);
+                   atomic_mass(i->first) / pyne::MeV_per_MJ;
   }
   return dh;
 }
@@ -14955,8 +15159,7 @@ double pyne::Material::molecular_mass(double apm) {
   return atsperm / inverseA;
 }
 
-
-pyne::Material pyne::Material::expand_elements() {
+pyne::Material pyne::Material::expand_elements(std::set<int> exception_ids) {
   // Expands the natural elements of a material and returns a new material note
   // that this implementation relies on the fact that maps of ints are stored in
   // a sorted manner in C++.
@@ -14969,16 +15172,22 @@ pyne::Material pyne::Material::expand_elements() {
   abund_end = pyne::natural_abund_map.end();
   zabund = nucname::znum((*abund_itr).first);
   for (comp_iter nuc = comp.begin(); nuc != comp.end(); nuc++) {
-    if (abund_itr == abund_end)
+    // keep element as-is if in exception list
+    if (0 < exception_ids.count(nuc->first)) {
       newcomp.insert(*nuc);
-    else if (0 == nucname::anum((*nuc).first)) {
+      continue;
+    }
+
+    if(abund_itr == abund_end)
+      newcomp.insert(*nuc);
+    else if(0 == nucname::anum((*nuc).first)) {
       n = (*nuc).first;
       znuc = nucname::znum(n);
       if (znuc < zabund) {
         newcomp.insert(*nuc);
         continue;
       }
-      while (zabund <= znuc) {
+      while(zabund <= znuc) {
         nabund = (*abund_itr).first;
         if (zabund == znuc && 0 != nucname::anum(nabund) && 0.0 != (*abund_itr).second)
           newcomp[nabund] = (*abund_itr).second * (*nuc).second * \
@@ -14997,6 +15206,22 @@ pyne::Material pyne::Material::expand_elements() {
   }
   return Material(newcomp, mass, density, atoms_per_molecule, metadata);
 }
+
+// Wrapped version for calling from python
+pyne::Material pyne::Material::expand_elements(int** int_ptr_arry ) {
+    std::set<int> nucvec;
+    // Set first pointer to first int pointed to by arg
+    if (int_ptr_arry != NULL) {
+      int *int_ptr = *int_ptr_arry;
+      while (int_ptr != NULL)
+	{
+	  nucvec.insert(*int_ptr);
+	  int_ptr++;
+	}
+    }
+    return expand_elements(nucvec);
+}
+
 
 pyne::Material pyne::Material::collapse_elements(std::set<int> exception_ids) {
   ////////////////////////////////////////////////////////////////////////
@@ -15019,21 +15244,21 @@ pyne::Material pyne::Material::collapse_elements(std::set<int> exception_ids) {
   pyne::comp_map cm;
 
   for (pyne::comp_iter ptr = comp.begin(); ptr != comp.end(); ptr++) {
-    if (0 < ptr->second) {
-      // There is a nonzero amount of this nucid in the current material,
-      // check if znum and anum are in the exception list,
-      int cur_stripped_id = nucname::znum(ptr->first) * 10000000
-                            + nucname::anum(ptr->first) * 10000;
-      if (0 < exception_ids.count(cur_stripped_id)) {
+      if (0 < ptr->second) {
+        // There is a nonzero amount of this nucid in the current material,
+        // check if znum and anum are in the exception list,
+        int cur_stripped_id = nucname::znum(ptr->first)*10000000
+                        + nucname::anum(ptr->first)*10000;
+        if (0 < exception_ids.count(cur_stripped_id)) {
         // The znum/anum combination identify the current material as a
         // fluka-named exception list => copy, don't collapse
-        cm[ptr->first] = (ptr->second) * mass;
-      } else {
-        // Not on exception list => add frac to id-component
-        int znum_id = nucname::id(nucname::znum(ptr->first));
-        cm[znum_id] += (ptr->second) * mass;
+          cm[ptr->first] = (ptr->second) * mass;
+        } else {
+          // Not on exception list => add frac to id-component
+          int znum_id = nucname::id(nucname::znum(ptr->first));
+          cm[znum_id] += (ptr->second) * mass;
+        }
       }
-    }
   }
   // Copy
   pyne::Material collapsed = pyne::Material(cm, mass, density,
@@ -15042,15 +15267,16 @@ pyne::Material pyne::Material::collapse_elements(std::set<int> exception_ids) {
 }
 
 // Wrapped version for calling from python
-pyne::Material pyne::Material::collapse_elements(int** int_ptr_arry) {
-  std::set<int> nucvec;
-  // Set first pointer to first int pointed to by arg
-  int* int_ptr = *int_ptr_arry;
-  while (int_ptr != NULL) {
-    nucvec.insert(*int_ptr);
-    int_ptr++;
-  }
-  return collapse_elements(nucvec);
+pyne::Material pyne::Material::collapse_elements(int** int_ptr_arry ) {
+    std::set<int> nucvec;
+    // Set first pointer to first int pointed to by arg
+    int *int_ptr = *int_ptr_arry;
+    while (int_ptr != NULL)
+    {
+      nucvec.insert(*int_ptr);
+      int_ptr++;
+    }
+    return collapse_elements(nucvec);
 }
 
 double pyne::Material::mass_density(double num_dens, double apm) {
@@ -15079,7 +15305,7 @@ pyne::Material pyne::Material::sub_mat(std::set<int> nucset) {
 
   pyne::comp_map cm;
   for (pyne::comp_iter i = comp.begin(); i != comp.end(); i++) {
-    if (0 < nucset.count(i->first))
+    if ( 0 < nucset.count(i->first) )
       cm[i->first] = (i->second) * mass;
   }
 
@@ -15101,7 +15327,7 @@ pyne::Material pyne::Material::sub_mat(std::set<std::string> nucset) {
 
 
 
-pyne::Material pyne::Material::set_mat(std::set<int> nucset, double value) {
+pyne::Material pyne::Material::set_mat (std::set<int> nucset, double value) {
   // Sets a sub-material from this mat based on a set of integers.
   // Integers can either be of id form -OR- they can be a z-numer (is 8 for O, 93 for Np, etc).
   // n is the name of the new material.
@@ -15110,7 +15336,7 @@ pyne::Material pyne::Material::set_mat(std::set<int> nucset, double value) {
 
   // Add non-set components
   for (pyne::comp_iter i = comp.begin(); i != comp.end(); i++) {
-    if (0 == nucset.count(i->first))
+    if ( 0 == nucset.count(i->first) )
       cm[i->first] = (i->second) * mass;
   }
 
@@ -15145,7 +15371,7 @@ pyne::Material pyne::Material::del_mat(std::set<int> nucset) {
   pyne::comp_map cm;
   for (pyne::comp_iter i = comp.begin(); i != comp.end(); i++) {
     // Only add to new comp if not in nucset
-    if (0 == nucset.count(i->first))
+    if ( 0 == nucset.count(i->first) )
       cm[i->first] = (i->second) * mass;
   }
 
@@ -15154,7 +15380,7 @@ pyne::Material pyne::Material::del_mat(std::set<int> nucset) {
 
 
 
-pyne::Material pyne::Material::del_mat(std::set<std::string> nucset) {
+pyne::Material pyne::Material::del_mat (std::set<std::string> nucset) {
   // Removes a substream from this stream based on a set of strings.
   // Strings can be of any form.
   std::set<int> iset;
@@ -15172,7 +15398,8 @@ pyne::Material pyne::Material::del_mat(std::set<std::string> nucset) {
 
 pyne::Material pyne::Material::sub_range(int lower, int upper) {
   // Grabs a sub-material from this mat based on a range of integers.
-  if (upper < lower) {
+  if (upper < lower)
+  {
     int temp_upper = upper;
     upper = lower;
     lower = temp_upper;
@@ -15184,7 +15411,7 @@ pyne::Material pyne::Material::sub_range(int lower, int upper) {
       cm[i->first] = (i->second) * mass;
   }
 
-  return pyne::Material(cm, -1, -1);
+  return pyne::Material(cm, -1,-1);
 }
 
 
@@ -15205,7 +15432,7 @@ pyne::Material pyne::Material::set_range(int lower, int upper, double value) {
       cm[i->first] = (i->second) * mass;
   }
 
-  return pyne::Material(cm, -1, -1);
+  return pyne::Material(cm, -1,-1);
 }
 
 
@@ -15331,14 +15558,14 @@ std::vector<std::pair<double, double> > pyne::Material::gammas() {
   int state_id;
   for (comp_iter ci = comp.begin(); ci != comp.end(); ci++) {
     if (ci->first % 10000 > 0)
-      state_id = nucname::id_to_state_id(ci->first);
+        state_id = nucname::id_to_state_id(ci->first);
     else
-      state_id = ci->first;
+        state_id = ci->first;
 
     std::vector<std::pair<double, double> > raw_gammas = pyne::gammas(state_id);
     for (int i = 0; i < raw_gammas.size(); ++i) {
       result.push_back(std::make_pair(raw_gammas[i].first,
-                                      atom_fracs[ci->first]*raw_gammas[i].second));
+        atom_fracs[ci->first]*raw_gammas[i].second));
     }
   }
   return result;
@@ -15350,14 +15577,14 @@ std::vector<std::pair<double, double> > pyne::Material::xrays() {
   int state_id;
   for (comp_iter ci = comp.begin(); ci != comp.end(); ci++) {
     if (ci->first % 10000 > 0)
-      state_id = nucname::id_to_state_id(ci->first);
+        state_id = nucname::id_to_state_id(ci->first);
     else
-      state_id = ci->first;
+        state_id = ci->first;
 
     std::vector<std::pair<double, double> > raw_xrays = pyne::xrays(state_id);
     for (int i = 0; i < raw_xrays.size(); ++i) {
       result.push_back(std::make_pair(raw_xrays[i].first,
-                                      atom_fracs[ci->first]*raw_xrays[i].second));
+        atom_fracs[ci->first]*raw_xrays[i].second));
     }
   }
   return result;
@@ -15374,7 +15601,7 @@ std::vector<std::pair<double, double> > pyne::Material::photons(bool norm) {
 }
 
 std::vector<std::pair<double, double> > pyne::Material::normalize_radioactivity(
-    std::vector<std::pair<double, double> > unnormed) {
+std::vector<std::pair<double, double> > unnormed) {
   std::vector<std::pair<double, double> > normed;
   double sum = 0.0;
   for (int i = 0; i < unnormed.size(); ++i) {
@@ -15384,7 +15611,7 @@ std::vector<std::pair<double, double> > pyne::Material::normalize_radioactivity(
   for (int i = 0; i < unnormed.size(); ++i) {
     if (!isnan(unnormed[i].second)) {
       normed.push_back(std::make_pair(unnormed[i].first,
-                                      (unnormed[i].second) / sum));
+        (unnormed[i].second)/sum));
     }
   }
   return normed;
@@ -15392,14 +15619,16 @@ std::vector<std::pair<double, double> > pyne::Material::normalize_radioactivity(
 
 
 pyne::Material pyne::Material::decay(double t) {
-  Material rtn;
-  std::cout << "--Warning--Warning--Warning--Warning--Warning--Warning--" << std::endl;
-  std::cout << "  There is no decay function in the material object within" << std::endl;
-  std::cout << "  this amalgamated pyne build" << std::endl;
-  std::cout << "--Warning--Warning--Warning--Warning--Warning--Warning--" << std::endl;
-  return rtn;
+  throw pyne::ValueError("Material::decay is not supported in this amalgamated"
+                         "version of PyNE.");
 }
 
+
+pyne::Material pyne::Material::cram(std::vector<double> A,
+                                    const int order) {
+  throw pyne::ValueError("Material::cram is not supported in this amalgamated"
+                         "version of PyNE.");
+}
 
 pyne::Material pyne::Material::operator+ (double y) {
   // Overloads x + y
@@ -15415,14 +15644,14 @@ pyne::Material pyne::Material::operator+ (Material y) {
   pyne::comp_map ywgt = y.mult_by_mass();
 
   for (pyne::comp_iter i = xwgt.begin(); i != xwgt.end(); i++) {
-    if (0 < ywgt.count(i->first))
+    if ( 0 < ywgt.count(i->first) )
       cm[i->first] = xwgt[i->first] + ywgt[i->first];
     else
       cm[i->first] = xwgt[i->first];
   }
 
   for (pyne::comp_iter i = ywgt.begin(); i != ywgt.end(); i++) {
-    if (0 == cm.count(i->first))
+    if ( 0 == cm.count(i->first) )
       cm[i->first] = ywgt[i->first];
   }
 
@@ -15440,8 +15669,9 @@ pyne::Material pyne::Material::operator* (double y) {
 
 pyne::Material pyne::Material::operator/ (double y) {
   // Overloads x / y
-  return pyne::Material(comp, mass / y, density);
+  return pyne::Material(comp, mass / y, density );
 }
+
 //
 // end of src/material.cpp
 //

--- a/src/pyne/pyne.cpp
+++ b/src/pyne/pyne.cpp
@@ -2423,11 +2423,9 @@ pyne::nucname::name_zz_t pyne::nucname::name_zz = pyne::nucname::get_name_zz();
 
 
 /*** Constructs zz to LL dictionary **/
-pyne::nucname::zzname_t pyne::nucname::get_zz_name()
-{
+pyne::nucname::zzname_t pyne::nucname::get_zz_name() {
   zzname_t zld;
-  for (name_zz_iter i = name_zz.begin(); i != name_zz.end(); i++)
-  {
+  for (name_zz_iter i = name_zz.begin(); i != name_zz.end(); i++) {
     zld[i->second] = i->first;
   }
   return zld;
@@ -2589,11 +2587,9 @@ pyne::nucname::name_zz_t pyne::nucname::fluka_zz = pyne::nucname::get_fluka_zz()
 
 
 /*** Constructs zz to fluka dictionary **/
-pyne::nucname::zzname_t pyne::nucname::get_zz_fluka()
-{
+pyne::nucname::zzname_t pyne::nucname::get_zz_fluka() {
   zzname_t zfd;
-  for (name_zz_iter i = fluka_zz.begin(); i != fluka_zz.end(); i++)
-  {
+  for (name_zz_iter i = fluka_zz.begin(); i != fluka_zz.end(); i++) {
     zfd[i->second] = i->first;
   }
   return zfd;
@@ -2606,8 +2602,7 @@ pyne::nucname::zzname_t pyne::nucname::zz_fluka = pyne::nucname::get_zz_fluka();
 /*** Define useful elemental group sets ***/
 /******************************************/
 
-pyne::nucname::zz_group pyne::nucname::name_to_zz_group(pyne::nucname::name_group eg)
-{
+pyne::nucname::zz_group pyne::nucname::name_to_zz_group(pyne::nucname::name_group eg) {
   zz_group zg;
   for (name_group_iter i = eg.begin(); i != eg.end(); i++)
     zg.insert(name_zz[*i]);
@@ -2616,48 +2611,53 @@ pyne::nucname::zz_group pyne::nucname::name_to_zz_group(pyne::nucname::name_grou
 
 // Lanthanides
 pyne::nucname::name_t pyne::nucname::LAN_array[15] = {"La", "Ce", "Pr", "Nd",
-  "Pm", "Sm", "Eu", "Gd", "Tb", "Dy", "Ho", "Er", "Tm", "Yb", "Lu"};
-pyne::nucname::name_group pyne::nucname::LAN (pyne::nucname::LAN_array,
-                                              pyne::nucname::LAN_array+15);
+                                                      "Pm", "Sm", "Eu", "Gd", "Tb", "Dy", "Ho", "Er", "Tm", "Yb", "Lu"
+                                                     };
+pyne::nucname::name_group pyne::nucname::LAN(pyne::nucname::LAN_array,
+                                             pyne::nucname::LAN_array + 15);
 pyne::nucname::zz_group pyne::nucname::lan = \
-  pyne::nucname::name_to_zz_group(pyne::nucname::LAN);
+                                             pyne::nucname::name_to_zz_group(pyne::nucname::LAN);
 
 // Actinides
 pyne::nucname::name_t pyne::nucname::ACT_array[15] = {"Ac", "Th", "Pa", "U",
-  "Np", "Pu", "Am", "Cm", "Bk", "Cf", "Es", "Fm", "Md", "No", "Lr"};
-pyne::nucname::name_group pyne::nucname::ACT (pyne::nucname::ACT_array, pyne::nucname::ACT_array+15);
+                                                      "Np", "Pu", "Am", "Cm", "Bk", "Cf", "Es", "Fm", "Md", "No", "Lr"
+                                                     };
+pyne::nucname::name_group pyne::nucname::ACT(pyne::nucname::ACT_array, pyne::nucname::ACT_array + 15);
 pyne::nucname::zz_group pyne::nucname::act = pyne::nucname::name_to_zz_group(pyne::nucname::ACT);
 
 // Transuarnics
 pyne::nucname::name_t pyne::nucname::TRU_array[22] = {"Np", "Pu", "Am", "Cm",
-  "Bk", "Cf", "Es", "Fm", "Md", "No", "Lr", "Rf", "Db", "Sg", "Bh", "Hs", "Mt",
-  "Ds", "Rg", "Cn", "Fl", "Lv"};
-pyne::nucname::name_group pyne::nucname::TRU (pyne::nucname::TRU_array,
-                                              pyne::nucname::TRU_array+22);
+                                                      "Bk", "Cf", "Es", "Fm", "Md", "No", "Lr", "Rf", "Db", "Sg", "Bh", "Hs", "Mt",
+                                                      "Ds", "Rg", "Cn", "Fl", "Lv"
+                                                     };
+pyne::nucname::name_group pyne::nucname::TRU(pyne::nucname::TRU_array,
+                                             pyne::nucname::TRU_array + 22);
 pyne::nucname::zz_group pyne::nucname::tru = \
-  pyne::nucname::name_to_zz_group(pyne::nucname::TRU);
+                                             pyne::nucname::name_to_zz_group(pyne::nucname::TRU);
 
 //Minor Actinides
 pyne::nucname::name_t pyne::nucname::MA_array[10] = {"Np", "Am", "Cm", "Bk",
-  "Cf", "Es", "Fm", "Md", "No", "Lr"};
-pyne::nucname::name_group pyne::nucname::MA (pyne::nucname::MA_array,
-                                             pyne::nucname::MA_array+10);
+                                                     "Cf", "Es", "Fm", "Md", "No", "Lr"
+                                                    };
+pyne::nucname::name_group pyne::nucname::MA(pyne::nucname::MA_array,
+                                            pyne::nucname::MA_array + 10);
 pyne::nucname::zz_group pyne::nucname::ma = \
-  pyne::nucname::name_to_zz_group(pyne::nucname::MA);
+                                            pyne::nucname::name_to_zz_group(pyne::nucname::MA);
 
 //Fission Products
 pyne::nucname::name_t pyne::nucname::FP_array[88] = {"Ag", "Al", "Ar", "As",
-  "At", "Au", "B",  "Ba", "Be", "Bi", "Br", "C",  "Ca", "Cd", "Ce", "Cl", "Co",
-  "Cr", "Cs", "Cu", "Dy", "Er", "Eu", "F",  "Fe", "Fr", "Ga", "Gd", "Ge", "H",
-  "He", "Hf", "Hg", "Ho", "I",  "In", "Ir", "K",  "Kr", "La", "Li", "Lu", "Mg",
-  "Mn", "Mo", "N",  "Na", "Nb", "Nd", "Ne", "Ni", "O",  "Os", "P",  "Pb", "Pd",
-  "Pm", "Po", "Pr", "Pt", "Ra", "Rb", "Re", "Rh", "Rn", "Ru", "S",  "Sb", "Sc",
-  "Se", "Si", "Sm", "Sn", "Sr", "Ta", "Tb", "Tc", "Te", "Ti", "Tl", "Tm", "V",
-  "W",  "Xe", "Y",  "Yb", "Zn", "Zr"};
-pyne::nucname::name_group pyne::nucname::FP (pyne::nucname::FP_array,
-                                             pyne::nucname::FP_array+88);
+                                                     "At", "Au", "B",  "Ba", "Be", "Bi", "Br", "C",  "Ca", "Cd", "Ce", "Cl", "Co",
+                                                     "Cr", "Cs", "Cu", "Dy", "Er", "Eu", "F",  "Fe", "Fr", "Ga", "Gd", "Ge", "H",
+                                                     "He", "Hf", "Hg", "Ho", "I",  "In", "Ir", "K",  "Kr", "La", "Li", "Lu", "Mg",
+                                                     "Mn", "Mo", "N",  "Na", "Nb", "Nd", "Ne", "Ni", "O",  "Os", "P",  "Pb", "Pd",
+                                                     "Pm", "Po", "Pr", "Pt", "Ra", "Rb", "Re", "Rh", "Rn", "Ru", "S",  "Sb", "Sc",
+                                                     "Se", "Si", "Sm", "Sn", "Sr", "Ta", "Tb", "Tc", "Te", "Ti", "Tl", "Tm", "V",
+                                                     "W",  "Xe", "Y",  "Yb", "Zn", "Zr"
+                                                    };
+pyne::nucname::name_group pyne::nucname::FP(pyne::nucname::FP_array,
+                                            pyne::nucname::FP_array + 88);
 pyne::nucname::zz_group pyne::nucname::fp = \
-  pyne::nucname::name_to_zz_group(pyne::nucname::FP);
+                                            pyne::nucname::name_to_zz_group(pyne::nucname::FP);
 
 
 /***************************/
@@ -2668,17 +2668,15 @@ bool pyne::nucname::isnuclide(std::string nuc) {
   int n;
   try {
     n = id(nuc);
-  }
-  catch(NotANuclide) {
+  } catch (NotANuclide) {
     return false;
-  }
-  catch(IndeterminateNuclideForm) {
+  } catch (IndeterminateNuclideForm) {
     return false;
   }
   return isnuclide(n);
 }
 
-bool pyne::nucname::isnuclide(const char * nuc) {
+bool pyne::nucname::isnuclide(const char* nuc) {
   return isnuclide(std::string(nuc));
 }
 
@@ -2686,11 +2684,9 @@ bool pyne::nucname::isnuclide(int nuc) {
   int n;
   try {
     n = id(nuc);
-  }
-  catch(NotANuclide) {
+  } catch (NotANuclide) {
     return false;
-  }
-  catch(IndeterminateNuclideForm) {
+  } catch (IndeterminateNuclideForm) {
     return false;
   }
   if (n <= 10000000)
@@ -2721,9 +2717,9 @@ int pyne::nucname::id(int nuc) {
   // Nuclide must already be in id form
   if (0 < zzz && zzz <= aaa && aaa <= zzz * 7) {
     // Normal nuclide
-    if (5 < ssss){
-    // Unphysical metastable state warning
-     warning("You have indicated a metastable state of " + pyne::to_str(ssss) + ". Metastable state above 5, possibly unphysical. ");
+    if (5 < ssss) {
+      // Unphysical metastable state warning
+      warning("You have indicated a metastable state of " + pyne::to_str(ssss) + ". Metastable state above 5, possibly unphysical. ");
     }
     return nuc;
   } else if (aaassss == 0 && 0 < zz_name.count(zzz)) {
@@ -2740,18 +2736,18 @@ int pyne::nucname::id(int nuc) {
   ssss = nuc % 10;       // SSSS ?
   if (zzz <= aaa && aaa <= zzz * 7) {
     // ZZZAAAM nuclide
-    if (5 < ssss){
-    // Unphysical metastable state warning
+    if (5 < ssss) {
+      // Unphysical metastable state warning
       warning("You have indicated a metastable state of " + pyne::to_str(ssss) + ". Metastable state above 5, possibly unphysical. ");
     }
-    return (zzz*10000000) + (aaa*10000) + (nuc%10);
+    return (zzz * 10000000) + (aaa * 10000) + (nuc % 10);
   } else if (aaa <= zzz && zzz <= aaa * 7 && 0 < zz_name.count(aaa)) {
     // Cinder-form (aaazzzm), ie 2350920
-    if (5 < ssss){
-    // Unphysical metastable state warning
+    if (5 < ssss) {
+      // Unphysical metastable state warning
       warning("You have indicated a metastable state of " + pyne::to_str(ssss) + ". Metastable state above 5, possibly unphysical. ");
     }
-    return (aaa*10000000) + (zzz*10000) + (nuc%10);
+    return (aaa * 10000000) + (zzz * 10000) + (nuc % 10);
   }
   //else if (aaassss == 0 && 0 == zz_name.count(nuc/1000) && 0 < zz_name.count(zzz))
   else if (aaassss == 0 && 0 < zz_name.count(zzz)) {
@@ -2759,7 +2755,7 @@ int pyne::nucname::id(int nuc) {
     return zzz * 10000000;
   }
 
-  if (nuc >= 1000000){
+  if (nuc >= 1000000) {
     // From now we assume no metastable info has been given.
     throw IndeterminateNuclideForm(nuc, "");
   }
@@ -2778,9 +2774,9 @@ int pyne::nucname::id(int nuc) {
     } else {
       // Nuclide in MCNP metastable form
       if (nuc == 95642)
-        return (95642 - 400)*10000;  // special case MCNP Am-242
+        return (95642 - 400) * 10000; // special case MCNP Am-242
       nuc = ((nuc - 400) * 10000) + 1;
-      while (3.0 < (float ((nuc/10000)%1000) / float (nuc/10000000)))
+      while (3.0 < (float ((nuc / 10000) % 1000) / float (nuc / 10000000)))
         nuc -= 999999;
       return nuc;
     }
@@ -2797,8 +2793,8 @@ int pyne::nucname::id(int nuc) {
   throw IndeterminateNuclideForm(nuc, "");
 }
 
-int pyne::nucname::id(const char * nuc) {
-  std::string newnuc (nuc);
+int pyne::nucname::id(const char* nuc) {
+  std::string newnuc(nuc);
   return id(newnuc);
 }
 
@@ -2813,16 +2809,16 @@ int pyne::nucname::id(std::string nuc) {
   if (dash1 == npos)
     dash2 = npos;
   else
-    dash2 = nuc.find("-", dash1+1);
+    dash2 = nuc.find("-", dash1 + 1);
 
   // nuc must be at least 4 characters or greater if it is in ZZLLAAAM form.
   if (nuc.length() >= 5 && dash1 != npos && dash2 != npos) {
     // Nuclide most likely in ZZLLAAAM Form, only form that contains two "-"'s.
     std::string zz = nuc.substr(0, dash1);
-    std::string ll = nuc.substr(dash1+1, dash2);
+    std::string ll = nuc.substr(dash1 + 1, dash2);
     int zz_int = to_int(zz);
     // Verifying that the LL and ZZ point to the same element as secondary
-    if(znum(ll) != zz_int)
+    if (znum(ll) != zz_int)
       throw NotANuclide(nuc, "mismatched znum and chemical symbol");
     return zzllaaam_to_id(nuc);
   }
@@ -2833,7 +2829,7 @@ int pyne::nucname::id(std::string nuc) {
   int nuclen = nucstr.length();
 
   if (pyne::contains_substring(pyne::digits, nucstr.substr(0, 1))) {
-    if (pyne::contains_substring(pyne::digits, nucstr.substr(nuclen-1, nuclen))) {
+    if (pyne::contains_substring(pyne::digits, nucstr.substr(nuclen - 1, nuclen))) {
       // Nuclide must actually be an integer that
       // just happens to be living in string form.
       newnuc = pyne::to_int(nucstr);
@@ -2879,7 +2875,7 @@ int pyne::nucname::id(std::string nuc) {
       throw NotANuclide(nucstr, newnuc);
 
     // Add the Z-number
-    elem_name = pyne::remove_characters(nucstr.substr(0, nuclen-1), pyne::digits);
+    elem_name = pyne::remove_characters(nucstr.substr(0, nuclen - 1), pyne::digits);
     elem_name = pyne::capitalize(elem_name);
     if (0 < name_zz.count(elem_name))
       newnuc = (10000000 * name_zz[elem_name]) + newnuc;
@@ -2901,14 +2897,13 @@ bool pyne::nucname::iselement(std::string nuc) {
   int n;
   try {
     n = id(nuc);
-  }
-  catch(NotANuclide) {
+  } catch (NotANuclide) {
     return false;
   }
   return iselement(n);
 }
 
-bool pyne::nucname::iselement(const char * nuc) {
+bool pyne::nucname::iselement(const char* nuc) {
   return iselement(std::string(nuc));
 }
 
@@ -2916,8 +2911,7 @@ bool pyne::nucname::iselement(int nuc) {
   int n;
   try {
     n = id(nuc);
-  }
-  catch(NotANuclide) {
+  } catch (NotANuclide) {
     return false;
   }
 
@@ -2962,8 +2956,8 @@ std::string pyne::nucname::name(int nuc) {
 
 
 
-std::string pyne::nucname::name(const char * nuc) {
-  std::string newnuc (nuc);
+std::string pyne::nucname::name(const char* nuc) {
+  std::string newnuc(nuc);
   return name(newnuc);
 }
 
@@ -2980,7 +2974,7 @@ int pyne::nucname::znum(int nuc) {
   return id(nuc) / 10000000;
 }
 
-int pyne::nucname::znum(const char * nuc) {
+int pyne::nucname::znum(const char* nuc) {
   return id(nuc) / 10000000;
 }
 
@@ -2995,7 +2989,7 @@ int pyne::nucname::anum(int nuc) {
   return (id(nuc) / 10000) % 1000;
 }
 
-int pyne::nucname::anum(const char * nuc) {
+int pyne::nucname::anum(const char* nuc) {
   return (id(nuc) / 10000) % 1000;
 }
 
@@ -3010,7 +3004,7 @@ int pyne::nucname::snum(int nuc) {
   return id(nuc) % 10000;
 }
 
-int pyne::nucname::snum(const char * nuc) {
+int pyne::nucname::snum(const char* nuc) {
   return id(nuc) % 10000;
 }
 
@@ -3027,12 +3021,12 @@ int pyne::nucname::zzaaam(int nuc) {
   int ssss = nucid % 10000;
   if (10 <= ssss)
     ssss = 9;
-  return zzzaaa*10 + ssss;
+  return zzzaaa * 10 + ssss;
 }
 
 
-int pyne::nucname::zzaaam(const char * nuc) {
-  std::string newnuc (nuc);
+int pyne::nucname::zzaaam(const char* nuc) {
+  std::string newnuc(nuc);
   return zzaaam(newnuc);
 }
 
@@ -3043,11 +3037,11 @@ int pyne::nucname::zzaaam(std::string nuc) {
 
 
 int pyne::nucname::zzaaam_to_id(int nuc) {
-  return (nuc/10)*10000 + (nuc%10);
+  return (nuc / 10) * 10000 + (nuc % 10);
 }
 
 
-int pyne::nucname::zzaaam_to_id(const char * nuc) {
+int pyne::nucname::zzaaam_to_id(const char* nuc) {
   return zzaaam_to_id(std::string(nuc));
 }
 
@@ -3061,14 +3055,14 @@ int pyne::nucname::zzaaam_to_id(std::string nuc) {
 /************************/
 int pyne::nucname::zzzaaa(int nuc) {
   int nucid = id(nuc);
-  int zzzaaa = nucid/10000;
+  int zzzaaa = nucid / 10000;
 
   return zzzaaa;
 }
 
 
-int pyne::nucname::zzzaaa(const char * nuc) {
-  std::string newnuc (nuc);
+int pyne::nucname::zzzaaa(const char* nuc) {
+  std::string newnuc(nuc);
   return zzzaaa(newnuc);
 }
 
@@ -3079,11 +3073,11 @@ int pyne::nucname::zzzaaa(std::string nuc) {
 
 
 int pyne::nucname::zzzaaa_to_id(int nuc) {
-  return (nuc)*10000;
+  return (nuc) * 10000;
 }
 
 
-int pyne::nucname::zzzaaa_to_id(const char * nuc) {
+int pyne::nucname::zzzaaa_to_id(const char* nuc) {
   return zzzaaa_to_id(std::string(nuc));
 }
 
@@ -3124,8 +3118,8 @@ std::string pyne::nucname::zzllaaam(int nuc) {
 }
 
 
-std::string pyne::nucname::zzllaaam(const char * nuc) {
-  std::string newnuc (nuc);
+std::string pyne::nucname::zzllaaam(const char* nuc) {
+  std::string newnuc(nuc);
   return zzllaaam(newnuc);
 }
 
@@ -3135,7 +3129,7 @@ std::string pyne::nucname::zzllaaam(std::string nuc) {
 }
 
 
-int pyne::nucname::zzllaaam_to_id(const char * nuc) {
+int pyne::nucname::zzllaaam_to_id(const char* nuc) {
   return zzllaaam_to_id(std::string(nuc));
 }
 
@@ -3151,7 +3145,7 @@ int pyne::nucname::zzllaaam_to_id(std::string nuc) {
   // Removing first two characters (redundant), for 1 digit nuclides, such
   // as 2-He-4, the first slash will be removed, and the second attempt to
   // remove the second slash will do nothing.
-  nucstr.erase(0,2);
+  nucstr.erase(0, 2);
   nucstr = pyne::remove_substring(nucstr, "-");
   // Does nothing if nuclide is short, otherwise removes the second "-" instance
   nucstr = pyne::remove_substring(nucstr, "-");
@@ -3178,7 +3172,7 @@ int pyne::nucname::zzllaaam_to_id(std::string nuc) {
     throw NotANuclide(nucstr, nucid);
 
   // Add the Z-number
-  elem_name = pyne::remove_characters(nucstr.substr(0, nuclen-1), pyne::digits);
+  elem_name = pyne::remove_characters(nucstr.substr(0, nuclen - 1), pyne::digits);
   elem_name = pyne::capitalize(elem_name);
   if (0 < name_zz.count(elem_name))
     nucid = (10000000 * name_zz[elem_name]) + nucid;
@@ -3208,8 +3202,8 @@ int pyne::nucname::mcnp(int nuc) {
 
 
 
-int pyne::nucname::mcnp(const char * nuc) {
-  std::string newnuc (nuc);
+int pyne::nucname::mcnp(const char* nuc) {
+  std::string newnuc(nuc);
   return mcnp(newnuc);
 }
 
@@ -3236,9 +3230,9 @@ int pyne::nucname::mcnp_to_id(int nuc) {
     } else {
       // Nuclide in MCNP metastable form
       if (nuc == 95642)
-        return (95642 - 400)*10000;  // special case MCNP Am-242
+        return (95642 - 400) * 10000; // special case MCNP Am-242
       nuc = ((nuc - 400) * 10000) + 1;
-      while (3.0 < (float ((nuc/10000)%1000) / float (nuc/10000000)))
+      while (3.0 < (float ((nuc / 10000) % 1000) / float (nuc / 10000000)))
         nuc -= 999999;
       return nuc;
     }
@@ -3249,7 +3243,7 @@ int pyne::nucname::mcnp_to_id(int nuc) {
 }
 
 
-int pyne::nucname::mcnp_to_id(const char * nuc) {
+int pyne::nucname::mcnp_to_id(const char* nuc) {
   return mcnp_to_id(std::string(nuc));
 }
 
@@ -3280,8 +3274,8 @@ std::string pyne::nucname::openmc(int nuc) {
   return nucname;
 }
 
-std::string pyne::nucname::openmc(const char * nuc) {
-  std::string newnuc (nuc);
+std::string pyne::nucname::openmc(const char* nuc) {
+  std::string newnuc(nuc);
   return openmc(newnuc);
 }
 
@@ -3292,7 +3286,7 @@ std::string pyne::nucname::openmc(std::string nuc) {
 //
 // OPENMC -> id
 //
-int pyne::nucname::openmc_to_id(const char * nuc) {
+int pyne::nucname::openmc_to_id(const char* nuc) {
   return openmc_to_id(std::string(nuc));
 }
 
@@ -3303,14 +3297,14 @@ int pyne::nucname::openmc_to_id(std::string nuc) {
   // first two characters
   std::string::iterator aaa_start;
   int zzz = 0;
-  if (zznames.count(nuc.substr(0,2)) == 1) {
+  if (zznames.count(nuc.substr(0, 2)) == 1) {
     aaa_start = nuc.begin() + 2;
-    zzz = zznames[nuc.substr(0,2)];
+    zzz = zznames[nuc.substr(0, 2)];
   }
   // then try only the first
-  else if (zznames.count(nuc.substr(0,1)) == 1) {
+  else if (zznames.count(nuc.substr(0, 1)) == 1) {
     aaa_start = nuc.begin() + 1;
-    zzz = zznames[nuc.substr(0,1)];
+    zzz = zznames[nuc.substr(0, 1)];
   } else {
     throw NotANuclide(nuc, "Not in the OpenMC format");
   }
@@ -3354,7 +3348,7 @@ int pyne::nucname::fluka_to_id(std::string name) {
   return fluka_zz[name];
 }
 
-int pyne::nucname::fluka_to_id(char * name) {
+int pyne::nucname::fluka_to_id(char* name) {
   return fluka_to_id(std::string(name));
 }
 
@@ -3399,8 +3393,8 @@ std::string pyne::nucname::serpent(int nuc) {
 }
 
 
-std::string pyne::nucname::serpent(const char * nuc) {
-  std::string newnuc (nuc);
+std::string pyne::nucname::serpent(const char* nuc) {
+  std::string newnuc(nuc);
   return serpent(newnuc);
 }
 
@@ -3418,7 +3412,7 @@ std::string pyne::nucname::serpent(std::string nuc) {
 //}
 
 
-int pyne::nucname::serpent_to_id(const char * nuc) {
+int pyne::nucname::serpent_to_id(const char* nuc) {
   return serpent_to_id(std::string(nuc));
 }
 
@@ -3455,7 +3449,7 @@ int pyne::nucname::serpent_to_id(std::string nuc) {
     throw NotANuclide(nucstr, nucid);
 
   // Add the Z-number
-  elem_name = pyne::remove_characters(nucstr.substr(0, nuclen-1), pyne::digits);
+  elem_name = pyne::remove_characters(nucstr.substr(0, nuclen - 1), pyne::digits);
   elem_name = pyne::capitalize(elem_name);
   if (0 < name_zz.count(elem_name))
     nucid = (10000000 * name_zz[elem_name]) + nucid;
@@ -3502,8 +3496,8 @@ std::string pyne::nucname::nist(int nuc) {
 }
 
 
-std::string pyne::nucname::nist(const char * nuc) {
-  std::string newnuc (nuc);
+std::string pyne::nucname::nist(const char* nuc) {
+  std::string newnuc(nuc);
   return nist(newnuc);
 }
 
@@ -3521,7 +3515,7 @@ std::string pyne::nucname::nist(std::string nuc) {
 // NON-EXISTANT
 //};
 
-int pyne::nucname::nist_to_id(const char * nuc) {
+int pyne::nucname::nist_to_id(const char* nuc) {
   return nist_to_id(std::string(nuc));
 }
 
@@ -3567,13 +3561,13 @@ int pyne::nucname::cinder(int nuc) {
   int aaa = aaassss / 10000;
   if (10 <= ssss)
     ssss = 9;
-  return (aaa*10000) + (zzz*10) + ssss;
+  return (aaa * 10000) + (zzz * 10) + ssss;
 }
 
 
 
-int pyne::nucname::cinder(const char * nuc) {
-  std::string newnuc (nuc);
+int pyne::nucname::cinder(const char* nuc) {
+  std::string newnuc(nuc);
   return cinder(newnuc);
 }
 
@@ -3595,7 +3589,7 @@ int pyne::nucname::cinder_to_id(int nuc) {
 }
 
 
-int pyne::nucname::cinder_to_id(const char * nuc) {
+int pyne::nucname::cinder_to_id(const char* nuc) {
   return cinder_to_id(std::string(nuc));
 }
 
@@ -3627,12 +3621,12 @@ std::string pyne::nucname::alara(int nuc) {
   // Add LL, in lower case
   ll += zz_name[zzz];
 
-  for(int i = 0; ll[i] != '\0'; i++)
+  for (int i = 0; ll[i] != '\0'; i++)
     ll[i] = tolower(ll[i]);
   newnuc += ll;
 
   // Add A-number
-  if (0 < aaassss){
+  if (0 < aaassss) {
     newnuc += ":";
     newnuc += pyne::to_str(aaa);
   }
@@ -3642,8 +3636,8 @@ std::string pyne::nucname::alara(int nuc) {
 }
 
 
-std::string pyne::nucname::alara(const char * nuc) {
-  std::string newnuc (nuc);
+std::string pyne::nucname::alara(const char* nuc) {
+  std::string newnuc(nuc);
   return alara(newnuc);
 }
 
@@ -3662,7 +3656,7 @@ std::string pyne::nucname::alara(std::string nuc) {
 //}
 
 
-int pyne::nucname::alara_to_id(const char * nuc) {
+int pyne::nucname::alara_to_id(const char* nuc) {
   return alara_to_id(std::string(nuc));
 }
 
@@ -3710,8 +3704,8 @@ int pyne::nucname::sza(int nuc) {
 }
 
 
-int pyne::nucname::sza(const char * nuc) {
-  std::string newnuc (nuc);
+int pyne::nucname::sza(const char* nuc) {
+  std::string newnuc(nuc);
   return sza(newnuc);
 }
 
@@ -3724,16 +3718,16 @@ int pyne::nucname::sza(std::string nuc) {
 int pyne::nucname::sza_to_id(int nuc) {
   int sss = nuc / 1000000;
   int zzzaaa = nuc % 1000000;
-  if (5 < sss){
-  // Unphysical metastable state warning
-   warning("You have indicated a metastable state of " + pyne::to_str(sss) + ". Metastable state above 5, possibly unphysical. ");
+  if (5 < sss) {
+    // Unphysical metastable state warning
+    warning("You have indicated a metastable state of " + pyne::to_str(sss) + ". Metastable state above 5, possibly unphysical. ");
   }
   return zzzaaa * 10000 + sss;
 }
 
 
-int pyne::nucname::sza_to_id(const char * nuc) {
-  std::string newnuc (nuc);
+int pyne::nucname::sza_to_id(const char* nuc) {
+  std::string newnuc(nuc);
   return sza_to_id(newnuc);
 }
 
@@ -3743,21 +3737,22 @@ int pyne::nucname::sza_to_id(std::string nuc) {
 }
 
 
-void pyne::nucname::_load_state_map(){
-    for (int i = 0; i < TOTAL_STATE_MAPS; ++i) {
-       state_id_map[map_nuc_ids[i]] = map_metastable[i];
-    }
+void pyne::nucname::_load_state_map() {
+  for (int i = 0; i < TOTAL_STATE_MAPS; ++i) {
+    state_id_map[map_nuc_ids[i]] = map_metastable[i];
+  }
 }
 
 int pyne::nucname::state_id_to_id(int state) {
   int zzzaaa = (state / 10000) * 10000;
   int state_number = state % 10000;
-  if (state_number == 0) return state;
+  if (state_number == 0)
+    return state;
   std::map<int, int>::iterator nuc_iter, nuc_end;
 
   nuc_iter = state_id_map.find(state);
   nuc_end = state_id_map.end();
-  if (nuc_iter != nuc_end){
+  if (nuc_iter != nuc_end) {
     int m = (*nuc_iter).second;
     return zzzaaa + m;
   }
@@ -3773,12 +3768,13 @@ int pyne::nucname::state_id_to_id(int state) {
 int pyne::nucname::id_to_state_id(int nuc_id) {
   int zzzaaa = (nuc_id / 10000) * 10000;
   int state = nuc_id % 10000;
-  if (state == 0) return nuc_id;
+  if (state == 0)
+    return nuc_id;
   std::map<int, int>::iterator nuc_iter, nuc_end, it;
 
   nuc_iter = state_id_map.lower_bound(zzzaaa);
   nuc_end = state_id_map.upper_bound(zzzaaa + 9999);
-  for (it = nuc_iter; it!= nuc_end; ++it){
+  for (it = nuc_iter; it != nuc_end; ++it) {
     if (state == it->second) {
       return it->first;
     }
@@ -3799,7 +3795,7 @@ int pyne::nucname::id_to_state_id(int nuc_id) {
 // ENSDF  -> Id
 //
 
-int pyne::nucname::ensdf_to_id(const char * nuc) {
+int pyne::nucname::ensdf_to_id(const char* nuc) {
   return ensdf_to_id(std::string(nuc));
 }
 
@@ -3809,7 +3805,7 @@ int pyne::nucname::ensdf_to_id(std::string nuc) {
   } else if (std::isdigit(nuc[3])) {
     int aaa = to_int(nuc.substr(0, 3));
     int zzz;
-    std::string xx_str = nuc.substr(3,2);
+    std::string xx_str = nuc.substr(3, 2);
     zzz = to_int(xx_str) + 100;
     int nid = 10000 * aaa + 10000000 * zzz;
     return nid;
@@ -13939,10 +13935,10 @@ void pyne::Material::_load_comp_protocol0(hid_t db, std::string datapath, int ro
   // Iterate over datasets in the group.
   for (int matg = 0; matg < matG; matg++) {
     nuckeylen = 1 + H5Lget_name_by_idx(matgroup, ".", H5_INDEX_NAME, H5_ITER_INC, matg,
-                                        NULL, 0, H5P_DEFAULT);
-    char * nkey = new char[nuckeylen];
+                                       NULL, 0, H5P_DEFAULT);
+    char* nkey = new char[nuckeylen];
     nuckeylen = H5Lget_name_by_idx(matgroup, ".", H5_INDEX_NAME, H5_ITER_INC, matg,
-                                    nkey, nuckeylen, H5P_DEFAULT);
+                                   nkey, nuckeylen, H5P_DEFAULT);
     nuckey = nkey;
     nucset = H5Dopen2(matgroup, nkey, H5P_DEFAULT);
     nucvalue = h5wrap::get_array_index<double>(nucset, row);
@@ -13982,7 +13978,7 @@ void pyne::Material::_load_comp_protocol1(hid_t db, std::string datapath, int ro
   hsize_t nuc_attr_len = nuc_info.data_size;
   hid_t str_attr = H5Tcopy(H5T_C_S1);
   H5Tset_size(str_attr, nuc_attr_len);
-  char * nucpathbuf = new char [nuc_attr_len];
+  char* nucpathbuf = new char [nuc_attr_len];
   H5Aread(nuc_attr, str_attr, nucpathbuf);
   nucpath = std::string(nucpathbuf, nuc_attr_len);
   delete[] nucpathbuf;
@@ -14001,7 +13997,7 @@ void pyne::Material::_load_comp_protocol1(hid_t db, std::string datapath, int ro
   hid_t mem_space = H5Screate_simple(1, data_count, NULL);
 
   // Get material type
-  size_t material_data_size = sizeof(pyne::material_data) + sizeof(double)*(nuc_size-1);
+  size_t material_data_size = sizeof(pyne::material_data) + sizeof(double) * (nuc_size - 1);
   hid_t desc = H5Tcreate(H5T_COMPOUND, material_data_size);
   hid_t comp_values_array_type = H5Tarray_create2(H5T_NATIVE_DOUBLE, 1, nuc_dims);
 
@@ -14014,7 +14010,7 @@ void pyne::Material::_load_comp_protocol1(hid_t db, std::string datapath, int ro
   H5Tinsert(desc, "comp", HOFFSET(pyne::material_data, comp), comp_values_array_type);
 
   // make the data array, have to over-allocate
-  material_data * mat_data = new material_data [material_data_size];
+  material_data* mat_data = new material_data [material_data_size];
 
   // Finally, get data and put in on this instance
   H5Dread(data_set, desc, mem_space, data_hyperslab, H5P_DEFAULT, mat_data);
@@ -14023,7 +14019,7 @@ void pyne::Material::_load_comp_protocol1(hid_t db, std::string datapath, int ro
   density = (*mat_data).density;
   atoms_per_molecule = (*mat_data).atoms_per_mol;
   for (int i = 0; i < nuc_size; i++)
-    comp[nuclides[i]] = (double) (*mat_data).comp[i];
+    comp[nuclides[i]] = (double)(*mat_data).comp[i];
 
   delete[] mat_data;
   H5Tclose(str_attr);
@@ -14051,7 +14047,7 @@ void pyne::Material::_load_comp_protocol1(hid_t db, std::string datapath, int ro
 
   // convert to in-memory JSON
   Json::Reader reader;
-  reader.parse((char *) attrdata[0].p, (char *) attrdata[0].p+attrdata[0].len, metadata, false);
+  reader.parse((char*) attrdata[0].p, (char*) attrdata[0].p + attrdata[0].len, metadata, false);
 
   // close attr data objects
   H5Fflush(db, H5F_SCOPE_GLOBAL);
@@ -14067,9 +14063,9 @@ void pyne::Material::_load_comp_protocol1(hid_t db, std::string datapath, int ro
 
 
 
-void pyne::Material::from_hdf5(char * filename, char * datapath, int row, int protocol) {
-  std::string fname (filename);
-  std::string dpath (datapath);
+void pyne::Material::from_hdf5(char* filename, char* datapath, int row, int protocol) {
+  std::string fname(filename);
+  std::string dpath(datapath);
   from_hdf5(fname, dpath, row, protocol);
 }
 
@@ -14092,7 +14088,7 @@ void pyne::Material::from_hdf5(std::string filename, std::string datapath, int r
   //Set file access properties so it closes cleanly
   hid_t fapl;
   fapl = H5Pcreate(H5P_FILE_ACCESS);
-  H5Pset_fclose_degree(fapl,H5F_CLOSE_STRONG);
+  H5Pset_fclose_degree(fapl, H5F_CLOSE_STRONG);
   // Open the database
   hid_t db = H5Fopen(filename.c_str(), H5F_ACC_RDONLY, fapl);
 
@@ -14122,10 +14118,10 @@ void pyne::Material::from_hdf5(std::string filename, std::string datapath, int r
 
 
 
-void pyne::Material::write_hdf5(char * filename, char * datapath, char * nucpath, float row, int chunksize) {
-  std::string fname (filename);
-  std::string groupname (datapath);
-  std::string nuclist (nucpath);
+void pyne::Material::write_hdf5(char* filename, char* datapath, char* nucpath, float row, int chunksize) {
+  std::string fname(filename);
+  std::string groupname(datapath);
+  std::string nuclist(nucpath);
   write_hdf5(fname, groupname, nuclist, row, chunksize);
 }
 
@@ -14141,7 +14137,7 @@ void pyne::Material::write_hdf5(std::string filename, std::string datapath,
   //Set file access properties so it closes cleanly
   hid_t fapl;
   fapl = H5Pcreate(H5P_FILE_ACCESS);
-  H5Pset_fclose_degree(fapl,H5F_CLOSE_STRONG);
+  H5Pset_fclose_degree(fapl, H5F_CLOSE_STRONG);
   // Create new/open datafile.
   hid_t db;
   if (pyne::file_exists(filename)) {
@@ -14149,8 +14145,7 @@ void pyne::Material::write_hdf5(std::string filename, std::string datapath,
     if (!ish5)
       throw h5wrap::FileNotHDF5(filename);
     db = H5Fopen(filename.c_str(), H5F_ACC_RDWR, fapl);
-  }
-  else
+  } else
     db = H5Fcreate(filename.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, fapl);
 
   //
@@ -14193,7 +14188,7 @@ void pyne::Material::write_hdf5(std::string filename, std::string datapath,
   hsize_t data_max_dims[1] = {H5S_UNLIMITED};
   hsize_t data_offset[1] = {0};
 
-  size_t material_data_size = sizeof(pyne::material_data) + sizeof(double)*(nuc_size-1);
+  size_t material_data_size = sizeof(pyne::material_data) + sizeof(double) * (nuc_size - 1);
   hid_t desc = H5Tcreate(H5T_COMPOUND, material_data_size);
   hid_t comp_values_array_type = H5Tarray_create2(H5T_NATIVE_DOUBLE, 1, nuc_dims);
 
@@ -14206,7 +14201,7 @@ void pyne::Material::write_hdf5(std::string filename, std::string datapath,
   H5Tinsert(desc, "comp", HOFFSET(pyne::material_data, comp),
             comp_values_array_type);
 
-  material_data * mat_data  = new material_data[material_data_size];
+  material_data* mat_data  = new material_data[material_data_size];
   (*mat_data).mass = mass;
   (*mat_data).density = density;
   (*mat_data).atoms_per_mol = atoms_per_molecule;
@@ -14248,7 +14243,7 @@ void pyne::Material::write_hdf5(std::string filename, std::string datapath,
 
     // Create the data set
     data_set = H5Dcreate2(db, datapath.c_str(), desc, data_space, H5P_DEFAULT,
-                            data_set_params, H5P_DEFAULT);
+                          data_set_params, H5P_DEFAULT);
     H5Dset_extent(data_set, data_dims);
 
     // Add attribute pointing to nuc path
@@ -14314,13 +14309,13 @@ void pyne::Material::write_hdf5(std::string filename, std::string datapath,
 
     hvl_t attrfillvalue [1];
     attrfillvalue[0].len = 3;
-    attrfillvalue[0].p = (char *) "{}\n";
+    attrfillvalue[0].p = (char*) "{}\n";
     H5Pset_fill_value(metadataetparams, attrtype, &attrfillvalue);
 
     // make dataset
     metadatapace = H5Screate_simple(1, data_dims, data_max_dims);
     metadataet = H5Dcreate2(db, attrpath.c_str(), attrtype, metadatapace,
-                         H5P_DEFAULT, metadataetparams, H5P_DEFAULT);
+                            H5P_DEFAULT, metadataetparams, H5P_DEFAULT);
     H5Dset_extent(metadataet, data_dims);
     H5Pclose(metadataetparams);
   }
@@ -14329,7 +14324,7 @@ void pyne::Material::write_hdf5(std::string filename, std::string datapath,
   hvl_t attrdata [1];
   Json::FastWriter writer;
   std::string metadatatr = writer.write(metadata);
-  attrdata[0].p = (char *) metadatatr.c_str();
+  attrdata[0].p = (char*) metadatatr.c_str();
   attrdata[0].len = metadatatr.length();
 
   // write the attr
@@ -14391,13 +14386,13 @@ std::string pyne::Material::openmc(std::string frac_type) {
 
   // specify density
   oss << "<density ";
-    // if density is negtaive, report to user
+  // if density is negtaive, report to user
   if (temp_mat.density < 0.0) {
     throw pyne::ValueError("A density < 0.0 was found. This is not valid for use in OpenMC.");
   }
   std::string density_str = std::to_string(temp_mat.density);
   // remove trailing zeros
-  density_str.erase( density_str.find_last_not_of('0') + 1, std::string::npos);
+  density_str.erase(density_str.find_last_not_of('0') + 1, std::string::npos);
   oss << "value=" <<  std::fixed << new_quote << density_str << end_quote;
   oss << "units=" << new_quote << "g/cc" << end_quote << "/>";
   // new line
@@ -14405,18 +14400,19 @@ std::string pyne::Material::openmc(std::string frac_type) {
 
   std::map<int, double> fracs;
   std::string frac_attrib;
-  if(frac_type == "atom") {
+  if (frac_type == "atom") {
     fracs = temp_mat.to_atom_frac();
     frac_attrib = "ao=";
-  }
-  else {
+  } else {
     fracs = temp_mat.comp;
     frac_attrib = "wo=";
   }
 
   // add nuclides
-  for(comp_map::iterator f = fracs.begin(); f != fracs.end(); f++) {
-    if (f->second == 0.0) { continue; }
+  for (comp_map::iterator f = fracs.begin(); f != fracs.end(); f++) {
+    if (f->second == 0.0) {
+      continue;
+    }
     //indent
     oss << "  ";
     // start a new nuclide element
@@ -14431,7 +14427,7 @@ std::string pyne::Material::openmc(std::string frac_type) {
   }
 
   // other OpenMC material properties
-  if(temp_mat.metadata.isMember("sab")) {
+  if (temp_mat.metadata.isMember("sab")) {
     oss << indent;
     oss << "<sab name=";
     oss << new_quote << temp_mat.metadata["sab"].asString() << end_quote;
@@ -14439,7 +14435,7 @@ std::string pyne::Material::openmc(std::string frac_type) {
     oss << std::endl;
   }
 
-  if(temp_mat.metadata.isMember("temperature")) {
+  if (temp_mat.metadata.isMember("temperature")) {
     oss << indent;
     oss << "<temperature>";
     oss << new_quote << temp_mat.metadata["temperature"].asString() << end_quote;
@@ -14447,7 +14443,7 @@ std::string pyne::Material::openmc(std::string frac_type) {
     oss << std::endl;
   }
 
-  if(temp_mat.metadata.isMember("macroscopic")) {
+  if (temp_mat.metadata.isMember("macroscopic")) {
     oss << indent;
     oss << "<macroscopic name=";
     oss << new_quote << temp_mat.metadata["macroscropic"].asString() << end_quote;
@@ -14455,7 +14451,7 @@ std::string pyne::Material::openmc(std::string frac_type) {
     oss << std::endl;
   }
 
-  if(temp_mat.metadata.isMember("isotropic")) {
+  if (temp_mat.metadata.isMember("isotropic")) {
     oss << indent;
     oss << "<isotropic>";
     oss << new_quote << temp_mat.metadata["isotropic"].asString() << end_quote;
@@ -14478,13 +14474,13 @@ std::string pyne::Material::mcnp(std::string frac_type) {
   }
   // 'density'
   if (density != -1.0) {
-     std::stringstream ds;
-     ds << std::setprecision(1) << std::fixed << "C density = " << density << std::endl;
-     oss << ds.str();
+    std::stringstream ds;
+    ds << std::setprecision(1) << std::fixed << "C density = " << density << std::endl;
+    oss << ds.str();
   }
   // 'source'
   if (metadata.isMember("source")) {
-     oss << "C source: " << metadata["source"].asString() << std::endl;
+    oss << "C source: " << metadata["source"].asString() << std::endl;
   }
   // Metadata comments
   if (metadata.isMember("comments")) {
@@ -14492,13 +14488,12 @@ std::string pyne::Material::mcnp(std::string frac_type) {
     // Include as is if short enough
     if (comment_string.length() <= 77) {
       oss << "C " << comment_string << std::endl;
-    }
-    else { // otherwise create a remainder string and iterate/update it
-      oss << "C " << comment_string.substr(0,77) << std::endl;
+    } else { // otherwise create a remainder string and iterate/update it
+      oss << "C " << comment_string.substr(0, 77) << std::endl;
       std::string remainder_string = comment_string.substr(77);
       while (remainder_string.length() > 77) {
-        oss << "C " << remainder_string.substr(0,77) << std::endl;
-        remainder_string.erase(0,77);
+        oss << "C " << remainder_string.substr(0, 77) << std::endl;
+        remainder_string.erase(0, 77);
       }
       if (remainder_string.length() > 0) {
         oss << "C " << remainder_string << std::endl;
@@ -14532,7 +14527,7 @@ std::string pyne::Material::mcnp(std::string frac_type) {
   std::stringstream ss;
   std::string nucmcnp;
   std::string table_item;
-  for(pyne::comp_iter i = fracs.begin(); i != fracs.end(); ++i) {
+  for (pyne::comp_iter i = fracs.begin(); i != fracs.end(); ++i) {
     if (i->second > 0.0) {
       // Clear first
       ss.str(std::string());
@@ -14545,14 +14540,14 @@ std::string pyne::Material::mcnp(std::string frac_type) {
       // Spaces are important for tests
       table_item = metadata["table_ids"][nucmcnp].asString();
       if (!table_item.empty()) {
-	oss << "     " << mcnp_id << "." << table_item << " ";
+        oss << "     " << mcnp_id << "." << table_item << " ";
       } else {
-	oss << "     " << mcnp_id << " ";
+        oss << "     " << mcnp_id << " ";
       }
       // The int needs a little formatting
       std::stringstream fs;
       fs << std::setprecision(4) << std::scientific << frac_sign << i->second \
-	 << std::endl;
+         << std::endl;
       oss << fs.str();
     }
   }
@@ -14563,7 +14558,7 @@ std::string pyne::Material::mcnp(std::string frac_type) {
 ///---------------------------------------------------------------------------//
 /// Create a set out of the static string array.
 std::set<std::string> fluka_builtin(pyne::fluka_mat_strings,
-                                    pyne::fluka_mat_strings+pyne::FLUKA_MAT_NUM);
+                                    pyne::fluka_mat_strings + pyne::FLUKA_MAT_NUM);
 
 ///---------------------------------------------------------------------------//
 /// not_fluka_builtin
@@ -14585,7 +14580,7 @@ std::string pyne::Material::fluka(int id, std::string frac_type) {
   if (comp.size() == 1) {
     rs << fluka_material_str(id);
   } else if (comp.size() > 1) {
-  // Compound
+    // Compound
     rs << fluka_compound_str(id, frac_type);
   } else {
     rs << "There is no nuclide information in the Material Object" << std::endl;
@@ -14613,7 +14608,7 @@ std::string pyne::Material::fluka_material_str(int id) {
   if (metadata.isMember("fluka_name")) {
     fluka_name = metadata["fluka_name"].asString();
   } else {  // Should be elemental
-    if (comp.size() > 1 ) {
+    if (comp.size() > 1) {
       std::cerr << "Error: this mix is a compound, there should be a fluka_name defined."
                 << std::endl;
       return ms.str();
@@ -14637,7 +14632,7 @@ std::string pyne::Material::fluka_material_str(int id) {
 /// This function is not called for a compound, but it is called on the
 /// material-ized components of compounds
 std::string pyne::Material::fluka_material_component(int fid, int nucid,
-                                               std::string fluka_name) {
+                                                     std::string fluka_name) {
   int znum = pyne::nucname::znum(nucid);
 
   double atomic_mass;
@@ -14656,24 +14651,24 @@ std::string pyne::Material::fluka_material_component(int fid, int nucid,
 ///---------------------------------------------------------------------------//
 /// Given all the info, return the Material string
 std::string pyne::Material::fluka_material_line(int znum, double atomic_mass,
-                                          int fid, std::string fluka_name) {
+                                                int fid, std::string fluka_name) {
   std::stringstream ls;
 
-  if (metadata.isMember("comments") ) {
-     std::string comment = metadata["comments"].asString();
-     ls << "* " << comment;
-     ls << std::endl;
+  if (metadata.isMember("comments")) {
+    std::string comment = metadata["comments"].asString();
+    ls << "* " << comment;
+    ls << std::endl;
   }
   ls << std::setw(10) << std::left << "MATERIAL";
   ls << std::setprecision(0) << std::fixed << std::showpoint <<
-        std::setw(10) << std::right << (float)znum;
+     std::setw(10) << std::right << (float)znum;
 
   ls << fluka_format_field(atomic_mass);
   // Note this is the current object density, and may or may not be meaningful
-  ls << fluka_format_field(std::sqrt(density*density));
+  ls << fluka_format_field(std::sqrt(density * density));
 
   ls << std::setprecision(0) << std::fixed << std::showpoint <<
-        std::setw(10) << std::right << (float)fid;
+     std::setw(10) << std::right << (float)fid;
   ls << std::setw(10) << std::right << "";
   ls << std::setw(10) << std::right << "";
   ls << std::setw(10) << std::left << fluka_name << std::endl;
@@ -14692,12 +14687,12 @@ std::string pyne::Material::fluka_material_line(int znum, double atomic_mass,
 std::string pyne::Material::fluka_format_field(float field) {
   std::stringstream ls;
   double intpart;
-  modf (field, &intpart);
+  modf(field, &intpart);
   if (field == intpart) {
     ls << std::setprecision(0) << std::fixed << std::showpoint
        << std::setw(10) << std::right << field;
   } else {
-  // This will print however many digits after the decimal, up to a max of six
+    // This will print however many digits after the decimal, up to a max of six
     ls.unsetf(std::ios::showpoint);
     ls.unsetf(std::ios::floatfield);
     ls.precision(6);
@@ -14783,7 +14778,7 @@ std::string pyne::Material::fluka_compound_str(int id, std::string frac_type) {
     nuc++;
     temp_s.str("");
 
-    if  (nuc != comp.end()) {
+    if (nuc != comp.end()) {
       temp_s << frac_sign << nuc->second;
       ss << std::setw(10) << std::right << temp_s.str();
       ss << std::setw(10) << std::right << nucname::fluka(nuc->first);
@@ -14798,13 +14793,13 @@ std::string pyne::Material::fluka_compound_str(int id, std::string frac_type) {
     ss << std::setw(10) << std::right << "";
     ss << std::setw(10) << std::left << compound_name;
     ss << std::endl;
-    }
+  }
 
   return ss.str();
 }
 
-void pyne::Material::from_text(char * filename) {
-  std::string fname (filename);
+void pyne::Material::from_text(char* filename) {
+  std::string fname(filename);
   from_text(fname);
 }
 
@@ -14823,12 +14818,12 @@ void pyne::Material::from_text(std::string filename) {
   std::string keystr, valstr;
 
   f >> keystr;
-  while ( !f.eof() ) {
+  while (!f.eof()) {
 
     if (0 == keystr.length())
       continue;
 
-    if (keystr == "Mass"){
+    if (keystr == "Mass") {
       f >> valstr;
       mass = pyne::to_dbl(valstr);
     } else if (keystr == "Density") {
@@ -14840,28 +14835,28 @@ void pyne::Material::from_text(std::string filename) {
     } else if (pyne::nucname::isnuclide(keystr) ||
                pyne::nucname::iselement(keystr)) {
       f >> valstr;
-      if (comp.count(pyne::nucname::id(keystr))>0) {
+      if (comp.count(pyne::nucname::id(keystr)) > 0) {
         comp[pyne::nucname::id(keystr)] += pyne::to_dbl(valstr);
       } else {
         comp[pyne::nucname::id(keystr)] = pyne::to_dbl(valstr);
       }
     } else {
       getline(f, valstr);
-      valstr= valstr.substr(0, valstr.length()-1);
-      metadata[keystr]= valstr;
+      valstr = valstr.substr(0, valstr.length() - 1);
+      metadata[keystr] = valstr;
 
     }
     f >> keystr;
-   }
+  }
 
-   f.close();
-   norm_comp();
+  f.close();
+  norm_comp();
 }
 
 
 
-void pyne::Material::write_text(char * filename) {
-  std::string fname (filename);
+void pyne::Material::write_text(char* filename) {
+  std::string fname(filename);
   write_text(fname);
 }
 
@@ -14882,13 +14877,13 @@ void pyne::Material::write_text(std::string filename) {
   if (0 <= atoms_per_molecule)
     f << "APerM   " << atoms_per_molecule << "\n";
 
-  for (int i=0; i < metadata.size(); i=i+2){
-    f <<metadata.get(obj.at(i), "") << metadata.get(obj.at(i+1), "");
+  for (int i = 0; i < metadata.size(); i = i + 2) {
+    f << metadata.get(obj.at(i), "") << metadata.get(obj.at(i + 1), "");
   }
 
   std::string nuc_name;
-  for(pyne::comp_iter i = comp.begin(); i != comp.end(); i++) {
-    nuc_name = pyne::nucname::name( i->first ) + "  ";
+  for (pyne::comp_iter i = comp.begin(); i != comp.end(); i++) {
+    nuc_name = pyne::nucname::name(i->first) + "  ";
     while (nuc_name.length() < 8)
       nuc_name += " ";
     f << nuc_name << i->second << "\n";
@@ -14920,15 +14915,15 @@ Json::Value pyne::Material::dump_json() {
   json["density"] = density;
   json["atoms_per_molecule"] = atoms_per_molecule;
   json["metadata"] = metadata;
-  for(comp_iter i = comp.begin(); i != comp.end(); i++)
+  for (comp_iter i = comp.begin(); i != comp.end(); i++)
     jcomp[nucname::name(i->first)] = (i->second);
   json["comp"] = jcomp;
   return json;
 }
 
 
-void pyne::Material::from_json(char * filename) {
-  std::string fname (filename);
+void pyne::Material::from_json(char* filename) {
+  std::string fname(filename);
   from_json(fname);
 }
 
@@ -14936,7 +14931,7 @@ void pyne::Material::from_json(std::string filename) {
   if (!pyne::file_exists(filename))
     throw pyne::FileNotFound(filename);
   std::string s;
-  std::ifstream f (filename.c_str(), std::ios::in | std::ios::binary);
+  std::ifstream f(filename.c_str(), std::ios::in | std::ios::binary);
   f.seekg(0, std::ios::end);
   s.resize(f.tellg());
   f.seekg(0, std::ios::beg);
@@ -14949,8 +14944,8 @@ void pyne::Material::from_json(std::string filename) {
 }
 
 
-void pyne::Material::write_json(char * filename) {
-  std::string fname (filename);
+void pyne::Material::write_json(char* filename) {
+  std::string fname(filename);
   write_json(fname);
 }
 
@@ -14985,7 +14980,7 @@ pyne::Material::Material(pyne::comp_map cm, double m, double d, double apm,
   // Initializes the mass stream based on an isotopic component dictionary.
   comp = cm;
   mass = m;
-  density=d;
+  density = d;
   atoms_per_molecule = apm;
   metadata = attributes;
   if (!comp.empty())
@@ -14994,15 +14989,15 @@ pyne::Material::Material(pyne::comp_map cm, double m, double d, double apm,
 
 
 
-pyne::Material::Material(char * filename, double m, double d, double apm,
+pyne::Material::Material(char* filename, double m, double d, double apm,
                          Json::Value attributes) {
   mass = m;
-  density=d;
+  density = d;
   atoms_per_molecule = apm;
   metadata = attributes;
 
   // Check that the file is there
-  std::string fname (filename);
+  std::string fname(filename);
   if (!pyne::file_exists(fname))
     throw pyne::FileNotFound(fname);
 
@@ -15019,7 +15014,7 @@ pyne::Material::Material(std::string filename, double m, double d, double apm,
                          Json::Value attributes) {
   // Initializes the mass stream based on an isotopic composition file with a string name.
   mass = m;
-  density=d;
+  density = d;
   atoms_per_molecule = apm;
   metadata = attributes;
 
@@ -15048,9 +15043,8 @@ std::ostream& operator<<(std::ostream& os, pyne::Material mat) {
   //print the Mass Stream to stdout
   os << "\tMass: " << mat.mass << "\n";
   os << "\t---------\n";
-  for(pyne::comp_iter i = mat.comp.begin(); i != mat.comp.end(); i++)
-  {
-    os << "\t" << pyne::nucname::name( i->first ) << "\t" << i->second << "\n";
+  for (pyne::comp_iter i = mat.comp.begin(); i != mat.comp.end(); i++) {
+    os << "\t" << pyne::nucname::name(i->first) << "\t" << i->second << "\n";
   }
   return os;
 }
@@ -15060,7 +15054,7 @@ std::ostringstream& operator<<(std::ostringstream& os, pyne::Material mat) {
   return os;
 }
 
-void pyne::Material::normalize () {
+void pyne::Material::normalize() {
   // normalizes the mass
   mass = 1.0;
 }
@@ -15178,16 +15172,16 @@ pyne::Material pyne::Material::expand_elements(std::set<int> exception_ids) {
       continue;
     }
 
-    if(abund_itr == abund_end)
+    if (abund_itr == abund_end)
       newcomp.insert(*nuc);
-    else if(0 == nucname::anum((*nuc).first)) {
+    else if (0 == nucname::anum((*nuc).first)) {
       n = (*nuc).first;
       znuc = nucname::znum(n);
       if (znuc < zabund) {
         newcomp.insert(*nuc);
         continue;
       }
-      while(zabund <= znuc) {
+      while (zabund <= znuc) {
         nabund = (*abund_itr).first;
         if (zabund == znuc && 0 != nucname::anum(nabund) && 0.0 != (*abund_itr).second)
           newcomp[nabund] = (*abund_itr).second * (*nuc).second * \
@@ -15208,18 +15202,17 @@ pyne::Material pyne::Material::expand_elements(std::set<int> exception_ids) {
 }
 
 // Wrapped version for calling from python
-pyne::Material pyne::Material::expand_elements(int** int_ptr_arry ) {
-    std::set<int> nucvec;
-    // Set first pointer to first int pointed to by arg
-    if (int_ptr_arry != NULL) {
-      int *int_ptr = *int_ptr_arry;
-      while (int_ptr != NULL)
-	{
-	  nucvec.insert(*int_ptr);
-	  int_ptr++;
-	}
+pyne::Material pyne::Material::expand_elements(int** int_ptr_arry) {
+  std::set<int> nucvec;
+  // Set first pointer to first int pointed to by arg
+  if (int_ptr_arry != NULL) {
+    int* int_ptr = *int_ptr_arry;
+    while (int_ptr != NULL) {
+      nucvec.insert(*int_ptr);
+      int_ptr++;
     }
-    return expand_elements(nucvec);
+  }
+  return expand_elements(nucvec);
 }
 
 
@@ -15244,21 +15237,21 @@ pyne::Material pyne::Material::collapse_elements(std::set<int> exception_ids) {
   pyne::comp_map cm;
 
   for (pyne::comp_iter ptr = comp.begin(); ptr != comp.end(); ptr++) {
-      if (0 < ptr->second) {
-        // There is a nonzero amount of this nucid in the current material,
-        // check if znum and anum are in the exception list,
-        int cur_stripped_id = nucname::znum(ptr->first)*10000000
-                        + nucname::anum(ptr->first)*10000;
-        if (0 < exception_ids.count(cur_stripped_id)) {
+    if (0 < ptr->second) {
+      // There is a nonzero amount of this nucid in the current material,
+      // check if znum and anum are in the exception list,
+      int cur_stripped_id = nucname::znum(ptr->first) * 10000000
+                            + nucname::anum(ptr->first) * 10000;
+      if (0 < exception_ids.count(cur_stripped_id)) {
         // The znum/anum combination identify the current material as a
         // fluka-named exception list => copy, don't collapse
-          cm[ptr->first] = (ptr->second) * mass;
-        } else {
-          // Not on exception list => add frac to id-component
-          int znum_id = nucname::id(nucname::znum(ptr->first));
-          cm[znum_id] += (ptr->second) * mass;
-        }
+        cm[ptr->first] = (ptr->second) * mass;
+      } else {
+        // Not on exception list => add frac to id-component
+        int znum_id = nucname::id(nucname::znum(ptr->first));
+        cm[znum_id] += (ptr->second) * mass;
       }
+    }
   }
   // Copy
   pyne::Material collapsed = pyne::Material(cm, mass, density,
@@ -15267,16 +15260,15 @@ pyne::Material pyne::Material::collapse_elements(std::set<int> exception_ids) {
 }
 
 // Wrapped version for calling from python
-pyne::Material pyne::Material::collapse_elements(int** int_ptr_arry ) {
-    std::set<int> nucvec;
-    // Set first pointer to first int pointed to by arg
-    int *int_ptr = *int_ptr_arry;
-    while (int_ptr != NULL)
-    {
-      nucvec.insert(*int_ptr);
-      int_ptr++;
-    }
-    return collapse_elements(nucvec);
+pyne::Material pyne::Material::collapse_elements(int** int_ptr_arry) {
+  std::set<int> nucvec;
+  // Set first pointer to first int pointed to by arg
+  int* int_ptr = *int_ptr_arry;
+  while (int_ptr != NULL) {
+    nucvec.insert(*int_ptr);
+    int_ptr++;
+  }
+  return collapse_elements(nucvec);
 }
 
 double pyne::Material::mass_density(double num_dens, double apm) {
@@ -15305,7 +15297,7 @@ pyne::Material pyne::Material::sub_mat(std::set<int> nucset) {
 
   pyne::comp_map cm;
   for (pyne::comp_iter i = comp.begin(); i != comp.end(); i++) {
-    if ( 0 < nucset.count(i->first) )
+    if (0 < nucset.count(i->first))
       cm[i->first] = (i->second) * mass;
   }
 
@@ -15327,7 +15319,7 @@ pyne::Material pyne::Material::sub_mat(std::set<std::string> nucset) {
 
 
 
-pyne::Material pyne::Material::set_mat (std::set<int> nucset, double value) {
+pyne::Material pyne::Material::set_mat(std::set<int> nucset, double value) {
   // Sets a sub-material from this mat based on a set of integers.
   // Integers can either be of id form -OR- they can be a z-numer (is 8 for O, 93 for Np, etc).
   // n is the name of the new material.
@@ -15336,7 +15328,7 @@ pyne::Material pyne::Material::set_mat (std::set<int> nucset, double value) {
 
   // Add non-set components
   for (pyne::comp_iter i = comp.begin(); i != comp.end(); i++) {
-    if ( 0 == nucset.count(i->first) )
+    if (0 == nucset.count(i->first))
       cm[i->first] = (i->second) * mass;
   }
 
@@ -15371,7 +15363,7 @@ pyne::Material pyne::Material::del_mat(std::set<int> nucset) {
   pyne::comp_map cm;
   for (pyne::comp_iter i = comp.begin(); i != comp.end(); i++) {
     // Only add to new comp if not in nucset
-    if ( 0 == nucset.count(i->first) )
+    if (0 == nucset.count(i->first))
       cm[i->first] = (i->second) * mass;
   }
 
@@ -15380,7 +15372,7 @@ pyne::Material pyne::Material::del_mat(std::set<int> nucset) {
 
 
 
-pyne::Material pyne::Material::del_mat (std::set<std::string> nucset) {
+pyne::Material pyne::Material::del_mat(std::set<std::string> nucset) {
   // Removes a substream from this stream based on a set of strings.
   // Strings can be of any form.
   std::set<int> iset;
@@ -15398,8 +15390,7 @@ pyne::Material pyne::Material::del_mat (std::set<std::string> nucset) {
 
 pyne::Material pyne::Material::sub_range(int lower, int upper) {
   // Grabs a sub-material from this mat based on a range of integers.
-  if (upper < lower)
-  {
+  if (upper < lower) {
     int temp_upper = upper;
     upper = lower;
     lower = temp_upper;
@@ -15411,7 +15402,7 @@ pyne::Material pyne::Material::sub_range(int lower, int upper) {
       cm[i->first] = (i->second) * mass;
   }
 
-  return pyne::Material(cm, -1,-1);
+  return pyne::Material(cm, -1, -1);
 }
 
 
@@ -15432,7 +15423,7 @@ pyne::Material pyne::Material::set_range(int lower, int upper, double value) {
       cm[i->first] = (i->second) * mass;
   }
 
-  return pyne::Material(cm, -1,-1);
+  return pyne::Material(cm, -1, -1);
 }
 
 
@@ -15558,14 +15549,14 @@ std::vector<std::pair<double, double> > pyne::Material::gammas() {
   int state_id;
   for (comp_iter ci = comp.begin(); ci != comp.end(); ci++) {
     if (ci->first % 10000 > 0)
-        state_id = nucname::id_to_state_id(ci->first);
+      state_id = nucname::id_to_state_id(ci->first);
     else
-        state_id = ci->first;
+      state_id = ci->first;
 
     std::vector<std::pair<double, double> > raw_gammas = pyne::gammas(state_id);
     for (int i = 0; i < raw_gammas.size(); ++i) {
       result.push_back(std::make_pair(raw_gammas[i].first,
-        atom_fracs[ci->first]*raw_gammas[i].second));
+                                      atom_fracs[ci->first]*raw_gammas[i].second));
     }
   }
   return result;
@@ -15577,14 +15568,14 @@ std::vector<std::pair<double, double> > pyne::Material::xrays() {
   int state_id;
   for (comp_iter ci = comp.begin(); ci != comp.end(); ci++) {
     if (ci->first % 10000 > 0)
-        state_id = nucname::id_to_state_id(ci->first);
+      state_id = nucname::id_to_state_id(ci->first);
     else
-        state_id = ci->first;
+      state_id = ci->first;
 
     std::vector<std::pair<double, double> > raw_xrays = pyne::xrays(state_id);
     for (int i = 0; i < raw_xrays.size(); ++i) {
       result.push_back(std::make_pair(raw_xrays[i].first,
-        atom_fracs[ci->first]*raw_xrays[i].second));
+                                      atom_fracs[ci->first]*raw_xrays[i].second));
     }
   }
   return result;
@@ -15601,7 +15592,7 @@ std::vector<std::pair<double, double> > pyne::Material::photons(bool norm) {
 }
 
 std::vector<std::pair<double, double> > pyne::Material::normalize_radioactivity(
-std::vector<std::pair<double, double> > unnormed) {
+    std::vector<std::pair<double, double> > unnormed) {
   std::vector<std::pair<double, double> > normed;
   double sum = 0.0;
   for (int i = 0; i < unnormed.size(); ++i) {
@@ -15611,7 +15602,7 @@ std::vector<std::pair<double, double> > unnormed) {
   for (int i = 0; i < unnormed.size(); ++i) {
     if (!isnan(unnormed[i].second)) {
       normed.push_back(std::make_pair(unnormed[i].first,
-        (unnormed[i].second)/sum));
+                                      (unnormed[i].second) / sum));
     }
   }
   return normed;
@@ -15644,14 +15635,14 @@ pyne::Material pyne::Material::operator+ (Material y) {
   pyne::comp_map ywgt = y.mult_by_mass();
 
   for (pyne::comp_iter i = xwgt.begin(); i != xwgt.end(); i++) {
-    if ( 0 < ywgt.count(i->first) )
+    if (0 < ywgt.count(i->first))
       cm[i->first] = xwgt[i->first] + ywgt[i->first];
     else
       cm[i->first] = xwgt[i->first];
   }
 
   for (pyne::comp_iter i = ywgt.begin(); i != ywgt.end(); i++) {
-    if ( 0 == cm.count(i->first) )
+    if (0 == cm.count(i->first))
       cm[i->first] = ywgt[i->first];
   }
 
@@ -15669,7 +15660,7 @@ pyne::Material pyne::Material::operator* (double y) {
 
 pyne::Material pyne::Material::operator/ (double y) {
   // Overloads x / y
-  return pyne::Material(comp, mass / y, density );
+  return pyne::Material(comp, mass / y, density);
 }
 
 //

--- a/src/pyne/pyne.h
+++ b/src/pyne/pyne.h
@@ -95,158 +95,194 @@
 #include <algorithm>
 
 #if (__GNUC__ >= 4)
-#include <cmath>
-#define isnan(x) std::isnan(x)
+  #include <cmath>
+  #define isnan(x) std::isnan(x)
 #else
-#include <math.h>
-#define isnan(x) __isnand((double)x)
+  #include <math.h>
+  #define isnan(x) __isnand((double)x)
 #endif
 
 #ifdef __WIN_MSVC__
-#define isnan(x) ((x) != (x))
+    #define isnan(x) ((x) != (x))
 #endif
 
 #ifndef JSON_IS_AMALGAMATION
-#define JSON_IS_AMALGAMATION
+  #define JSON_IS_AMALGAMATION
 #endif
 
 /// The 'pyne' namespace all PyNE functionality is included in.
 namespace pyne {
 
-void pyne_start();  ///< Initializes PyNE based on environment.
+  void pyne_start (); ///< Initializes PyNE based on environment.
 
-/// Path to the directory containing the PyNE data.
-extern std::string PYNE_DATA;
-extern std::string NUC_DATA_PATH; ///< Path to the nuc_data.h5 file.
+  /// Path to the directory containing the PyNE data.
+  extern std::string PYNE_DATA;
+  extern std::string NUC_DATA_PATH; ///< Path to the nuc_data.h5 file.
+  extern std::string VERSION; ///< PyNE version number
 
-// String Transformations
-/// string of digit characters
-static std::string digits = "0123456789";
-/// uppercase alphabetical characters
-static std::string alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-/// string of all valid word characters for variable names in programing languages.
-static std::string words = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_";
+  // String Transformations
+  /// string of digit characters
+  static std::string digits = "0123456789";
+  /// uppercase alphabetical characters
+  static std::string alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+  /// string of all valid word characters for variable names in programing languages.
+  static std::string words = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_";
 
-/// \name String Conversion Functions
-/// \{
-/// Converts the variables of various types to their C++ string representation.
-std::string to_str(int t);
-std::string to_str(unsigned int t);
-std::string to_str(double t);
-std::string to_str(bool t);
-/// \}
+  /// \name String Conversion Functions
+  /// \{
+  /// Converts the variables of various types to their C++ string representation.
+  std::string to_str(int t);
+  std::string to_str(unsigned int t);
+  std::string to_str(double t);
+  std::string to_str(bool t);
+  /// \}
 
-int to_int(std::string s);  ///< Converts a string of digits to an int using atoi().
+  int to_int(std::string s);  ///< Converts a string of digits to an int using atoi().
 
-double to_dbl(std::string s);  ///< Converts a valid string to a float using atof().
+  double to_dbl(std::string s);  ///< Converts a valid string to a float using atof().
 
-/// Converts a string from ENDF format to a float. Only handles E-less format
-/// but is roughly 5 times faster than endftod.
-double endftod_cpp(char* s);
-double endftod_f(char* s);  ///< Converts a string from ENDF format to a float.
-extern  double (*endftod)(char* s);  ///< endftod function pointer. defaults to fortran
+  /// Converts a string from ENDF format to a float. Only handles E-less format
+  /// but is roughly 5 times faster than endftod.
+  double endftod_cpp(char * s);
+  double endftod_f(char * s); ///< Converts a string from ENDF format to a float.
+  extern  double (*endftod)(char * s); ///< endftod function pointer. defaults to fortran
 
-void use_fast_endftod();/// switches endftod to fast cpp version
+  void use_fast_endftod();/// switches endftod to fast cpp version
 
-/// Returns an all upper case copy of the string.
-std::string to_upper(std::string s);
+  /// Returns an all upper case copy of the string.
+  std::string to_upper(std::string s);
 
-/// Returns an all lower case copy of the string.
-std::string to_lower(std::string s);
+  /// Returns an all lower case copy of the string.
+  std::string to_lower(std::string s);
 
-/// Returns a capitalized copy of the string.
-std::string capitalize(std::string s);
+  /// Returns a capitalized copy of the string.
+  std::string capitalize(std::string s);
 
-/// Finds and returns the first white-space delimited token of a line.
-/// \param line a character array to take the first token from.
-/// \param max_l an upper bound to the length of the token.  Must be 11 or less.
-/// \returns a the flag as a string
-std::string get_flag(char line[], int max_l);
+  /// Finds and returns the first white-space delimited token of a line.
+  /// \param line a character array to take the first token from.
+  /// \param max_l an upper bound to the length of the token.  Must be 11 or less.
+  /// \returns a the flag as a string
+  std::string get_flag(char line[], int max_l);
 
-/// Creates a copy of \a s with all instances of \a substr taken out.
-std::string remove_substring(std::string s, std::string substr);
+  /// Creates a copy of \a s with all instances of \a substr taken out.
+  std::string remove_substring(std::string s, std::string substr);
 
-/// Removes all characters in the string \a chars from \a s.
-std::string remove_characters(std::string s, std::string chars);
+  /// Removes all characters in the string \a chars from \a s.
+  std::string remove_characters(std::string s, std::string chars);
 
-/// Replaces all instance of \a substr in \a s with \a repstr.
-std::string replace_all_substrings(std::string s, std::string substr,
-                                   std::string repstr);
+  /// Replaces all instance of \a substr in \a s with \a repstr.
+  std::string replace_all_substrings(std::string s, std::string substr,
+                                                    std::string repstr);
 
-/// Returns the last character in a string.
-std::string last_char(std::string s);
+  /// Returns the last character in a string.
+  std::string last_char(std::string s);
 
-/// Returns the slice of a string \a s using the negative index \a n and the
-/// length of the slice \a l.
-std::string slice_from_end(std::string s, int n = -1, int l = 1);
+  /// Returns the slice of a string \a s using the negative index \a n and the
+  /// length of the slice \a l.
+  std::string slice_from_end(std::string s, int n=-1, int l=1);
 
-/// Returns true if \a a <= \a b <= \a c and flase otherwise.
-bool ternary_ge(int a, int b, int c);
+  /// Returns true if \a a <= \a b <= \a c and flase otherwise.
+  bool ternary_ge(int a, int b, int c);
 
-/// Returns true if \a substr is in \a s.
-bool contains_substring(std::string s, std::string substr);
+  /// Returns true if \a substr is in \a s.
+  bool contains_substring(std::string s, std::string substr);
 
-/// Calculates a version of the string \a name that is also a valid variable name.
-/// That is to say that the return value uses only word characters.
-std::string natural_naming(std::string name);
+  /// Calculates a version of the string \a name that is also a valid variable name.
+  /// That is to say that the return value uses only word characters.
+  std::string natural_naming(std::string name);
 
-/// Finds the slope of a line from the points (\a x1, \a y1) and (\a x2, \a y2).
-double slope(double x2, double y2, double x1, double y1);
+  /// Finds the slope of a line from the points (\a x1, \a y1) and (\a x2, \a y2).
+  double slope (double x2, double y2, double x1, double y1);
 
-/// Solves the equation for the line y = mx + b, given \a x and the points that
-/// form the line: (\a x1, \a y1) and (\a x2, \a y2).
-double solve_line(double x, double x2, double y2, double x1, double y1);
+  /// Solves the equation for the line y = mx + b, given \a x and the points that
+  /// form the line: (\a x1, \a y1) and (\a x2, \a y2).
+  double solve_line (double x, double x2, double y2, double x1, double y1);
 
-double tanh(double x);  ///< The hyperbolic tangent function.
-double coth(double x);  ///< The hyperbolic cotangent function.
+  double tanh(double x);  ///< The hyperbolic tangent function.
+  double coth(double x);  ///< The hyperbolic cotangent function.
 
 
-// File Helpers
-/// Returns true if the file can be found.
-bool file_exists(std::string strfilename);
+  // File Helpers
+  /// Returns true if the file can be found.
+  bool file_exists(std::string strfilename);
 
-// Message Helpers
-extern bool USE_WARNINGS;
-/// Toggles warnings on and off
-bool toggle_warnings();
+  // Message Helpers
+  extern bool USE_WARNINGS;
+  /// Toggles warnings on and off
+  bool toggle_warnings();
 
-/// Prints a warning message.
-void warning(std::string s);
+  /// Prints a warning message.
+  void warning(std::string s);
 
-/// Custom exception to be thrown in the event that a required file is not able to
-/// be found.
-class FileNotFound : public std::exception {
- public:
+  /// Custom exception to be thrown in the event that a required file is not able to
+  /// be found.
+  class FileNotFound : public std::exception
+  {
+  public:
 
-  /// default constructor
-  FileNotFound() {};
+    /// default constructor
+    FileNotFound () {};
 
-  /// default destructor
-  ~FileNotFound() throw () {};
+    /// default destructor
+    ~FileNotFound () throw () {};
 
-  /// constructor with the filename \a fname.
-  FileNotFound(std::string fname) {
-    filename = fname;
+    /// constructor with the filename \a fname.
+    FileNotFound(std::string fname)
+    {
+      filename = fname;
+    };
+
+    /// Creates a helpful error message.
+    virtual const char* what() const throw()
+    {
+      std::string FNFstr ("File not found: ");
+      if (!filename.empty())
+        FNFstr += filename;
+
+      return (const char *) FNFstr.c_str();
+    };
+
+  private:
+    std::string filename; ///< unfindable filename.
   };
 
-  /// Creates a helpful error message.
-  virtual const char* what() const throw() {
-    std::string FNFstr("File not found: ");
-    if (!filename.empty())
-      FNFstr += filename;
+  /// Exception representing value errors of all kinds
+  class ValueError : public std::exception
+  {
+  public:
 
-    return (const char*) FNFstr.c_str();
+    /// default constructor
+    ValueError () {};
+
+    /// default destructor
+    ~ValueError () throw () {};
+
+    /// constructor with the filename \a fname.
+    ValueError(std::string msg)
+    {
+      message = msg;
+    };
+
+    /// Creates a helpful error message.
+    virtual const char* what() const throw()
+    {
+      std::string msgstr ("ValueError: ");
+      if (!message.empty())
+        msgstr += message;
+
+      return (const char *) msgstr.c_str();
+    };
+
+  private:
+    std::string message; ///< extra message for the user.
   };
-
- private:
-  std::string filename; ///< unfindable filename.
-};
 
 
 // End PyNE namespace
 }
 
 #endif  // PYNE_KMMHYNANYFF5BFMEYIP7TUNLHA
+
 //
 // end of src/utils.h
 //
@@ -770,585 +806,620 @@ inline bool path_exists(hid_t h5file, std::string path) {
 #include "utils.h"
 #endif
 
-namespace pyne {
+namespace pyne
+{
 //! Nuclide naming conventions
-namespace nucname {
-typedef std::string name_t; ///< name type
-typedef int zz_t;           ///< Z number type
+namespace nucname
+{
+  typedef std::string name_t; ///< name type
+  typedef int zz_t;           ///< Z number type
 
-typedef std::map<name_t, zz_t> name_zz_t; ///< name and Z num map type
-typedef name_zz_t::iterator name_zz_iter; ///< name and Z num iter type
-name_zz_t get_name_zz();  ///< Creates standard name to Z number mapping.
-extern name_zz_t name_zz; ///< name to Z num map
+  typedef std::map<name_t, zz_t> name_zz_t; ///< name and Z num map type
+  typedef name_zz_t::iterator name_zz_iter; ///< name and Z num iter type
+  name_zz_t get_name_zz();  ///< Creates standard name to Z number mapping.
+  extern name_zz_t name_zz; ///< name to Z num map
 
-typedef std::map<zz_t, name_t> zzname_t;  ///< Z num to name map type
-typedef zzname_t::iterator zzname_iter;   ///< Z num to name iter type
-zzname_t get_zz_name();   ///< Creates standard Z number to name mapping.
-extern zzname_t zz_name;  ///< Z num to name map
+  typedef std::map<zz_t, name_t> zzname_t;  ///< Z num to name map type
+  typedef zzname_t::iterator zzname_iter;   ///< Z num to name iter type
+  zzname_t get_zz_name();   ///< Creates standard Z number to name mapping.
+  extern zzname_t zz_name;  ///< Z num to name map
 
-name_zz_t get_fluka_zz();  ///< Creates standard fluka-name to nucid mapping.
-extern name_zz_t fluka_zz; ///< fluka-name to nucid map
-zzname_t get_zz_fluka();   ///< Creates standard nucid to fluka-name mapping.
-extern zzname_t zz_fluka;  ///< nucid to fluka-name map
-/******************************************/
-/*** Define useful elemental group sets ***/
-/******************************************/
+  name_zz_t get_fluka_zz();  ///< Creates standard fluka-name to nucid mapping.
+  extern name_zz_t fluka_zz; ///< fluka-name to nucid map
+  zzname_t get_zz_fluka();   ///< Creates standard nucid to fluka-name mapping.
+  extern zzname_t zz_fluka;  ///< nucid to fluka-name map
+  /******************************************/
+  /*** Define useful elemental group sets ***/
+  /******************************************/
 
-/// name grouping type (for testing containment)
-typedef std::set<name_t> name_group;
-typedef name_group::iterator name_group_iter; ///< name grouping iter type
+  /// name grouping type (for testing containment)
+  typedef std::set<name_t> name_group;
+  typedef name_group::iterator name_group_iter; ///< name grouping iter type
 
-/// Z number grouping type (for testing containment)
-typedef std::set<zz_t> zz_group;
-typedef zz_group::iterator zz_group_iter; ///< Z number grouping iter
+  /// Z number grouping type (for testing containment)
+  typedef std::set<zz_t> zz_group;
+  typedef zz_group::iterator zz_group_iter; ///< Z number grouping iter
 
-/// Converts a name group to a Z number group.
-/// \param eg a grouping of nuclides by name
-/// \return a Z numbered group
-zz_group name_to_zz_group(name_group eg);
+  /// Converts a name group to a Z number group.
+  /// \param eg a grouping of nuclides by name
+  /// \return a Z numbered group
+  zz_group name_to_zz_group (name_group eg);
 
-extern name_t LAN_array[15];  ///< array of lanthanide names
-extern name_group LAN;        ///< lanthanide name group
-extern zz_group lan;          ///< lanthanide Z number group
+  extern name_t LAN_array[15];  ///< array of lanthanide names
+  extern name_group LAN;        ///< lanthanide name group
+  extern zz_group lan;          ///< lanthanide Z number group
 
-extern name_t ACT_array[15];  ///< array of actinide names
-extern name_group ACT;        ///< actinide name group
-extern zz_group act;          ///< actinide Z number group
+  extern name_t ACT_array[15];  ///< array of actinide names
+  extern name_group ACT;        ///< actinide name group
+  extern zz_group act;          ///< actinide Z number group
 
-extern name_t TRU_array[22];  ///< array of transuranic names
-extern name_group TRU;        ///< transuranic name group
-extern zz_group tru;          ///< transuranic Z number group
+  extern name_t TRU_array[22];  ///< array of transuranic names
+  extern name_group TRU;        ///< transuranic name group
+  extern zz_group tru;          ///< transuranic Z number group
 
-extern name_t MA_array[10];   ///< array of minor actinide names
-extern name_group MA;         ///< minor actinide name group
-extern zz_group ma;           ///< minor actinide Z number group
+  extern name_t MA_array[10];   ///< array of minor actinide names
+  extern name_group MA;         ///< minor actinide name group
+  extern zz_group ma;           ///< minor actinide Z number group
 
-extern name_t FP_array[88];   ///< array of fission product names
-extern name_group FP;         ///< fission product name group
-extern zz_group fp;           ///< fission product Z number group
+  extern name_t FP_array[88];   ///< array of fission product names
+  extern name_group FP;         ///< fission product name group
+  extern zz_group fp;           ///< fission product Z number group
 
 
-/******************/
-/*** Exceptions ***/
-/******************/
+  /******************/
+  /*** Exceptions ***/
+  /******************/
 
-/// Custom expection for declaring that a value does not follow a recognizable
-/// nuclide naming convention.
-class NotANuclide : public std::exception {
- public:
-  /// default constructor
-  NotANuclide() {};
+  /// Custom expection for declaring that a value does not follow a recognizable
+  /// nuclide naming convention.
+  class NotANuclide : public std::exception
+  {
+  public:
+    /// default constructor
+    NotANuclide () {};
 
-  /// default destructor
-  ~NotANuclide() throw () {};
+    /// default destructor
+    ~NotANuclide () throw () {};
 
-  /// Constructor given previous and current state of nulide name
-  /// \param wasptr Previous state, typically user input.
-  /// \param nowptr Current state, as far as PyNE could get.
-  NotANuclide(std::string wasptr, std::string nowptr) {
-    nucwas = wasptr;
-    nucnow = nowptr;
+    /// Constructor given previous and current state of nulide name
+    /// \param wasptr Previous state, typically user input.
+    /// \param nowptr Current state, as far as PyNE could get.
+    NotANuclide(std::string wasptr, std::string nowptr)
+    {
+       nucwas = wasptr;
+       nucnow = nowptr;
+    };
+
+    /// Constructor given previous and current state of nulide name
+    /// \param wasptr Previous state, typically user input.
+    /// \param nowptr Current state, as far as PyNE could get.
+    NotANuclide(std::string wasptr, int nowptr)
+    {
+      nucwas = wasptr;
+      nucnow = pyne::to_str(nowptr);
+    };
+
+    /// Constructor given previous and current state of nulide name
+    /// \param wasptr Previous state, typically user input.
+    /// \param nowptr Current state, as far as PyNE could get.
+    NotANuclide(int wasptr, std::string nowptr)
+    {
+      nucwas = pyne::to_str(wasptr);
+      nucnow = nowptr;
+    };
+
+    /// Constructor given previous and current state of nulide name
+    /// \param wasptr Previous state, typically user input.
+    /// \param nowptr Current state, as far as PyNE could get.
+    NotANuclide(int wasptr, int nowptr)
+    {
+      nucwas = pyne::to_str(wasptr);
+      nucnow = pyne::to_str(nowptr);
+    };
+
+    /// Generates an informational message for the exception
+    /// \return The error string
+    virtual const char* what() const throw()
+    {
+      std::string NaNEstr ("Not a Nuclide! ");
+      if (!nucwas.empty())
+        NaNEstr += nucwas;
+
+      if (!nucnow.empty())
+      {
+        NaNEstr += " --> ";
+        NaNEstr += nucnow;
+      }
+      return (const char *) NaNEstr.c_str();
+    };
+
+  private:
+    std::string nucwas; ///< previous nuclide state
+    std::string nucnow; ///< current nuclide state
   };
 
-  /// Constructor given previous and current state of nulide name
-  /// \param wasptr Previous state, typically user input.
-  /// \param nowptr Current state, as far as PyNE could get.
-  NotANuclide(std::string wasptr, int nowptr) {
-    nucwas = wasptr;
-    nucnow = pyne::to_str(nowptr);
-  };
+  /// Custom expection for declaring that a value represents one or more nuclides
+  /// in one or more namig conventions
+  class IndeterminateNuclideForm : public std::exception
+  {
+  public:
+    /// default constructor
+    IndeterminateNuclideForm () {};
 
-  /// Constructor given previous and current state of nulide name
-  /// \param wasptr Previous state, typically user input.
-  /// \param nowptr Current state, as far as PyNE could get.
-  NotANuclide(int wasptr, std::string nowptr) {
-    nucwas = pyne::to_str(wasptr);
-    nucnow = nowptr;
-  };
+    /// default destuctor
+    ~IndeterminateNuclideForm () throw () {};
 
-  /// Constructor given previous and current state of nulide name
-  /// \param wasptr Previous state, typically user input.
-  /// \param nowptr Current state, as far as PyNE could get.
-  NotANuclide(int wasptr, int nowptr) {
-    nucwas = pyne::to_str(wasptr);
-    nucnow = pyne::to_str(nowptr);
-  };
+    /// Constructor given previous and current state of nulide name
+    /// \param wasptr Previous state, typically user input.
+    /// \param nowptr Current state, as far as PyNE could get.
+    IndeterminateNuclideForm(std::string wasptr, std::string nowptr)
+    {
+       nucwas = wasptr;
+       nucnow = nowptr;
+    };
 
-  /// Generates an informational message for the exception
-  /// \return The error string
-  virtual const char* what() const throw() {
-    std::string NaNEstr("Not a Nuclide! ");
-    if (!nucwas.empty())
-      NaNEstr += nucwas;
+    /// Constructor given previous and current state of nulide name
+    /// \param wasptr Previous state, typically user input.
+    /// \param nowptr Current state, as far as PyNE could get.
+    IndeterminateNuclideForm(std::string wasptr, int nowptr)
+    {
+      nucwas = wasptr;
+      nucnow = pyne::to_str(nowptr);
+    };
 
-    if (!nucnow.empty()) {
-      NaNEstr += " --> ";
-      NaNEstr += nucnow;
+    /// Constructor given previous and current state of nulide name
+    /// \param wasptr Previous state, typically user input.
+    /// \param nowptr Current state, as far as PyNE could get.
+    IndeterminateNuclideForm(int wasptr, std::string nowptr)
+    {
+      nucwas = pyne::to_str(wasptr);
+      nucnow = nowptr;
+    };
+
+    /// Constructor given previous and current state of nulide name
+    /// \param wasptr Previous state, typically user input.
+    /// \param nowptr Current state, as far as PyNE could get.
+    IndeterminateNuclideForm(int wasptr, int nowptr)
+    {
+      nucwas = pyne::to_str(wasptr);
+      nucnow = pyne::to_str(nowptr);
+    };
+
+    /// Generates an informational message for the exception
+    /// \return The error string
+    virtual const char* what() const throw()
+    {
+      std::string INFEstr ("Indeterminate nuclide form: ");
+      if (!nucwas.empty())
+        INFEstr += nucwas;
+
+      if (!nucnow.empty())
+      {
+        INFEstr += " --> ";
+        INFEstr += nucnow;
+      }
+      return (const char *) INFEstr.c_str();
     }
-    return (const char*) NaNEstr.c_str();
+
+  private:
+    std::string nucwas; ///< previous nuclide state
+    std::string nucnow; ///< current nuclide state
   };
 
- private:
-  std::string nucwas; ///< previous nuclide state
-  std::string nucnow; ///< current nuclide state
-};
+  /// \name isnuclide functions
+  /// \{
+  /// These functions test if an input \a nuc is a valid nuclide.
+  /// \param nuc a possible nuclide
+  /// \return a bool
+  bool isnuclide(std::string nuc);
+  bool isnuclide(const char * nuc);
+  bool isnuclide(int nuc);
+  /// \}
 
-/// Custom expection for declaring that a value represents one or more nuclides
-/// in one or more namig conventions
-class IndeterminateNuclideForm : public std::exception {
- public:
-  /// default constructor
-  IndeterminateNuclideForm() {};
+  /// \name iselement functions
+  /// \{
+  /// These functions test if an input \a nuc is a valid element.
+  /// \param nuc a possible element
+  /// \return a bool
+  bool iselement(std::string nuc);
+  bool iselement(const char * nuc);
+  bool iselement(int nuc);
 
-  /// default destuctor
-  ~IndeterminateNuclideForm() throw () {};
+  /// \}
+  /// \name Identifier Form Functions
+  /// \{
+  /// The 'id' nuclide naming convention is the canonical form for representing
+  /// nuclides in PyNE. This is termed a ZAS, or ZZZAAASSSS, representation because
+  /// It stores 3 Z-number digits, 3 A-number digits, followed by 4 S-number digits
+  /// which the nucleus excitation state.
+  ///
+  /// The id() function will always return an nuclide in id form, if successful.
+  /// If the input nuclide is in id form already, then this is function does no
+  /// work. For all other formats, the id() function provides a best-guess based
+  /// on a heirarchy of other formats that is used to resolve ambiguities between
+  /// naming conventions. For integer input the form resolution order is:
+  ///   - id
+  ///   - zz (elemental z-num only given)
+  ///   - zzaaam
+  ///   - cinder (aaazzzm)
+  ///   - mcnp
+  ///   - zzaaa
+  /// For string (or char *) input the form resolution order is as follows:
+  ///   - ZZ-LL-AAAM
+  ///   - Integer form in a string representation, uses interger resolution
+  ///   - NIST
+  ///   - name form
+  ///   - Serpent
+  ///   - LL (element symbol)
+  /// For well-defined situations where you know ahead of time what format the
+  /// nuclide is in, you should use the various form_to_id() functions, rather
+  /// than the id() function which is meant to resolve possibly ambiquous cases.
+  /// \param nuc a nuclide
+  /// \return nucid 32-bit integer identifier
+  int id(int nuc);
+  int id(const char * nuc);
+  int id(std::string nuc);
+  /// \}
 
-  /// Constructor given previous and current state of nulide name
-  /// \param wasptr Previous state, typically user input.
-  /// \param nowptr Current state, as far as PyNE could get.
-  IndeterminateNuclideForm(std::string wasptr, std::string nowptr) {
-    nucwas = wasptr;
-    nucnow = nowptr;
-  };
+  /// \name Name Form Functions
+  /// \{
+  /// The 'name' nuclide naming convention is the more common, human readable
+  /// notation. The chemical symbol (one or two characters long) is first, followed
+  /// by the nucleon number. Lastly if the nuclide is metastable, the letter M is
+  /// concatenated to the end. For example, ‘H-1’ and ‘Am242M’ are both valid.
+  /// Note that nucname will always return name form with dashes removed, the
+  /// chemical symbol used for letter casing (ie 'Pu'), and a trailing upercase 'M'
+  /// for a metastable flag. The name() function first converts functions to id form
+  /// using the id() function. Thus the form order resolution for id() also applies
+  /// here.
+  /// \param nuc a nuclide
+  /// \return a string nuclide identifier.
+  std::string name(int nuc);
+  std::string name(const char * nuc);
+  std::string name(std::string nuc);
+  /// \}
 
-  /// Constructor given previous and current state of nulide name
-  /// \param wasptr Previous state, typically user input.
-  /// \param nowptr Current state, as far as PyNE could get.
-  IndeterminateNuclideForm(std::string wasptr, int nowptr) {
-    nucwas = wasptr;
-    nucnow = pyne::to_str(nowptr);
-  };
+  /// \name Z-Number Functions
+  /// \{
+  /// The Z-number, or charge number, represents the number of protons in a
+  /// nuclide.  This function returns that number.
+  /// \param nuc a nuclide
+  /// \return an integer Z-number.
+  int znum(int nuc);
+  int znum(const char * nuc);
+  int znum(std::string nuc);
+  /// \}
 
-  /// Constructor given previous and current state of nulide name
-  /// \param wasptr Previous state, typically user input.
-  /// \param nowptr Current state, as far as PyNE could get.
-  IndeterminateNuclideForm(int wasptr, std::string nowptr) {
-    nucwas = pyne::to_str(wasptr);
-    nucnow = nowptr;
-  };
+  /// \name A-Number Functions
+  /// \{
+  /// The A-number, or nucleon number, represents the number of protons and
+  /// neutrons in a nuclide.  This function returns that number.
+  /// \param nuc a nuclide
+  /// \return an integer A-number.
+  int anum(int nuc);
+  int anum(const char * nuc);
+  int anum(std::string nuc);
+  /// \}
 
-  /// Constructor given previous and current state of nulide name
-  /// \param wasptr Previous state, typically user input.
-  /// \param nowptr Current state, as far as PyNE could get.
-  IndeterminateNuclideForm(int wasptr, int nowptr) {
-    nucwas = pyne::to_str(wasptr);
-    nucnow = pyne::to_str(nowptr);
-  };
+  /// \name S-Number Functions
+  /// \{
+  /// The S-number, or excitation state number, represents the excitation
+  /// level of a nuclide.  Normally, this is zero.  This function returns
+  /// that number.
+  /// \param nuc a nuclide
+  /// \return an integer A-number.
+  int snum(int nuc);
+  int snum(const char * nuc);
+  int snum(std::string nuc);
+  /// \}
 
-  /// Generates an informational message for the exception
-  /// \return The error string
-  virtual const char* what() const throw() {
-    std::string INFEstr("Indeterminate nuclide form: ");
-    if (!nucwas.empty())
-      INFEstr += nucwas;
+  /// \name ZZAAAM Form Functions
+  /// \{
+  /// The ZZAAAM nuclide naming convention is the former canonical form for
+  /// nuclides in PyNE. This places the charge of the nucleus out front, then has
+  /// three digits for the atomic mass number, and ends with a metastable flag
+  /// (0 = ground, 1 = first excited state, 2 = second excited state, etc).
+  /// Uranium-235 here would be expressed as ‘922350’.
+  /// \param nuc a nuclide
+  /// \return an integer nuclide identifier.
+  int zzaaam(int nuc);
+  int zzaaam(const char * nuc);
+  int zzaaam(std::string nuc);
+  /// \}
 
-    if (!nucnow.empty()) {
-      INFEstr += " --> ";
-      INFEstr += nucnow;
-    }
-    return (const char*) INFEstr.c_str();
-  }
-
- private:
-  std::string nucwas; ///< previous nuclide state
-  std::string nucnow; ///< current nuclide state
-};
-
-/// \name isnuclide functions
-/// \{
-/// These functions test if an input \a nuc is a valid nuclide.
-/// \param nuc a possible nuclide
-/// \return a bool
-bool isnuclide(std::string nuc);
-bool isnuclide(const char* nuc);
-bool isnuclide(int nuc);
-/// \}
-
-/// \name iselement functions
-/// \{
-/// These functions test if an input \a nuc is a valid element.
-/// \param nuc a possible element
-/// \return a bool
-bool iselement(std::string nuc);
-bool iselement(const char* nuc);
-bool iselement(int nuc);
-
-/// \}
-/// \name Identifier Form Functions
-/// \{
-/// The 'id' nuclide naming convention is the canonical form for representing
-/// nuclides in PyNE. This is termed a ZAS, or ZZZAAASSSS, representation because
-/// It stores 3 Z-number digits, 3 A-number digits, followed by 4 S-number digits
-/// which the nucleus excitation state.
-///
-/// The id() function will always return an nuclide in id form, if successful.
-/// If the input nuclide is in id form already, then this is function does no
-/// work. For all other formats, the id() function provides a best-guess based
-/// on a heirarchy of other formats that is used to resolve ambiguities between
-/// naming conventions. For integer input the form resolution order is:
-///   - id
-///   - zz (elemental z-num only given)
-///   - zzaaam
-///   - cinder (aaazzzm)
-///   - mcnp
-///   - zzaaa
-/// For string (or char *) input the form resolution order is as follows:
-///   - ZZ-LL-AAAM
-///   - Integer form in a string representation, uses interger resolution
-///   - NIST
-///   - name form
-///   - Serpent
-///   - LL (element symbol)
-/// For well-defined situations where you know ahead of time what format the
-/// nuclide is in, you should use the various form_to_id() functions, rather
-/// than the id() function which is meant to resolve possibly ambiquous cases.
-/// \param nuc a nuclide
-/// \return nucid 32-bit integer identifier
-int id(int nuc);
-int id(const char* nuc);
-int id(std::string nuc);
-/// \}
-
-/// \name Name Form Functions
-/// \{
-/// The 'name' nuclide naming convention is the more common, human readable
-/// notation. The chemical symbol (one or two characters long) is first, followed
-/// by the nucleon number. Lastly if the nuclide is metastable, the letter M is
-/// concatenated to the end. For example, ‘H-1’ and ‘Am242M’ are both valid.
-/// Note that nucname will always return name form with dashes removed, the
-/// chemical symbol used for letter casing (ie 'Pu'), and a trailing upercase 'M'
-/// for a metastable flag. The name() function first converts functions to id form
-/// using the id() function. Thus the form order resolution for id() also applies
-/// here.
-/// \param nuc a nuclide
-/// \return a string nuclide identifier.
-std::string name(int nuc);
-std::string name(const char* nuc);
-std::string name(std::string nuc);
-/// \}
-
-/// \name Z-Number Functions
-/// \{
-/// The Z-number, or charge number, represents the number of protons in a
-/// nuclide.  This function returns that number.
-/// \param nuc a nuclide
-/// \return an integer Z-number.
-int znum(int nuc);
-int znum(const char* nuc);
-int znum(std::string nuc);
-/// \}
-
-/// \name A-Number Functions
-/// \{
-/// The A-number, or nucleon number, represents the number of protons and
-/// neutrons in a nuclide.  This function returns that number.
-/// \param nuc a nuclide
-/// \return an integer A-number.
-int anum(int nuc);
-int anum(const char* nuc);
-int anum(std::string nuc);
-/// \}
-
-/// \name S-Number Functions
-/// \{
-/// The S-number, or excitation state number, represents the excitation
-/// level of a nuclide.  Normally, this is zero.  This function returns
-/// that number.
-/// \param nuc a nuclide
-/// \return an integer A-number.
-int snum(int nuc);
-int snum(const char* nuc);
-int snum(std::string nuc);
-/// \}
-
-/// \name ZZAAAM Form Functions
-/// \{
-/// The ZZAAAM nuclide naming convention is the former canonical form for
-/// nuclides in PyNE. This places the charge of the nucleus out front, then has
-/// three digits for the atomic mass number, and ends with a metastable flag
-/// (0 = ground, 1 = first excited state, 2 = second excited state, etc).
-/// Uranium-235 here would be expressed as ‘922350’.
-/// \param nuc a nuclide
-/// \return an integer nuclide identifier.
-int zzaaam(int nuc);
-int zzaaam(const char* nuc);
-int zzaaam(std::string nuc);
-/// \}
-
-/// \name ZZAAAM Form to Identifier Form Functions
-/// \{
-/// This converts from the ZZAAAM nuclide naming convention
-/// to the id canonical form  for nuclides in PyNE.
-/// \param nuc a nuclide in ZZAAAM form.
-/// \return an integer id nuclide identifier.
-int zzaaam_to_id(int nuc);
-int zzaaam_to_id(const char* nuc);
-int zzaaam_to_id(std::string nuc);
-/// \}
+  /// \name ZZAAAM Form to Identifier Form Functions
+  /// \{
+  /// This converts from the ZZAAAM nuclide naming convention
+  /// to the id canonical form  for nuclides in PyNE.
+  /// \param nuc a nuclide in ZZAAAM form.
+  /// \return an integer id nuclide identifier.
+  int zzaaam_to_id(int nuc);
+  int zzaaam_to_id(const char * nuc);
+  int zzaaam_to_id(std::string nuc);
+  /// \}
 
 
-/// \name ZZZAAA Form Functions
-/// \{
-/// The ZZZAAA nuclide naming convention is a form in which the nuclides three
-///digit ZZZ number is followed by the 3 digit AAA number.  If the ZZZ number
-///is 2 digits, the preceding zeros are not included.
-/// Uranium-235 here would be expressed as ‘92235’.
-/// \param nuc a nuclide
-/// \return an integer nuclide identifier.
-int zzzaaa(int nuc);
-int zzzaaa(const char* nuc);
-int zzzaaa(std::string nuc);
-/// \}
+  /// \name ZZZAAA Form Functions
+  /// \{
+  /// The ZZZAAA nuclide naming convention is a form in which the nuclides three
+  ///digit ZZZ number is followed by the 3 digit AAA number.  If the ZZZ number
+  ///is 2 digits, the preceding zeros are not included.
+  /// Uranium-235 here would be expressed as ‘92235’.
+  /// \param nuc a nuclide
+  /// \return an integer nuclide identifier.
+  int zzzaaa(int nuc);
+  int zzzaaa(const char * nuc);
+  int zzzaaa(std::string nuc);
+  /// \}
 
 
-/// \name ZZZAAA Form to Identifier Form Functions
-/// \{
-/// This converts from the ZZZAAA nuclide naming convention
-/// to the id canonical form  for nuclides in PyNE.
-/// \param nuc a nuclide in ZZZAAA form.
-/// \return an integer id nuclide identifier.
-int zzzaaa_to_id(int nuc);
-int zzzaaa_to_id(const char* nuc);
-int zzzaaa_to_id(std::string nuc);
-/// \}
+  /// \name ZZZAAA Form to Identifier Form Functions
+  /// \{
+  /// This converts from the ZZZAAA nuclide naming convention
+  /// to the id canonical form  for nuclides in PyNE.
+  /// \param nuc a nuclide in ZZZAAA form.
+  /// \return an integer id nuclide identifier.
+  int zzzaaa_to_id(int nuc);
+  int zzzaaa_to_id(const char * nuc);
+  int zzzaaa_to_id(std::string nuc);
+  /// \}
 
 
-/// \name ZZLLAAAM Form Functions
-/// \{
-/// The ZZLLAAAM nuclide naming convention is a form in which the nuclides
-/// AA number is followed by the redundant two LL characters, followed by
-/// the nuclides ZZZ number.  Can also be followed with a metastable flag.
-/// Uranium-235 here would be expressed as ‘92-U-235’.
-/// \param nuc a nuclide
-/// \return an integer nuclide identifier.
-std::string zzllaaam(int nuc);
-std::string zzllaaam(const char* nuc);
-std::string zzllaaam(std::string nuc);
-/// \}
+  /// \name ZZLLAAAM Form Functions
+  /// \{
+  /// The ZZLLAAAM nuclide naming convention is a form in which the nuclides
+  /// AA number is followed by the redundant two LL characters, followed by
+  /// the nuclides ZZZ number.  Can also be followed with a metastable flag.
+  /// Uranium-235 here would be expressed as ‘92-U-235’.
+  /// \param nuc a nuclide
+  /// \return an integer nuclide identifier.
+  std::string zzllaaam(int nuc);
+  std::string zzllaaam(const char * nuc);
+  std::string zzllaaam(std::string nuc);
+  /// \}
 
 
-/// \name ZZLLAAAM Form to Identifier Form Functions
-/// \{
-/// This converts from the ZZLLAAAM nuclide naming convention
-/// to the id canonical form  for nuclides in PyNE.
-/// \param nuc a nuclide in ZZLLAAAM form.
-/// \return an integer id nuclide identifier.
-//int zzllaaam_to_id(int nuc);
-int zzllaaam_to_id(const char* nuc);
-int zzllaaam_to_id(std::string nuc);
-/// \}
+  /// \name ZZLLAAAM Form to Identifier Form Functions
+  /// \{
+  /// This converts from the ZZLLAAAM nuclide naming convention
+  /// to the id canonical form  for nuclides in PyNE.
+  /// \param nuc a nuclide in ZZLLAAAM form.
+  /// \return an integer id nuclide identifier.
+  //int zzllaaam_to_id(int nuc);
+  int zzllaaam_to_id(const char * nuc);
+  int zzllaaam_to_id(std::string nuc);
+  /// \}
 
 
-/// \name MCNP Form Functions
-/// \{
-/// This is the naming convention used by the MCNP suite of codes.
-/// The MCNP format for entering nuclides is unfortunately non-standard.
-/// In most ways it is similar to zzaaam form, except that it lacks the metastable
-/// flag. For information on how metastable isotopes are named, please consult the
-/// MCNP documentation for more information.
-/// \param nuc a nuclide
-/// \return a string nuclide identifier.
-int mcnp(int nuc);
-int mcnp(const char* nuc);
-int mcnp(std::string nuc);
-/// \}
+  /// \name MCNP Form Functions
+  /// \{
+  /// This is the naming convention used by the MCNP suite of codes.
+  /// The MCNP format for entering nuclides is unfortunately non-standard.
+  /// In most ways it is similar to zzaaam form, except that it lacks the metastable
+  /// flag. For information on how metastable isotopes are named, please consult the
+  /// MCNP documentation for more information.
+  /// \param nuc a nuclide
+  /// \return a string nuclide identifier.
+  int mcnp(int nuc);
+  int mcnp(const char * nuc);
+  int mcnp(std::string nuc);
+  /// \}
 
-/// \name MCNP Form to Identifier Form Functions
-/// \{
-/// This converts from the MCNP nuclide naming convention
-/// to the id canonical form  for nuclides in PyNE.
-/// \param nuc a nuclide in MCNP form.
-/// \return an integer id nuclide identifier.
-int mcnp_to_id(int nuc);
-int mcnp_to_id(const char* nuc);
-int mcnp_to_id(std::string nuc);
-/// \}
+  /// \name MCNP Form to Identifier Form Functions
+  /// \{
+  /// This converts from the MCNP nuclide naming convention
+  /// to the id canonical form  for nuclides in PyNE.
+  /// \param nuc a nuclide in MCNP form.
+  /// \return an integer id nuclide identifier.
+  int mcnp_to_id(int nuc);
+  int mcnp_to_id(const char * nuc);
+  int mcnp_to_id(std::string nuc);
+  /// \}
 
-/// \name FLUKA Form Functions
-/// \{
-/// This is the naming convention used by the FLUKA suite of codes.
-/// The FLUKA format for entering nuclides requires some knowledge of FLUKA
-/// The nuclide in must cases should be the atomic # times 10000000.
-/// The exceptions are for FLUKA's named isotopes
-/// See the FLUKA Manual for more information.
-/// \param nuc a nuclide
-/// \return the received FLUKA name
-std::string fluka(int nuc);
-/// \}
+  /// \name OPENMC Form Functions
+  /// \{
+  /// This is the naming convention used by the OpenMC code.
+  /// The OpenMC format for entering nuclides uses a GND format.
+  /// For information on how metastable isotopes are named, please consult the
+  /// OpenMC documentation for more information.
+  /// \param nuc a nuclide
+  /// \return a string nuclide identifier.
+  std::string openmc(int nuc);
+  std::string openmc(const char * nuc);
+  std::string openmc(std::string nuc);
+  /// \}
 
-/// \name FLUKA Form to Identifier Form Functions
-/// \{
-/// This converts from the FLUKA name to the
-/// id canonical form  for nuclides in PyNE.
-/// \param name a fluka name
-/// \return an integer id nuclide identifier.
-int fluka_to_id(std::string name);
-int fluka_to_id(char* name);
-/// \}
+  /// \name OPENMC Form to Identifier Form Functions
+  /// \{
+  /// This converts from the OPENMC nuclide naming convention
+  /// to the id canonical form  for nuclides in PyNE.
+  /// \param nuc a nuclide in OPENMC form.
+  /// \return an integer id nuclide identifier.
+  int openmc_to_id(const char * nuc);
+  int openmc_to_id(std::string nuc);
+  /// \}
 
-/// \name Serpent Form Functions
-/// \{
-/// This is the string-based naming convention used by the Serpent suite of codes.
-/// The serpent naming convention is similar to name form. However, only the first
-/// letter in the chemical symbol is uppercase, the dash is always present, and the
-/// the meta-stable flag is lowercase. For instance, ‘Am-242m’ is the valid serpent
-/// notation for this nuclide.
-/// \param nuc a nuclide
-/// \return a string nuclide identifier.
-std::string serpent(int nuc);
-std::string serpent(const char* nuc);
-std::string serpent(std::string nuc);
-/// \}
+  /// \name FLUKA Form Functions
+  /// \{
+  /// This is the naming convention used by the FLUKA suite of codes.
+  /// The FLUKA format for entering nuclides requires some knowledge of FLUKA
+  /// The nuclide in must cases should be the atomic # times 10000000.
+  /// The exceptions are for FLUKA's named isotopes
+  /// See the FLUKA Manual for more information.
+  /// \param nuc a nuclide
+  /// \return the received FLUKA name
+  std::string fluka(int nuc);
+  /// \}
 
-/// \name Serpent Form to Identifier Form Functions
-/// \{
-/// This converts from the Serpent nuclide naming convention
-/// to the id canonical form  for nuclides in PyNE.
-/// \param nuc a nuclide in Serpent form.
-/// \return an integer id nuclide identifier.
-//int serpent_to_id(int nuc);  Should be ZAID
-int serpent_to_id(const char* nuc);
-int serpent_to_id(std::string nuc);
-/// \}
+  /// \name FLUKA Form to Identifier Form Functions
+  /// \{
+  /// This converts from the FLUKA name to the
+  /// id canonical form  for nuclides in PyNE.
+  /// \param name a fluka name
+  /// \return an integer id nuclide identifier.
+  int fluka_to_id(std::string name);
+  int fluka_to_id(char * name);
+  /// \}
 
-/// \name NIST Form Functions
-/// \{
-/// This is the string-based naming convention used by NIST.
-/// The NIST naming convention is also similar to the Serpent form. However, this
-/// convention contains no metastable information. Moreover, the A-number comes
-/// before the element symbol. For example, ‘242Am’ is the valid NIST notation.
-/// \param nuc a nuclide
-/// \return a string nuclide identifier.
-std::string nist(int nuc);
-std::string nist(const char* nuc);
-std::string nist(std::string nuc);
-/// \}
+  /// \name Serpent Form Functions
+  /// \{
+  /// This is the string-based naming convention used by the Serpent suite of codes.
+  /// The serpent naming convention is similar to name form. However, only the first
+  /// letter in the chemical symbol is uppercase, the dash is always present, and the
+  /// the meta-stable flag is lowercase. For instance, ‘Am-242m’ is the valid serpent
+  /// notation for this nuclide.
+  /// \param nuc a nuclide
+  /// \return a string nuclide identifier.
+  std::string serpent(int nuc);
+  std::string serpent(const char * nuc);
+  std::string serpent(std::string nuc);
+  /// \}
 
-/// \name NIST Form to Identifier Form Functions
-/// \{
-/// This converts from the NIST nuclide naming convention
-/// to the id canonical form  for nuclides in PyNE.
-/// \param nuc a nuclide in NIST form.
-/// \return an integer id nuclide identifier.
-//int serpent_to_id(int nuc);  NON-EXISTANT
-int nist_to_id(const char* nuc);
-int nist_to_id(std::string nuc);
-/// \}
+  /// \name Serpent Form to Identifier Form Functions
+  /// \{
+  /// This converts from the Serpent nuclide naming convention
+  /// to the id canonical form  for nuclides in PyNE.
+  /// \param nuc a nuclide in Serpent form.
+  /// \return an integer id nuclide identifier.
+  //int serpent_to_id(int nuc);  Should be ZAID
+  int serpent_to_id(const char * nuc);
+  int serpent_to_id(std::string nuc);
+  /// \}
 
-/// \name CINDER Form Functions
-/// \{
-/// This is the naming convention used by the CINDER burnup library.
-/// The CINDER format is similar to zzaaam form except that the placement of the
-/// Z- and A-numbers are swapped. Therefore, this format is effectively aaazzzm.
-/// For example, ‘2420951’ is the valid cinder notation for ‘AM242M’.
-/// \param nuc a nuclide
-/// \return a string nuclide identifier.
-int cinder(int nuc);
-int cinder(const char* nuc);
-int cinder(std::string nuc);
-/// \}
+  /// \name NIST Form Functions
+  /// \{
+  /// This is the string-based naming convention used by NIST.
+  /// The NIST naming convention is also similar to the Serpent form. However, this
+  /// convention contains no metastable information. Moreover, the A-number comes
+  /// before the element symbol. For example, ‘242Am’ is the valid NIST notation.
+  /// \param nuc a nuclide
+  /// \return a string nuclide identifier.
+  std::string nist(int nuc);
+  std::string nist(const char * nuc);
+  std::string nist(std::string nuc);
+  /// \}
 
-/// \name Cinder Form to Identifier Form Functions
-/// \{
-/// This converts from the Cinder nuclide naming convention
-/// to the id canonical form  for nuclides in PyNE.
-/// \param nuc a nuclide in Cinder form.
-/// \return an integer id nuclide identifier.
-int cinder_to_id(int nuc);
-int cinder_to_id(const char* nuc);
-int cinder_to_id(std::string nuc);
-/// \}
+  /// \name NIST Form to Identifier Form Functions
+  /// \{
+  /// This converts from the NIST nuclide naming convention
+  /// to the id canonical form  for nuclides in PyNE.
+  /// \param nuc a nuclide in NIST form.
+  /// \return an integer id nuclide identifier.
+  //int serpent_to_id(int nuc);  NON-EXISTANT
+  int nist_to_id(const char * nuc);
+  int nist_to_id(std::string nuc);
+  /// \}
 
-/// \name ALARA Form Functions
-/// \{
-/// This is the format used in the ALARA activation code elements library.
-/// For elements, the form is "ll" where ll is the atomic symbol. For isotopes
-/// the form is "ll:AAA". No metastable isotope flag is used.
-/// \param nuc a nuclide
-/// \return a string nuclide identifier.
-std::string alara(int nuc);
-std::string alara(const char* nuc);
-std::string alara(std::string nuc);
-/// \}
+  /// \name CINDER Form Functions
+  /// \{
+  /// This is the naming convention used by the CINDER burnup library.
+  /// The CINDER format is similar to zzaaam form except that the placement of the
+  /// Z- and A-numbers are swapped. Therefore, this format is effectively aaazzzm.
+  /// For example, ‘2420951’ is the valid cinder notation for ‘AM242M’.
+  /// \param nuc a nuclide
+  /// \return a string nuclide identifier.
+  int cinder(int nuc);
+  int cinder(const char * nuc);
+  int cinder(std::string nuc);
+  /// \}
 
-/// \name ALARA Form to Identifier Form Functions
-/// \{
-/// This converts from the ALARA nuclide naming convention
-/// to the id canonical form  for nuclides in PyNE.
-/// \param nuc a nuclide in ALARA form.
-/// \return an integer id nuclide identifier.
-//int alara_to_id(int nuc); NOT POSSIBLE
-int alara_to_id(const char* nuc);
-int alara_to_id(std::string nuc);
-/// \}
+  /// \name Cinder Form to Identifier Form Functions
+  /// \{
+  /// This converts from the Cinder nuclide naming convention
+  /// to the id canonical form  for nuclides in PyNE.
+  /// \param nuc a nuclide in Cinder form.
+  /// \return an integer id nuclide identifier.
+  int cinder_to_id(int nuc);
+  int cinder_to_id(const char * nuc);
+  int cinder_to_id(std::string nuc);
+  /// \}
 
-/// \name SZA Form Functions
-/// \{
-/// This is the new format for ACE data tables in the form SSSZZZAAA.
-/// The first three digits represent the excited state (000 = ground,
-/// 001 = first excited state, 002 = second excited state, etc).
-/// The second three digits are the atomic number and the last three
-/// digits are the atomic mass. Prepending zeros can be omitted, making
-/// the SZA form equal to the MCNP form for non-excited nuclides.
-/// \param nuc a nuclide
-/// \return a string nuclide identifier.
-int sza(int nuc);
-int sza(const char* nuc);
-int sza(std::string nuc);
-/// \}
+  /// \name ALARA Form Functions
+  /// \{
+  /// This is the format used in the ALARA activation code elements library.
+  /// For elements, the form is "ll" where ll is the atomic symbol. For isotopes
+  /// the form is "ll:AAA". No metastable isotope flag is used.
+  /// \param nuc a nuclide
+  /// \return a string nuclide identifier.
+  std::string alara(int nuc);
+  std::string alara(const char * nuc);
+  std::string alara(std::string nuc);
+  /// \}
 
-/// \name SZA Form to Identifier Form Functions
-/// \{
-/// This converts from the SZA nuclide naming convention
-/// to the id canonical form  for nuclides in PyNE.
-/// \param nuc a nuclide in SZA form.
-/// \return an integer id nuclide identifier.
-int sza_to_id(int nuc);
-int sza_to_id(const char* nuc);
-int sza_to_id(std::string nuc);
-/// \}
+  /// \name ALARA Form to Identifier Form Functions
+  /// \{
+  /// This converts from the ALARA nuclide naming convention
+  /// to the id canonical form  for nuclides in PyNE.
+  /// \param nuc a nuclide in ALARA form.
+  /// \return an integer id nuclide identifier.
+  //int alara_to_id(int nuc); NOT POSSIBLE
+  int alara_to_id(const char * nuc);
+  int alara_to_id(std::string nuc);
+  /// \}
 
-/// \name Ground State Form Functions
-/// \{
-/// This form stores the nuclide in id form, but removes
-/// the state information about the nuclide.  I is in the same
-/// form as ID, but the four last digits are all zeros.
-/// \param nuc a nuclide
-/// \return a integer groundstate id
-inline int groundstate(int nuc) {
-  return (id(nuc) / 10000) * 10000;
-}
-inline int groundstate(std::string nuc) {
-  return groundstate(id(nuc));
-}
-inline int groundstate(const char* nuc) {
-  return groundstate(std::string(nuc));
-}
-/// \}
+  /// \name SZA Form Functions
+  /// \{
+  /// This is the new format for ACE data tables in the form SSSZZZAAA.
+  /// The first three digits represent the excited state (000 = ground,
+  /// 001 = first excited state, 002 = second excited state, etc).
+  /// The second three digits are the atomic number and the last three
+  /// digits are the atomic mass. Prepending zeros can be omitted, making
+  /// the SZA form equal to the MCNP form for non-excited nuclides.
+  /// \param nuc a nuclide
+  /// \return a string nuclide identifier.
+  int sza(int nuc);
+  int sza(const char * nuc);
+  int sza(std::string nuc);
+  /// \}
 
-/// \name State Map functions
-/// \{
-/// These convert from/to decay state ids (used in decay data)
-/// to metastable ids (the PyNE default)
-void _load_state_map();
-int state_id_to_id(int state);
-int id_to_state_id(int nuc_id);
-extern std::map<int, int> state_id_map;
-/// \}
+  /// \name SZA Form to Identifier Form Functions
+  /// \{
+  /// This converts from the SZA nuclide naming convention
+  /// to the id canonical form  for nuclides in PyNE.
+  /// \param nuc a nuclide in SZA form.
+  /// \return an integer id nuclide identifier.
+  int sza_to_id(int nuc);
+  int sza_to_id(const char * nuc);
+  int sza_to_id(std::string nuc);
+  /// \}
 
-/// \name ENSDF Form Functions
-/// \{
-/// This converts id's stored using standard ensdf syntax to nuc_id's
-/// \param ensdf nuc string
-/// \return PyNE nuc_id
-int ensdf_to_id(const char* nuc);
-int ensdf_to_id(std::string nuc);
-/// \}
+  /// \name Ground State Form Functions
+  /// \{
+  /// This form stores the nuclide in id form, but removes
+  /// the state information about the nuclide.  I is in the same
+  /// form as ID, but the four last digits are all zeros.
+  /// \param nuc a nuclide
+  /// \return a integer groundstate id
+  inline int groundstate(int nuc) {return (id(nuc) / 10000 ) * 10000;}
+  inline int groundstate(std::string nuc) {return groundstate(id(nuc));}
+  inline int groundstate(const char * nuc) {return groundstate(std::string(nuc));}
+  /// \}
+
+  /// \name State Map functions
+  /// \{
+  /// These convert from/to decay state ids (used in decay data)
+  /// to metastable ids (the PyNE default). If the cooresponding value cannot
+  /// be found, -1 is returned.
+  void _load_state_map();
+  int state_id_to_id(int state);
+  int id_to_state_id(int nuc_id);
+  extern std::map<int, int> state_id_map;
+  /// \}
+
+  /// \name ENSDF Form Functions
+  /// \{
+  /// This converts id's stored using standard ensdf syntax to nuc_id's
+  /// \param ensdf nuc string
+  /// \return PyNE nuc_id
+  int ensdf_to_id(const char * nuc);
+  int ensdf_to_id(std::string nuc);
+  /// \}
 
 }
 }
 
 #endif  // PYNE_D35WIXV5DZAA5LLOWBY2BL2DPA
+
 //
 // end of src/nucname.h
 //
@@ -4807,10 +4878,10 @@ class JSON_API CustomWriter : public Writer {
 #include <set>
 #include <stdio.h>
 #include <stdlib.h>
-#include <sstream>  // std::ostringstream
+#include <sstream>	// std::ostringstream
 
 #if !defined(JSON_IS_AMALGAMATION)
-#define JSON_IS_AMALGAMATION
+  #define JSON_IS_AMALGAMATION
 #endif
 
 #ifndef PYNE_IS_AMALGAMATED
@@ -4823,350 +4894,367 @@ class JSON_API CustomWriter : public Writer {
 #include "decay.h"
 #endif
 
-namespace pyne {
-// Set Type Definitions
-typedef std::map<int, double> comp_map; ///< Nuclide-mass composition map type
-typedef comp_map::iterator comp_iter;   ///< Nuclide-mass composition iter type
+namespace pyne
+{
+  // Set Type Definitions
+  typedef std::map<int, double> comp_map; ///< Nuclide-mass composition map type
+  typedef comp_map::iterator comp_iter;   ///< Nuclide-mass composition iter type
 
-#ifdef PYNE_IS_AMALGAMATED
-namespace decayers {
-extern comp_map decay(comp_map, double);
-}  // namespace decayers
-#endif
+  #ifdef PYNE_IS_AMALGAMATED
+  namespace decayers {
+    extern comp_map decay(comp_map, double);
+  }  // namespace decayers
+  #endif
 
 
-// These 37 strings are predefined FLUKA materials.
-// Materials not on this list requires a MATERIAL card.
-static std::string fluka_mat_strings[] = {
-  "BLCKHOLE", "VACUUM",   "HYDROGEN", "HELIUM",   "BERYLLIU", "CARBON",
-  "NITROGEN", "OXYGEN",   "MAGNESIU", "ALUMINUM", "IRON",     "COPPER",
-  "SILVER",   "SILICON",  "GOLD",     "MERCURY",  "LEAD",     "TANTALUM",
-  "SODIUM",   "ARGON",    "CALCIUM",  "TIN",      "TUNGSTEN", "TITANIUM",
-  "NICKEL",   "WATER",    "POLYSTYR", "PLASCINT", "PMMA",     "BONECOMP",
-  "BONECORT", "MUSCLESK", "MUSCLEST", "ADTISSUE", "KAPTON", "POLYETHY", "AIR"
-};
+  // These 37 strings are predefined FLUKA materials.
+  // Materials not on this list requires a MATERIAL card.
+  static std::string fluka_mat_strings[] = {
+   "BLCKHOLE", "VACUUM",   "HYDROGEN", "HELIUM",   "BERYLLIU", "CARBON",
+   "NITROGEN", "OXYGEN",   "MAGNESIU", "ALUMINUM", "IRON",     "COPPER",
+   "SILVER",   "SILICON",  "GOLD",     "MERCURY",  "LEAD",     "TANTALUM",
+   "SODIUM",   "ARGON",    "CALCIUM",  "TIN",      "TUNGSTEN", "TITANIUM",
+   "NICKEL",   "WATER",    "POLYSTYR", "PLASCINT", "PMMA",     "BONECOMP",
+   "BONECORT", "MUSCLESK", "MUSCLEST", "ADTISSUE", "KAPTON", "POLYETHY", "AIR"
+  };
 
-static int FLUKA_MAT_NUM = 37;
+  static int FLUKA_MAT_NUM = 37;
 
-/// Material composed of nuclides.
-class Material {
- protected:
+  /// Material composed of nuclides.
+  class Material
+  {
+  protected:
 
-  /// Computes the total mass stored in the composition.
-  double get_comp_sum();
+    /// Computes the total mass stored in the composition.
+    double get_comp_sum ();
 
- public:
+  public:
 
-  // Material Constructors
-  Material();   ///< empty constructor
-  /// Constructor from composition map
-  /// \param cm composition map
-  /// \param m mass value, the mass is set to the sum of the values in the
-  ///          composition if \a m is negative.
-  /// \param d density value
-  /// \param apm atoms per mole
-  /// \param attributes initial metadata
-  Material(comp_map cm, double m = -1.0, double d = -1.0, double apm = -1.0,
-           Json::Value attributes = Json::Value(Json::objectValue));
-  /// Constructor from file
-  /// \param filename path to file on disk, this file may be either in plaintext
-  ///                 or HDF5 format.
-  /// \param m mass value, the mass is set to the sum of the values in the
-  ///          composition if \a m is negative,
-  ///          may be overridden by the value from disk.
-  /// \param d density value,
-  ///          may be overridden by the value from disk.
-  /// \param apm atoms per mole,
-  ///          may be overridden by the value from disk.
-  /// \param attributes initial metadata,
-  ///          may be overridden by the value from disk.
-  Material(char* filename, double m = -1.0, double d = -1.0, double apm = -1.0,
-           Json::Value attributes = Json::Value(Json::objectValue));
-  /// Constructor from file
-  /// \param filename path to file on disk, this file may be either in plaintext
-  ///                 or HDF5 format.
-  /// \param m mass value, the mass is set to the sum of the values in the
-  ///          composition if \a m is negative,
-  ///          may be overridden by the value from disk.
-  /// \param d density value,
-  ///          may be overridden by the value from disk.
-  /// \param apm atoms per mole,
-  ///          may be overridden by the value from disk.
-  /// \param attributes initial metadata,
-  ///          may be overridden by the value from disk.
-  Material(std::string filename, double m = -1.0, double d = -1.0, double apm = -1.0,
-           Json::Value attributes = Json::Value(Json::objectValue));
-  ~Material();  ///< default destructor
+    // Material Constructors
+    Material ();  ///< empty constructor
+    /// Constructor from composition map
+    /// \param cm composition map
+    /// \param m mass value, the mass is set to the sum of the values in the
+    ///          composition if \a m is negative.
+    /// \param d density value
+    /// \param apm atoms per mole
+    /// \param attributes initial metadata
+    Material(comp_map cm, double m=-1.0, double d=-1.0, double apm=-1.0,
+             Json::Value attributes=Json::Value(Json::objectValue));
+    /// Constructor from file
+    /// \param filename path to file on disk, this file may be either in plaintext
+    ///                 or HDF5 format.
+    /// \param m mass value, the mass is set to the sum of the values in the
+    ///          composition if \a m is negative,
+    ///          may be overridden by the value from disk.
+    /// \param d density value,
+    ///          may be overridden by the value from disk.
+    /// \param apm atoms per mole,
+    ///          may be overridden by the value from disk.
+    /// \param attributes initial metadata,
+    ///          may be overridden by the value from disk.
+    Material(char * filename, double m=-1.0, double d=-1.0, double apm=-1.0,
+             Json::Value attributes=Json::Value(Json::objectValue));
+    /// Constructor from file
+    /// \param filename path to file on disk, this file may be either in plaintext
+    ///                 or HDF5 format.
+    /// \param m mass value, the mass is set to the sum of the values in the
+    ///          composition if \a m is negative,
+    ///          may be overridden by the value from disk.
+    /// \param d density value,
+    ///          may be overridden by the value from disk.
+    /// \param apm atoms per mole,
+    ///          may be overridden by the value from disk.
+    /// \param attributes initial metadata,
+    ///          may be overridden by the value from disk.
+    Material(std::string filename, double m=-1.0, double d=-1.0, double apm=-1.0,
+             Json::Value attributes=Json::Value(Json::objectValue));
+    ~Material (); ///< default destructor
 
-  /// Normalizes the mass values in the composition.
-  void norm_comp();
+    /// Normalizes the mass values in the composition.
+    void norm_comp ();
 
-  // Persistence functions.
+    // Persistence functions.
 
-  /// Loads the matrial composition from an HDF5 file according to the layout
-  /// defined by protocol 0.  This protocol is depratacted.
-  /// \param db HDF5 id for the open HDF5 file.
-  /// \param datapath Path to the base node for the material in \a db.
-  /// \param row The index to read out, may be negative.
-  void _load_comp_protocol0(hid_t db, std::string datapath, int row);
+    /// Loads the matrial composition from an HDF5 file according to the layout
+    /// defined by protocol 0.  This protocol is depratacted.
+    /// \param db HDF5 id for the open HDF5 file.
+    /// \param datapath Path to the base node for the material in \a db.
+    /// \param row The index to read out, may be negative.
+    void _load_comp_protocol0(hid_t db, std::string datapath, int row);
 
-  /// Loads the matrial composition from an HDF5 file according to the layout
-  /// defined by protocol 1.  This protocol should be used in favor of protocol 0.
-  /// \param db HDF5 id for the open HDF5 file.
-  /// \param datapath Path to the base node for the material in \a db.
-  /// \param row The index to read out, may be negative.
-  void _load_comp_protocol1(hid_t db, std::string datapath, int row);
+    /// Loads the matrial composition from an HDF5 file according to the layout
+    /// defined by protocol 1.  This protocol should be used in favor of protocol 0.
+    /// \param db HDF5 id for the open HDF5 file.
+    /// \param datapath Path to the base node for the material in \a db.
+    /// \param row The index to read out, may be negative.
+    void _load_comp_protocol1(hid_t db, std::string datapath, int row);
 
-  /// Loads a material from an HDF5 file into this object.
-  /// \param filename Path on disk to the HDF5 file.
-  /// \param datapath Path to the the material in the file.
-  /// \param row The index to read out, may be negative.
-  /// \param protocol Flag for layout of material on disk.
-  void from_hdf5(char* filename, char* datapath, int row = -1, int protocol = 1);
+    /// Loads a material from an HDF5 file into this object.
+    /// \param filename Path on disk to the HDF5 file.
+    /// \param datapath Path to the the material in the file.
+    /// \param row The index to read out, may be negative.
+    /// \param protocol Flag for layout of material on disk.
+    void from_hdf5(char * filename, char * datapath, int row=-1, int protocol=1);
 
-  /// Loads a material from an HDF5 file into this object.
-  /// \param filename Path on disk to the HDF5 file.
-  /// \param datapath Path to the the material in the file.
-  /// \param row The index to read out, may be negative.
-  /// \param protocol Flag for layout of material on disk.
-  void from_hdf5(std::string filename, std::string datapath = "/material",
-                 int row = -1, int protocol = 1);
+    /// Loads a material from an HDF5 file into this object.
+    /// \param filename Path on disk to the HDF5 file.
+    /// \param datapath Path to the the material in the file.
+    /// \param row The index to read out, may be negative.
+    /// \param protocol Flag for layout of material on disk.
+    void from_hdf5(std::string filename, std::string datapath="/material",
+                                                          int row=-1, int protocol=1);
 
-  /// Writes this material out to an HDF5 file.
-  /// This happens according to protocol 1.
-  /// \param filename Path on disk to the HDF5 file.
-  /// \param datapath Path to the the material in the file.
-  /// \param nucpath Path to the nuclides set in the file.
-  /// \param row The index to read out, may be negative. Also note that this is a
-  ///            float.  A value of -0.0 indicates that the material should be
-  ///            appended to the end of the dataset.
-  /// \param chunksize The chunksize for all material data on disk.
-  void write_hdf5(char* filename, char* datapath, char* nucpath, float row = -0.0,
-                  int chunksize = 100);
-  /// Writes this material out to an HDF5 file.
-  /// This happens according to protocol 1.
-  /// \param filename Path on disk to the HDF5 file.
-  /// \param datapath Path to the the material in the file.
-  /// \param nucpath Path to the nuclides set in the file.
-  /// \param row The index to read out, may be negative. Also note that this is a
-  ///            float.  A value of -0.0 indicates that the material should be
-  ///            appended to the end of the dataset.
-  /// \param chunksize The chunksize for all material data on disk.
-  void write_hdf5(std::string filename, std::string datapath = "/material",
-                  std::string nucpath = "/nucid", float row = -0.0, int chunksize = 100);
+    /// Writes this material out to an HDF5 file.
+    /// This happens according to protocol 1.
+    /// \param filename Path on disk to the HDF5 file.
+    /// \param datapath Path to the the material in the file.
+    /// \param nucpath Path to the nuclides set in the file.
+    /// \param row The index to read out, may be negative. Also note that this is a
+    ///            float.  A value of -0.0 indicates that the material should be
+    ///            appended to the end of the dataset.
+    /// \param chunksize The chunksize for all material data on disk.
+    void write_hdf5(char * filename, char * datapath, char * nucpath, float row=-0.0,
+                                                                    int chunksize=100);
+    /// Writes this material out to an HDF5 file.
+    /// This happens according to protocol 1.
+    /// \param filename Path on disk to the HDF5 file.
+    /// \param datapath Path to the the material in the file.
+    /// \param nucpath Path to the nuclides set in the file.
+    /// \param row The index to read out, may be negative. Also note that this is a
+    ///            float.  A value of -0.0 indicates that the material should be
+    ///            appended to the end of the dataset.
+    /// \param chunksize The chunksize for all material data on disk.
+    void write_hdf5(std::string filename, std::string datapath="/material",
+                    std::string nucpath="/nucid", float row=-0.0, int chunksize=100);
 
-  /// Return an mcnp input deck record as a string
-  std::string mcnp(std::string frac_type = "mass");
-  ///
-  /// Return a fluka input deck MATERIAL card as a string
-  std::string fluka(int id, std::string frac_type = "mass");
-  /// Convenience function to tell whether a given name needs a material card
-  bool not_fluka_builtin(std::string fluka_name);
-  /// High level call to get details and call material_component(..)
-  std::string fluka_material_str(int id);
-  /// Intermediate level call to prepare final info and call material_line(..)
-  std::string fluka_material_component(int fid, int nucid,
-                                       std::string fluka_name);
-  /// Format information into a FLUKA material card
-  std::string fluka_material_line(int znum, double atomic_mass,
-                                  int fid, std::string fluka_name);
-  /// Convenience function to format a single fluka field
-  std::string fluka_format_field(float field);
-  /// Return FLUKA compound card and the material card for the named compound
-  /// but not the material cards of the components
-  std::string fluka_compound_str(int id, std::string frac_type = "mass");
+    /// Return an openmc xml material element as a string
+    std::string openmc(std::string fact_type = "mass");
 
-  /// Reads data from a plaintext file at \a filename into this Material instance.
-  void from_text(char* filename);
-  /// Reads data from a plaintext file at \a filename into this Material instance.
-  void from_text(std::string filename);
+    /// Return an mcnp input deck record as a string
+    std::string mcnp(std::string frac_type = "mass");
+    ///
+    /// Return a fluka input deck MATERIAL card as a string
+    std::string fluka(int id, std::string frac_type = "mass");
+    /// Convenience function to tell whether a given name needs a material card
+    bool not_fluka_builtin(std::string fluka_name);
+    /// High level call to get details and call material_component(..)
+    std::string fluka_material_str(int id);
+    /// Intermediate level call to prepare final info and call material_line(..)
+    std::string fluka_material_component(int fid, int nucid,
+                                         std::string fluka_name);
+    /// Format information into a FLUKA material card
+    std::string fluka_material_line(int znum, double atomic_mass,
+                              int fid, std::string fluka_name);
+    /// Convenience function to format a single fluka field
+    std::string fluka_format_field(float field);
+    /// Return FLUKA compound card and the material card for the named compound
+    /// but not the material cards of the components
+    std::string fluka_compound_str(int id, std::string frac_type = "mass");
 
-  /// Writes the Material out to a simple plaintext file readable by from_text().
-  void write_text(char* filename);
-  /// Writes the Material out to a simple plaintext file readable by from_text().
-  void write_text(std::string filename);
+    /// Reads data from a plaintext file at \a filename into this Material instance.
+    void from_text(char * filename);
+    /// Reads data from a plaintext file at \a filename into this Material instance.
+    void from_text(std::string filename);
 
-  /// Loads a JSON instance tree into this Material.
-  void load_json(Json::Value);
-  /// Dumps the Material out to a JSON instance tree.
-  Json::Value dump_json();
-  /// Reads data from a JSON file at \a filename into this Material instance.
-  void from_json(char* filename);
-  /// Reads data from a JSON file at \a filename into this Material instance.
-  void from_json(std::string filname);
-  /// Writes the Material out to a JSON file
-  void write_json(char* filename);
-  /// Writes the Material out to a JSON file
-  void write_json(std::string filename);
+    /// Writes the Material out to a simple plaintext file readable by from_text().
+    void write_text(char * filename);
+    /// Writes the Material out to a simple plaintext file readable by from_text().
+    void write_text(std::string filename);
 
-  // Fundemental mass stream data
-  /// composition, maps nuclides in id form to normalized mass weights.
-  comp_map comp;
-  double mass;  ///< mass (in arbitrary units) of the Material.
-  double density; ///< density (in arbitrary units) of the Material.
-  double atoms_per_molecule; ///< The number of atoms per molecule.
-  /// container for arbitrary metadata, following the JSON rules.
-  Json::Value metadata;
+    /// Loads a JSON instance tree into this Material.
+    void load_json(Json::Value);
+    /// Dumps the Material out to a JSON instance tree.
+    Json::Value dump_json();
+    /// Reads data from a JSON file at \a filename into this Material instance.
+    void from_json(char * filename);
+    /// Reads data from a JSON file at \a filename into this Material instance.
+    void from_json(std::string filname);
+    /// Writes the Material out to a JSON file
+    void write_json(char * filename);
+    /// Writes the Material out to a JSON file
+    void write_json(std::string filename);
 
-  // Material function definitions
-  void normalize();   ///< Normalizes the mass.
-  /// Returns a composition map that has been unnormalized by multiplying each
-  /// mass weight by the actual mass of the material.
-  comp_map mult_by_mass();
-  /// Calculates the atomic weight of this material based on the composition
-  /// and the number of atoms per mol.  If \a apm is non-negative then it is
-  /// used (and stored on the instance) as the atoms_per_molecule for this calculation.
-  /// If \a apm and atoms_per_molecule on this instance are both negative, then the best
-  /// guess value calculated from the normailized composition is used here.
-  double molecular_mass(double apm = -1.0);
-  /// Calculates the activity of a material based on the composition and each
-  /// nuclide's mass, decay_const, and atmoic_mass.
-  comp_map activity();
-  /// Calculates the decay heat of a material based on the composition and
-  /// each nuclide's mass, q_val, decay_const, and atomic_mass.
-  comp_map decay_heat();
-  /// Caclulates the dose per gram using the composition of the the
-  /// material, the dose type desired, and the source for dose factors
-  ///   dose_type is one of:
-  ///     ext_air -- returns mrem/h per g per m^3
-  ///     ext_soil -- returns mrem/h per g per m^2
-  ///     ingest -- returns mrem per g
-  ///     inhale -- returns mrem per g
-  ///   source is:
-  ///     {EPA=0, DOE=1, GENII=2}, default is EPA
-  comp_map dose_per_g(std::string dose_type, int source = 0);
-  /// Returns a copy of the current material where all natural elements in the
-  /// composition are expanded to their natural isotopic abundances.
-  Material expand_elements();
-  // Returns a copy of the current material where all the isotopes of the elements
-  // are added up, atomic-fraction-wise, unless they are in the exception set
-  Material collapse_elements(std::set<int> exception_znum);
-  // Wrapped version to facilitate calling from python
-  Material collapse_elements(int** int_ptr_arry);
-  // void print_material( pyne::Material test_mat);
-  /// Computes, sets, and returns the mass density when \a num_dens is greater
-  /// than or equal zero.  If \a num_dens is negative, this simply returns the
-  /// current value of the density member variable.  You may also use / set the
-  /// atoms per molecule (atoms_per_molecule) in this function using \a apm.
-  double mass_density(double num_dens = -1.0, double apm = -1.0);
-  /// Computes and returns the number density of the material using the
-  /// mass density if \a mass_dens is greater than or equal to zero.  If
-  /// \a mass_dens is negative, the denisty member variable is used instead.
-  /// You may also use / set the atoms per molecule (atoms_per_molecule) in this
-  /// function using \a apm.
-  double number_density(double mass_dens = -1.0, double apm = -1.0);
+    // Fundemental mass stream data
+    /// composition, maps nuclides in id form to normalized mass weights.
+    comp_map comp;
+    double mass;  ///< mass (in arbitrary units) of the Material.
+    double density; ///< density (in arbitrary units) of the Material.
+    double atoms_per_molecule; ///< The number of atoms per molecule.
+    /// container for arbitrary metadata, following the JSON rules.
+    Json::Value metadata;
 
-  // Sub-Stream Computation
-  /// Creates a sub-Material with only the nuclides present in \a nucset.
-  /// Elements of this set may be either in id form or simple Z numbers.
-  Material sub_mat(std::set<int> nucset);
-  /// Creates a sub-Material with only the nuclides present in \a nucset.
-  /// Elements of this set may be in any form.
-  Material sub_mat(std::set<std::string> nucset);
+    // Material function definitions
+    void normalize ();  ///< Normalizes the mass.
+    /// Returns a composition map that has been unnormalized by multiplying each
+    /// mass weight by the actual mass of the material.
+    comp_map mult_by_mass();
+    /// Calculates the atomic weight of this material based on the composition
+    /// and the number of atoms per mol.  If \a apm is non-negative then it is
+    /// used (and stored on the instance) as the atoms_per_molecule for this calculation.
+    /// If \a apm and atoms_per_molecule on this instance are both negative, then the best
+    /// guess value calculated from the normailized composition is used here.
+    double molecular_mass(double apm=-1.0);
+    /// Calculates the activity of a material based on the composition and each
+    /// nuclide's mass, decay_const, and atmoic_mass.
+    comp_map activity();
+    /// Calculates the decay heat of a material based on the composition and
+    /// each nuclide's mass, q_val, decay_const, and atomic_mass. This assumes
+    /// input mass of grams. Return values is in megawatts.
+    comp_map decay_heat();
+    /// Caclulates the dose per gram using the composition of the the
+    /// material, the dose type desired, and the source for dose factors
+    ///   dose_type is one of:
+    ///     ext_air -- returns mrem/h per g per m^3
+    ///     ext_soil -- returns mrem/h per g per m^2
+    ///     ingest -- returns mrem per g
+    ///     inhale -- returns mrem per g
+    ///   source is:
+    ///     {EPA=0, DOE=1, GENII=2}, default is EPA
+    comp_map dose_per_g(std::string dose_type, int source=0);
+    /// Returns a copy of the current material where all natural elements in the
+    /// composition are expanded to their natural isotopic abundances.
+    Material expand_elements(std::set<int> exception_ids);
+    // Wrapped version to facilitate calling from python
+    Material expand_elements(int **int_ptr_arry = NULL);
+    // Returns a copy of the current material where all the isotopes of the elements
+    // are added up, atomic-fraction-wise, unless they are in the exception set
+    Material collapse_elements(std::set<int> exception_znum);
+    // Wrapped version to facilitate calling from python
+    Material collapse_elements(int **int_ptr_arry);
+    // void print_material( pyne::Material test_mat);
+    /// Computes, sets, and returns the mass density when \a num_dens is greater
+    /// than or equal zero.  If \a num_dens is negative, this simply returns the
+    /// current value of the density member variable.  You may also use / set the
+    /// atoms per molecule (atoms_per_molecule) in this function using \a apm.
+    double mass_density(double num_dens=-1.0, double apm=-1.0);
+    /// Computes and returns the number density of the material using the
+    /// mass density if \a mass_dens is greater than or equal to zero.  If
+    /// \a mass_dens is negative, the denisty member variable is used instead.
+    /// You may also use / set the atoms per molecule (atoms_per_molecule) in this
+    /// function using \a apm.
+    double number_density(double mass_dens=-1.0, double apm=-1.0);
 
-  /// Creates a new Material with the mass weights for all nuclides in \a nucset
-  /// set to \a value.
-  /// Elements of \a nucset may be either in id form or simple Z numbers.
-  Material set_mat(std::set<int> nucset, double value);
-  /// Creates a new Material with the mass weights for all nuclides in \a nucset
-  /// set to \a value.  Elements of \a nucset may be in any form.
-  Material set_mat(std::set<std::string> nucset, double value);
+    // Sub-Stream Computation
+    /// Creates a sub-Material with only the nuclides present in \a nucset.
+    /// Elements of this set may be either in id form or simple Z numbers.
+    Material sub_mat(std::set<int> nucset);
+    /// Creates a sub-Material with only the nuclides present in \a nucset.
+    /// Elements of this set may be in any form.
+    Material sub_mat(std::set<std::string> nucset);
 
-  /// Creates a new Material with the all nuclides in \a nucset removed.
-  /// Elements of \a nucset may be either in id form or simple Z numbers.
-  Material del_mat(std::set<int> nucset);
-  /// Creates a new Material with the all nuclides in \a nucset removed.
-  /// Elements of \a nucset may be in any form.
-  Material del_mat(std::set<std::string> nucset);
+    /// Creates a new Material with the mass weights for all nuclides in \a nucset
+    /// set to \a value.
+    /// Elements of \a nucset may be either in id form or simple Z numbers.
+    Material set_mat(std::set<int> nucset, double value);
+    /// Creates a new Material with the mass weights for all nuclides in \a nucset
+    /// set to \a value.  Elements of \a nucset may be in any form.
+    Material set_mat(std::set<std::string> nucset, double value);
 
-  /// Creates a sub-Material based on a range of id-form integers.
-  Material sub_range(int lower = 0, int upper = 10000000);
-  /// Creates a new Material with the mass weights for all nuclides in the id
-  /// range set to \a value.
-  Material set_range(int lower = 0, int upper = 10000000, double value = 0.0);
-  /// Creates a new Material with the all nuclides in the id range removed.
-  Material del_range(int lower = 0, int upper = 10000000);
+    /// Creates a new Material with the all nuclides in \a nucset removed.
+    /// Elements of \a nucset may be either in id form or simple Z numbers.
+    Material del_mat(std::set<int> nucset);
+    /// Creates a new Material with the all nuclides in \a nucset removed.
+    /// Elements of \a nucset may be in any form.
+    Material del_mat(std::set<std::string> nucset);
 
-  /// Creates a sub-Material of only the given element. Assumes element is
-  /// id form.
-  Material sub_elem(int element);
-  /// Creates a sub-Material of only lanthanides.
-  Material sub_lan();
-  /// Creates a sub-Material of only actinides.
-  Material sub_act();
-  /// Creates a sub-Material of only transuranics.
-  Material sub_tru();
-  /// Creates a sub-Material of only minor actinides.
-  Material sub_ma();
-  /// Creates a sub-Material of only fission products.
-  Material sub_fp();
+    /// Creates a sub-Material based on a range of id-form integers.
+    Material sub_range(int lower=0, int upper=10000000);
+    /// Creates a new Material with the mass weights for all nuclides in the id
+    /// range set to \a value.
+    Material set_range(int lower=0, int upper=10000000, double value=0.0);
+    /// Creates a new Material with the all nuclides in the id range removed.
+    Material del_range(int lower=0, int upper=10000000);
 
-  // Atom fraction functions
-  /// Returns a mapping of the nuclides in this material to their atom fractions.
-  /// This calculation is based off of the material's molecular weight.
-  std::map<int, double> to_atom_frac();
-  /// Sets the composition, mass, and atoms_per_molecule of this material to those
-  /// calculated from \a atom_fracs, a mapping of nuclides to atom fractions values.
-  void from_atom_frac(std::map<int, double> atom_fracs);
+    /// Creates a sub-Material of only the given element. Assumes element is
+    /// id form.
+    Material sub_elem(int element);
+    /// Creates a sub-Material of only lanthanides.
+    Material sub_lan();
+    /// Creates a sub-Material of only actinides.
+    Material sub_act();
+    /// Creates a sub-Material of only transuranics.
+    Material sub_tru();
+    /// Creates a sub-Material of only minor actinides.
+    Material sub_ma();
+    /// Creates a sub-Material of only fission products.
+    Material sub_fp();
 
-  /// Returns a mapping of the nuclides in this material to their atom densities.
-  /// This calculation is based off of the material's density.
-  std::map<int, double> to_atom_dens();
+    // Atom fraction functions
+    /// Returns a mapping of the nuclides in this material to their atom fractions.
+    /// This calculation is based off of the material's molecular weight.
+    std::map<int, double> to_atom_frac();
+    /// Sets the composition, mass, and atoms_per_molecule of this material to those
+    /// calculated from \a atom_fracs, a mapping of nuclides to atom fractions values.
+    void from_atom_frac(std::map<int, double> atom_fracs);
 
-  // Radioactive Material functions
-  /// Returns a list of gamma-rays energies in keV and intensities in
-  /// decays/s/atom material unnormalized
-  std::vector<std::pair<double, double> > gammas();
-  /// Returns a list of x-rays average energies in keV and intensities in
-  /// decays/s material unnormalized
-  std::vector<std::pair<double, double> > xrays();
-  /// Returns a list of photon energies in keV and intensities in
-  /// decays/s/atom material unnormalized
-  std::vector<std::pair<double, double> > photons(bool norm);
-  /// Takes a list of photon energies and intensities and normalizes them
-  /// so the sum of the intensities is one
-  std::vector<std::pair<double, double> > normalize_radioactivity(
+    /// Returns a mapping of the nuclides in this material to their atom densities.
+    /// This calculation is based off of the material's density.
+    std::map<int, double> to_atom_dens();
+
+    // Radioactive Material functions
+    /// Returns a list of gamma-rays energies in keV and intensities in
+    /// decays/s/atom material unnormalized
+    std::vector<std::pair<double, double> > gammas();
+    /// Returns a list of x-rays average energies in keV and intensities in
+    /// decays/s material unnormalized
+    std::vector<std::pair<double, double> > xrays();
+    /// Returns a list of photon energies in keV and intensities in
+    /// decays/s/atom material unnormalized
+    std::vector<std::pair<double, double> > photons(bool norm);
+    /// Takes a list of photon energies and intensities and normalizes them
+    /// so the sum of the intensities is one
+    std::vector<std::pair<double, double> > normalize_radioactivity(
       std::vector<std::pair<double, double> > unnormed);
 
-  /// Decays this material for a given amount of time in seconds
-  Material decay(double t);
+    /// Decays this material for a given amount of time in seconds
+    Material decay(double t);
 
-  // Overloaded Operators
-  /// Adds mass to a material instance.
-  Material operator+ (double);
-  /// Adds two materials together.
-  Material operator+ (Material);
-  /// Multiplies a material's mass.
-  Material operator* (double);
-  /// Divides a material's mass.
-  Material operator/ (double);
-};
+    /// Transmutes the material via the CRAM method.
+    /// \param A The transmutation matrix [unitless]
+    /// \param order The CRAM approximation order (default 14).
+    /// \return A new material which has been transmuted.
+    Material cram(std::vector<double> A, const int order=14);
 
-/// Converts a Material to a string stream representation for canonical writing.
-/// This operator is also defined on inheritors of std::ostream
-std::ostream& operator<< (std::ostream& os, Material mat);
+    // Overloaded Operators
+    /// Adds mass to a material instance.
+    Material operator+ (double);
+    /// Adds two materials together.
+    Material operator+ (Material);
+    /// Multiplies a material's mass.
+    Material operator* (double);
+    /// Divides a material's mass.
+    Material operator/ (double);
+  };
 
-/// A stuct for reprensenting fundemental data in a material.
-/// Useful for HDF5 representations.
-typedef struct material_data {
-  double mass;  ///< material mass
-  double density; ///< material density
-  double atoms_per_mol; ///< material atoms per mole
-  double comp[1]; ///< array of material composition mass weights.
-} material_data;
+  /// Converts a Material to a string stream representation for canonical writing.
+  /// This operator is also defined on inheritors of std::ostream
+  std::ostream& operator<< (std::ostream& os, Material mat);
 
-/// Custom exception for invalid HDF5 protocol numbers
-class MaterialProtocolError: public std::exception {
-  /// marginally helpful error message.
-  virtual const char* what() const throw() {
-    return "Invalid loading protocol number; please use 0 or 1.";
-  }
-};
+  /// A stuct for reprensenting fundemental data in a material.
+  /// Useful for HDF5 representations.
+  typedef struct material_data {
+    double mass;  ///< material mass
+    double density; ///< material density
+    double atoms_per_mol; ///< material atoms per mole
+    double comp[1]; ///< array of material composition mass weights.
+  } material_data;
+
+  /// Custom exception for invalid HDF5 protocol numbers
+  class MaterialProtocolError: public std::exception
+  {
+    /// marginally helpful error message.
+    virtual const char* what() const throw()
+    {
+      return "Invalid loading protocol number; please use 0 or 1.";
+    }
+  };
 
 // End pyne namespace
 }
 
 #endif  // PYNE_MR34UE5INRGMZK2QYRDWICFHVM
+
 //
 // end of src/material.h
 //

--- a/src/pyne/pyne.h
+++ b/src/pyne/pyne.h
@@ -95,187 +95,181 @@
 #include <algorithm>
 
 #if (__GNUC__ >= 4)
-  #include <cmath>
-  #define isnan(x) std::isnan(x)
+#include <cmath>
+#define isnan(x) std::isnan(x)
 #else
-  #include <math.h>
-  #define isnan(x) __isnand((double)x)
+#include <math.h>
+#define isnan(x) __isnand((double)x)
 #endif
 
 #ifdef __WIN_MSVC__
-    #define isnan(x) ((x) != (x))
+#define isnan(x) ((x) != (x))
 #endif
 
 #ifndef JSON_IS_AMALGAMATION
-  #define JSON_IS_AMALGAMATION
+#define JSON_IS_AMALGAMATION
 #endif
 
 /// The 'pyne' namespace all PyNE functionality is included in.
 namespace pyne {
 
-  void pyne_start (); ///< Initializes PyNE based on environment.
+void pyne_start();  ///< Initializes PyNE based on environment.
 
-  /// Path to the directory containing the PyNE data.
-  extern std::string PYNE_DATA;
-  extern std::string NUC_DATA_PATH; ///< Path to the nuc_data.h5 file.
-  extern std::string VERSION; ///< PyNE version number
+/// Path to the directory containing the PyNE data.
+extern std::string PYNE_DATA;
+extern std::string NUC_DATA_PATH; ///< Path to the nuc_data.h5 file.
+extern std::string VERSION; ///< PyNE version number
 
-  // String Transformations
-  /// string of digit characters
-  static std::string digits = "0123456789";
-  /// uppercase alphabetical characters
-  static std::string alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-  /// string of all valid word characters for variable names in programing languages.
-  static std::string words = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_";
+// String Transformations
+/// string of digit characters
+static std::string digits = "0123456789";
+/// uppercase alphabetical characters
+static std::string alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+/// string of all valid word characters for variable names in programing languages.
+static std::string words = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_";
 
-  /// \name String Conversion Functions
-  /// \{
-  /// Converts the variables of various types to their C++ string representation.
-  std::string to_str(int t);
-  std::string to_str(unsigned int t);
-  std::string to_str(double t);
-  std::string to_str(bool t);
-  /// \}
+/// \name String Conversion Functions
+/// \{
+/// Converts the variables of various types to their C++ string representation.
+std::string to_str(int t);
+std::string to_str(unsigned int t);
+std::string to_str(double t);
+std::string to_str(bool t);
+/// \}
 
-  int to_int(std::string s);  ///< Converts a string of digits to an int using atoi().
+int to_int(std::string s);  ///< Converts a string of digits to an int using atoi().
 
-  double to_dbl(std::string s);  ///< Converts a valid string to a float using atof().
+double to_dbl(std::string s);  ///< Converts a valid string to a float using atof().
 
-  /// Converts a string from ENDF format to a float. Only handles E-less format
-  /// but is roughly 5 times faster than endftod.
-  double endftod_cpp(char * s);
-  double endftod_f(char * s); ///< Converts a string from ENDF format to a float.
-  extern  double (*endftod)(char * s); ///< endftod function pointer. defaults to fortran
+/// Converts a string from ENDF format to a float. Only handles E-less format
+/// but is roughly 5 times faster than endftod.
+double endftod_cpp(char* s);
+double endftod_f(char* s);  ///< Converts a string from ENDF format to a float.
+extern  double (*endftod)(char* s);  ///< endftod function pointer. defaults to fortran
 
-  void use_fast_endftod();/// switches endftod to fast cpp version
+void use_fast_endftod();/// switches endftod to fast cpp version
 
-  /// Returns an all upper case copy of the string.
-  std::string to_upper(std::string s);
+/// Returns an all upper case copy of the string.
+std::string to_upper(std::string s);
 
-  /// Returns an all lower case copy of the string.
-  std::string to_lower(std::string s);
+/// Returns an all lower case copy of the string.
+std::string to_lower(std::string s);
 
-  /// Returns a capitalized copy of the string.
-  std::string capitalize(std::string s);
+/// Returns a capitalized copy of the string.
+std::string capitalize(std::string s);
 
-  /// Finds and returns the first white-space delimited token of a line.
-  /// \param line a character array to take the first token from.
-  /// \param max_l an upper bound to the length of the token.  Must be 11 or less.
-  /// \returns a the flag as a string
-  std::string get_flag(char line[], int max_l);
+/// Finds and returns the first white-space delimited token of a line.
+/// \param line a character array to take the first token from.
+/// \param max_l an upper bound to the length of the token.  Must be 11 or less.
+/// \returns a the flag as a string
+std::string get_flag(char line[], int max_l);
 
-  /// Creates a copy of \a s with all instances of \a substr taken out.
-  std::string remove_substring(std::string s, std::string substr);
+/// Creates a copy of \a s with all instances of \a substr taken out.
+std::string remove_substring(std::string s, std::string substr);
 
-  /// Removes all characters in the string \a chars from \a s.
-  std::string remove_characters(std::string s, std::string chars);
+/// Removes all characters in the string \a chars from \a s.
+std::string remove_characters(std::string s, std::string chars);
 
-  /// Replaces all instance of \a substr in \a s with \a repstr.
-  std::string replace_all_substrings(std::string s, std::string substr,
-                                                    std::string repstr);
+/// Replaces all instance of \a substr in \a s with \a repstr.
+std::string replace_all_substrings(std::string s, std::string substr,
+                                   std::string repstr);
 
-  /// Returns the last character in a string.
-  std::string last_char(std::string s);
+/// Returns the last character in a string.
+std::string last_char(std::string s);
 
-  /// Returns the slice of a string \a s using the negative index \a n and the
-  /// length of the slice \a l.
-  std::string slice_from_end(std::string s, int n=-1, int l=1);
+/// Returns the slice of a string \a s using the negative index \a n and the
+/// length of the slice \a l.
+std::string slice_from_end(std::string s, int n = -1, int l = 1);
 
-  /// Returns true if \a a <= \a b <= \a c and flase otherwise.
-  bool ternary_ge(int a, int b, int c);
+/// Returns true if \a a <= \a b <= \a c and flase otherwise.
+bool ternary_ge(int a, int b, int c);
 
-  /// Returns true if \a substr is in \a s.
-  bool contains_substring(std::string s, std::string substr);
+/// Returns true if \a substr is in \a s.
+bool contains_substring(std::string s, std::string substr);
 
-  /// Calculates a version of the string \a name that is also a valid variable name.
-  /// That is to say that the return value uses only word characters.
-  std::string natural_naming(std::string name);
+/// Calculates a version of the string \a name that is also a valid variable name.
+/// That is to say that the return value uses only word characters.
+std::string natural_naming(std::string name);
 
-  /// Finds the slope of a line from the points (\a x1, \a y1) and (\a x2, \a y2).
-  double slope (double x2, double y2, double x1, double y1);
+/// Finds the slope of a line from the points (\a x1, \a y1) and (\a x2, \a y2).
+double slope(double x2, double y2, double x1, double y1);
 
-  /// Solves the equation for the line y = mx + b, given \a x and the points that
-  /// form the line: (\a x1, \a y1) and (\a x2, \a y2).
-  double solve_line (double x, double x2, double y2, double x1, double y1);
+/// Solves the equation for the line y = mx + b, given \a x and the points that
+/// form the line: (\a x1, \a y1) and (\a x2, \a y2).
+double solve_line(double x, double x2, double y2, double x1, double y1);
 
-  double tanh(double x);  ///< The hyperbolic tangent function.
-  double coth(double x);  ///< The hyperbolic cotangent function.
+double tanh(double x);  ///< The hyperbolic tangent function.
+double coth(double x);  ///< The hyperbolic cotangent function.
 
 
-  // File Helpers
-  /// Returns true if the file can be found.
-  bool file_exists(std::string strfilename);
+// File Helpers
+/// Returns true if the file can be found.
+bool file_exists(std::string strfilename);
 
-  // Message Helpers
-  extern bool USE_WARNINGS;
-  /// Toggles warnings on and off
-  bool toggle_warnings();
+// Message Helpers
+extern bool USE_WARNINGS;
+/// Toggles warnings on and off
+bool toggle_warnings();
 
-  /// Prints a warning message.
-  void warning(std::string s);
+/// Prints a warning message.
+void warning(std::string s);
 
-  /// Custom exception to be thrown in the event that a required file is not able to
-  /// be found.
-  class FileNotFound : public std::exception
-  {
-  public:
+/// Custom exception to be thrown in the event that a required file is not able to
+/// be found.
+class FileNotFound : public std::exception {
+ public:
 
-    /// default constructor
-    FileNotFound () {};
+  /// default constructor
+  FileNotFound() {};
 
-    /// default destructor
-    ~FileNotFound () throw () {};
+  /// default destructor
+  ~FileNotFound() throw () {};
 
-    /// constructor with the filename \a fname.
-    FileNotFound(std::string fname)
-    {
-      filename = fname;
-    };
-
-    /// Creates a helpful error message.
-    virtual const char* what() const throw()
-    {
-      std::string FNFstr ("File not found: ");
-      if (!filename.empty())
-        FNFstr += filename;
-
-      return (const char *) FNFstr.c_str();
-    };
-
-  private:
-    std::string filename; ///< unfindable filename.
+  /// constructor with the filename \a fname.
+  FileNotFound(std::string fname) {
+    filename = fname;
   };
 
-  /// Exception representing value errors of all kinds
-  class ValueError : public std::exception
-  {
-  public:
+  /// Creates a helpful error message.
+  virtual const char* what() const throw() {
+    std::string FNFstr("File not found: ");
+    if (!filename.empty())
+      FNFstr += filename;
 
-    /// default constructor
-    ValueError () {};
-
-    /// default destructor
-    ~ValueError () throw () {};
-
-    /// constructor with the filename \a fname.
-    ValueError(std::string msg)
-    {
-      message = msg;
-    };
-
-    /// Creates a helpful error message.
-    virtual const char* what() const throw()
-    {
-      std::string msgstr ("ValueError: ");
-      if (!message.empty())
-        msgstr += message;
-
-      return (const char *) msgstr.c_str();
-    };
-
-  private:
-    std::string message; ///< extra message for the user.
+    return (const char*) FNFstr.c_str();
   };
+
+ private:
+  std::string filename; ///< unfindable filename.
+};
+
+/// Exception representing value errors of all kinds
+class ValueError : public std::exception {
+ public:
+
+  /// default constructor
+  ValueError() {};
+
+  /// default destructor
+  ~ValueError() throw () {};
+
+  /// constructor with the filename \a fname.
+  ValueError(std::string msg) {
+    message = msg;
+  };
+
+  /// Creates a helpful error message.
+  virtual const char* what() const throw() {
+    std::string msgstr("ValueError: ");
+    if (!message.empty())
+      msgstr += message;
+
+    return (const char*) msgstr.c_str();
+  };
+
+ private:
+  std::string message; ///< extra message for the user.
+};
 
 
 // End PyNE namespace
@@ -806,614 +800,598 @@ inline bool path_exists(hid_t h5file, std::string path) {
 #include "utils.h"
 #endif
 
-namespace pyne
-{
+namespace pyne {
 //! Nuclide naming conventions
-namespace nucname
-{
-  typedef std::string name_t; ///< name type
-  typedef int zz_t;           ///< Z number type
+namespace nucname {
+typedef std::string name_t; ///< name type
+typedef int zz_t;           ///< Z number type
 
-  typedef std::map<name_t, zz_t> name_zz_t; ///< name and Z num map type
-  typedef name_zz_t::iterator name_zz_iter; ///< name and Z num iter type
-  name_zz_t get_name_zz();  ///< Creates standard name to Z number mapping.
-  extern name_zz_t name_zz; ///< name to Z num map
+typedef std::map<name_t, zz_t> name_zz_t; ///< name and Z num map type
+typedef name_zz_t::iterator name_zz_iter; ///< name and Z num iter type
+name_zz_t get_name_zz();  ///< Creates standard name to Z number mapping.
+extern name_zz_t name_zz; ///< name to Z num map
 
-  typedef std::map<zz_t, name_t> zzname_t;  ///< Z num to name map type
-  typedef zzname_t::iterator zzname_iter;   ///< Z num to name iter type
-  zzname_t get_zz_name();   ///< Creates standard Z number to name mapping.
-  extern zzname_t zz_name;  ///< Z num to name map
+typedef std::map<zz_t, name_t> zzname_t;  ///< Z num to name map type
+typedef zzname_t::iterator zzname_iter;   ///< Z num to name iter type
+zzname_t get_zz_name();   ///< Creates standard Z number to name mapping.
+extern zzname_t zz_name;  ///< Z num to name map
 
-  name_zz_t get_fluka_zz();  ///< Creates standard fluka-name to nucid mapping.
-  extern name_zz_t fluka_zz; ///< fluka-name to nucid map
-  zzname_t get_zz_fluka();   ///< Creates standard nucid to fluka-name mapping.
-  extern zzname_t zz_fluka;  ///< nucid to fluka-name map
-  /******************************************/
-  /*** Define useful elemental group sets ***/
-  /******************************************/
+name_zz_t get_fluka_zz();  ///< Creates standard fluka-name to nucid mapping.
+extern name_zz_t fluka_zz; ///< fluka-name to nucid map
+zzname_t get_zz_fluka();   ///< Creates standard nucid to fluka-name mapping.
+extern zzname_t zz_fluka;  ///< nucid to fluka-name map
+/******************************************/
+/*** Define useful elemental group sets ***/
+/******************************************/
 
-  /// name grouping type (for testing containment)
-  typedef std::set<name_t> name_group;
-  typedef name_group::iterator name_group_iter; ///< name grouping iter type
+/// name grouping type (for testing containment)
+typedef std::set<name_t> name_group;
+typedef name_group::iterator name_group_iter; ///< name grouping iter type
 
-  /// Z number grouping type (for testing containment)
-  typedef std::set<zz_t> zz_group;
-  typedef zz_group::iterator zz_group_iter; ///< Z number grouping iter
+/// Z number grouping type (for testing containment)
+typedef std::set<zz_t> zz_group;
+typedef zz_group::iterator zz_group_iter; ///< Z number grouping iter
 
-  /// Converts a name group to a Z number group.
-  /// \param eg a grouping of nuclides by name
-  /// \return a Z numbered group
-  zz_group name_to_zz_group (name_group eg);
+/// Converts a name group to a Z number group.
+/// \param eg a grouping of nuclides by name
+/// \return a Z numbered group
+zz_group name_to_zz_group(name_group eg);
 
-  extern name_t LAN_array[15];  ///< array of lanthanide names
-  extern name_group LAN;        ///< lanthanide name group
-  extern zz_group lan;          ///< lanthanide Z number group
+extern name_t LAN_array[15];  ///< array of lanthanide names
+extern name_group LAN;        ///< lanthanide name group
+extern zz_group lan;          ///< lanthanide Z number group
 
-  extern name_t ACT_array[15];  ///< array of actinide names
-  extern name_group ACT;        ///< actinide name group
-  extern zz_group act;          ///< actinide Z number group
+extern name_t ACT_array[15];  ///< array of actinide names
+extern name_group ACT;        ///< actinide name group
+extern zz_group act;          ///< actinide Z number group
 
-  extern name_t TRU_array[22];  ///< array of transuranic names
-  extern name_group TRU;        ///< transuranic name group
-  extern zz_group tru;          ///< transuranic Z number group
+extern name_t TRU_array[22];  ///< array of transuranic names
+extern name_group TRU;        ///< transuranic name group
+extern zz_group tru;          ///< transuranic Z number group
 
-  extern name_t MA_array[10];   ///< array of minor actinide names
-  extern name_group MA;         ///< minor actinide name group
-  extern zz_group ma;           ///< minor actinide Z number group
+extern name_t MA_array[10];   ///< array of minor actinide names
+extern name_group MA;         ///< minor actinide name group
+extern zz_group ma;           ///< minor actinide Z number group
 
-  extern name_t FP_array[88];   ///< array of fission product names
-  extern name_group FP;         ///< fission product name group
-  extern zz_group fp;           ///< fission product Z number group
+extern name_t FP_array[88];   ///< array of fission product names
+extern name_group FP;         ///< fission product name group
+extern zz_group fp;           ///< fission product Z number group
 
 
-  /******************/
-  /*** Exceptions ***/
-  /******************/
+/******************/
+/*** Exceptions ***/
+/******************/
 
-  /// Custom expection for declaring that a value does not follow a recognizable
-  /// nuclide naming convention.
-  class NotANuclide : public std::exception
-  {
-  public:
-    /// default constructor
-    NotANuclide () {};
+/// Custom expection for declaring that a value does not follow a recognizable
+/// nuclide naming convention.
+class NotANuclide : public std::exception {
+ public:
+  /// default constructor
+  NotANuclide() {};
 
-    /// default destructor
-    ~NotANuclide () throw () {};
+  /// default destructor
+  ~NotANuclide() throw () {};
 
-    /// Constructor given previous and current state of nulide name
-    /// \param wasptr Previous state, typically user input.
-    /// \param nowptr Current state, as far as PyNE could get.
-    NotANuclide(std::string wasptr, std::string nowptr)
-    {
-       nucwas = wasptr;
-       nucnow = nowptr;
-    };
-
-    /// Constructor given previous and current state of nulide name
-    /// \param wasptr Previous state, typically user input.
-    /// \param nowptr Current state, as far as PyNE could get.
-    NotANuclide(std::string wasptr, int nowptr)
-    {
-      nucwas = wasptr;
-      nucnow = pyne::to_str(nowptr);
-    };
-
-    /// Constructor given previous and current state of nulide name
-    /// \param wasptr Previous state, typically user input.
-    /// \param nowptr Current state, as far as PyNE could get.
-    NotANuclide(int wasptr, std::string nowptr)
-    {
-      nucwas = pyne::to_str(wasptr);
-      nucnow = nowptr;
-    };
-
-    /// Constructor given previous and current state of nulide name
-    /// \param wasptr Previous state, typically user input.
-    /// \param nowptr Current state, as far as PyNE could get.
-    NotANuclide(int wasptr, int nowptr)
-    {
-      nucwas = pyne::to_str(wasptr);
-      nucnow = pyne::to_str(nowptr);
-    };
-
-    /// Generates an informational message for the exception
-    /// \return The error string
-    virtual const char* what() const throw()
-    {
-      std::string NaNEstr ("Not a Nuclide! ");
-      if (!nucwas.empty())
-        NaNEstr += nucwas;
-
-      if (!nucnow.empty())
-      {
-        NaNEstr += " --> ";
-        NaNEstr += nucnow;
-      }
-      return (const char *) NaNEstr.c_str();
-    };
-
-  private:
-    std::string nucwas; ///< previous nuclide state
-    std::string nucnow; ///< current nuclide state
+  /// Constructor given previous and current state of nulide name
+  /// \param wasptr Previous state, typically user input.
+  /// \param nowptr Current state, as far as PyNE could get.
+  NotANuclide(std::string wasptr, std::string nowptr) {
+    nucwas = wasptr;
+    nucnow = nowptr;
   };
 
-  /// Custom expection for declaring that a value represents one or more nuclides
-  /// in one or more namig conventions
-  class IndeterminateNuclideForm : public std::exception
-  {
-  public:
-    /// default constructor
-    IndeterminateNuclideForm () {};
+  /// Constructor given previous and current state of nulide name
+  /// \param wasptr Previous state, typically user input.
+  /// \param nowptr Current state, as far as PyNE could get.
+  NotANuclide(std::string wasptr, int nowptr) {
+    nucwas = wasptr;
+    nucnow = pyne::to_str(nowptr);
+  };
 
-    /// default destuctor
-    ~IndeterminateNuclideForm () throw () {};
+  /// Constructor given previous and current state of nulide name
+  /// \param wasptr Previous state, typically user input.
+  /// \param nowptr Current state, as far as PyNE could get.
+  NotANuclide(int wasptr, std::string nowptr) {
+    nucwas = pyne::to_str(wasptr);
+    nucnow = nowptr;
+  };
 
-    /// Constructor given previous and current state of nulide name
-    /// \param wasptr Previous state, typically user input.
-    /// \param nowptr Current state, as far as PyNE could get.
-    IndeterminateNuclideForm(std::string wasptr, std::string nowptr)
-    {
-       nucwas = wasptr;
-       nucnow = nowptr;
-    };
+  /// Constructor given previous and current state of nulide name
+  /// \param wasptr Previous state, typically user input.
+  /// \param nowptr Current state, as far as PyNE could get.
+  NotANuclide(int wasptr, int nowptr) {
+    nucwas = pyne::to_str(wasptr);
+    nucnow = pyne::to_str(nowptr);
+  };
 
-    /// Constructor given previous and current state of nulide name
-    /// \param wasptr Previous state, typically user input.
-    /// \param nowptr Current state, as far as PyNE could get.
-    IndeterminateNuclideForm(std::string wasptr, int nowptr)
-    {
-      nucwas = wasptr;
-      nucnow = pyne::to_str(nowptr);
-    };
+  /// Generates an informational message for the exception
+  /// \return The error string
+  virtual const char* what() const throw() {
+    std::string NaNEstr("Not a Nuclide! ");
+    if (!nucwas.empty())
+      NaNEstr += nucwas;
 
-    /// Constructor given previous and current state of nulide name
-    /// \param wasptr Previous state, typically user input.
-    /// \param nowptr Current state, as far as PyNE could get.
-    IndeterminateNuclideForm(int wasptr, std::string nowptr)
-    {
-      nucwas = pyne::to_str(wasptr);
-      nucnow = nowptr;
-    };
-
-    /// Constructor given previous and current state of nulide name
-    /// \param wasptr Previous state, typically user input.
-    /// \param nowptr Current state, as far as PyNE could get.
-    IndeterminateNuclideForm(int wasptr, int nowptr)
-    {
-      nucwas = pyne::to_str(wasptr);
-      nucnow = pyne::to_str(nowptr);
-    };
-
-    /// Generates an informational message for the exception
-    /// \return The error string
-    virtual const char* what() const throw()
-    {
-      std::string INFEstr ("Indeterminate nuclide form: ");
-      if (!nucwas.empty())
-        INFEstr += nucwas;
-
-      if (!nucnow.empty())
-      {
-        INFEstr += " --> ";
-        INFEstr += nucnow;
-      }
-      return (const char *) INFEstr.c_str();
+    if (!nucnow.empty()) {
+      NaNEstr += " --> ";
+      NaNEstr += nucnow;
     }
-
-  private:
-    std::string nucwas; ///< previous nuclide state
-    std::string nucnow; ///< current nuclide state
+    return (const char*) NaNEstr.c_str();
   };
 
-  /// \name isnuclide functions
-  /// \{
-  /// These functions test if an input \a nuc is a valid nuclide.
-  /// \param nuc a possible nuclide
-  /// \return a bool
-  bool isnuclide(std::string nuc);
-  bool isnuclide(const char * nuc);
-  bool isnuclide(int nuc);
-  /// \}
+ private:
+  std::string nucwas; ///< previous nuclide state
+  std::string nucnow; ///< current nuclide state
+};
 
-  /// \name iselement functions
-  /// \{
-  /// These functions test if an input \a nuc is a valid element.
-  /// \param nuc a possible element
-  /// \return a bool
-  bool iselement(std::string nuc);
-  bool iselement(const char * nuc);
-  bool iselement(int nuc);
+/// Custom expection for declaring that a value represents one or more nuclides
+/// in one or more namig conventions
+class IndeterminateNuclideForm : public std::exception {
+ public:
+  /// default constructor
+  IndeterminateNuclideForm() {};
 
-  /// \}
-  /// \name Identifier Form Functions
-  /// \{
-  /// The 'id' nuclide naming convention is the canonical form for representing
-  /// nuclides in PyNE. This is termed a ZAS, or ZZZAAASSSS, representation because
-  /// It stores 3 Z-number digits, 3 A-number digits, followed by 4 S-number digits
-  /// which the nucleus excitation state.
-  ///
-  /// The id() function will always return an nuclide in id form, if successful.
-  /// If the input nuclide is in id form already, then this is function does no
-  /// work. For all other formats, the id() function provides a best-guess based
-  /// on a heirarchy of other formats that is used to resolve ambiguities between
-  /// naming conventions. For integer input the form resolution order is:
-  ///   - id
-  ///   - zz (elemental z-num only given)
-  ///   - zzaaam
-  ///   - cinder (aaazzzm)
-  ///   - mcnp
-  ///   - zzaaa
-  /// For string (or char *) input the form resolution order is as follows:
-  ///   - ZZ-LL-AAAM
-  ///   - Integer form in a string representation, uses interger resolution
-  ///   - NIST
-  ///   - name form
-  ///   - Serpent
-  ///   - LL (element symbol)
-  /// For well-defined situations where you know ahead of time what format the
-  /// nuclide is in, you should use the various form_to_id() functions, rather
-  /// than the id() function which is meant to resolve possibly ambiquous cases.
-  /// \param nuc a nuclide
-  /// \return nucid 32-bit integer identifier
-  int id(int nuc);
-  int id(const char * nuc);
-  int id(std::string nuc);
-  /// \}
+  /// default destuctor
+  ~IndeterminateNuclideForm() throw () {};
 
-  /// \name Name Form Functions
-  /// \{
-  /// The 'name' nuclide naming convention is the more common, human readable
-  /// notation. The chemical symbol (one or two characters long) is first, followed
-  /// by the nucleon number. Lastly if the nuclide is metastable, the letter M is
-  /// concatenated to the end. For example, ‘H-1’ and ‘Am242M’ are both valid.
-  /// Note that nucname will always return name form with dashes removed, the
-  /// chemical symbol used for letter casing (ie 'Pu'), and a trailing upercase 'M'
-  /// for a metastable flag. The name() function first converts functions to id form
-  /// using the id() function. Thus the form order resolution for id() also applies
-  /// here.
-  /// \param nuc a nuclide
-  /// \return a string nuclide identifier.
-  std::string name(int nuc);
-  std::string name(const char * nuc);
-  std::string name(std::string nuc);
-  /// \}
+  /// Constructor given previous and current state of nulide name
+  /// \param wasptr Previous state, typically user input.
+  /// \param nowptr Current state, as far as PyNE could get.
+  IndeterminateNuclideForm(std::string wasptr, std::string nowptr) {
+    nucwas = wasptr;
+    nucnow = nowptr;
+  };
 
-  /// \name Z-Number Functions
-  /// \{
-  /// The Z-number, or charge number, represents the number of protons in a
-  /// nuclide.  This function returns that number.
-  /// \param nuc a nuclide
-  /// \return an integer Z-number.
-  int znum(int nuc);
-  int znum(const char * nuc);
-  int znum(std::string nuc);
-  /// \}
+  /// Constructor given previous and current state of nulide name
+  /// \param wasptr Previous state, typically user input.
+  /// \param nowptr Current state, as far as PyNE could get.
+  IndeterminateNuclideForm(std::string wasptr, int nowptr) {
+    nucwas = wasptr;
+    nucnow = pyne::to_str(nowptr);
+  };
 
-  /// \name A-Number Functions
-  /// \{
-  /// The A-number, or nucleon number, represents the number of protons and
-  /// neutrons in a nuclide.  This function returns that number.
-  /// \param nuc a nuclide
-  /// \return an integer A-number.
-  int anum(int nuc);
-  int anum(const char * nuc);
-  int anum(std::string nuc);
-  /// \}
+  /// Constructor given previous and current state of nulide name
+  /// \param wasptr Previous state, typically user input.
+  /// \param nowptr Current state, as far as PyNE could get.
+  IndeterminateNuclideForm(int wasptr, std::string nowptr) {
+    nucwas = pyne::to_str(wasptr);
+    nucnow = nowptr;
+  };
 
-  /// \name S-Number Functions
-  /// \{
-  /// The S-number, or excitation state number, represents the excitation
-  /// level of a nuclide.  Normally, this is zero.  This function returns
-  /// that number.
-  /// \param nuc a nuclide
-  /// \return an integer A-number.
-  int snum(int nuc);
-  int snum(const char * nuc);
-  int snum(std::string nuc);
-  /// \}
+  /// Constructor given previous and current state of nulide name
+  /// \param wasptr Previous state, typically user input.
+  /// \param nowptr Current state, as far as PyNE could get.
+  IndeterminateNuclideForm(int wasptr, int nowptr) {
+    nucwas = pyne::to_str(wasptr);
+    nucnow = pyne::to_str(nowptr);
+  };
 
-  /// \name ZZAAAM Form Functions
-  /// \{
-  /// The ZZAAAM nuclide naming convention is the former canonical form for
-  /// nuclides in PyNE. This places the charge of the nucleus out front, then has
-  /// three digits for the atomic mass number, and ends with a metastable flag
-  /// (0 = ground, 1 = first excited state, 2 = second excited state, etc).
-  /// Uranium-235 here would be expressed as ‘922350’.
-  /// \param nuc a nuclide
-  /// \return an integer nuclide identifier.
-  int zzaaam(int nuc);
-  int zzaaam(const char * nuc);
-  int zzaaam(std::string nuc);
-  /// \}
+  /// Generates an informational message for the exception
+  /// \return The error string
+  virtual const char* what() const throw() {
+    std::string INFEstr("Indeterminate nuclide form: ");
+    if (!nucwas.empty())
+      INFEstr += nucwas;
 
-  /// \name ZZAAAM Form to Identifier Form Functions
-  /// \{
-  /// This converts from the ZZAAAM nuclide naming convention
-  /// to the id canonical form  for nuclides in PyNE.
-  /// \param nuc a nuclide in ZZAAAM form.
-  /// \return an integer id nuclide identifier.
-  int zzaaam_to_id(int nuc);
-  int zzaaam_to_id(const char * nuc);
-  int zzaaam_to_id(std::string nuc);
-  /// \}
+    if (!nucnow.empty()) {
+      INFEstr += " --> ";
+      INFEstr += nucnow;
+    }
+    return (const char*) INFEstr.c_str();
+  }
+
+ private:
+  std::string nucwas; ///< previous nuclide state
+  std::string nucnow; ///< current nuclide state
+};
+
+/// \name isnuclide functions
+/// \{
+/// These functions test if an input \a nuc is a valid nuclide.
+/// \param nuc a possible nuclide
+/// \return a bool
+bool isnuclide(std::string nuc);
+bool isnuclide(const char* nuc);
+bool isnuclide(int nuc);
+/// \}
+
+/// \name iselement functions
+/// \{
+/// These functions test if an input \a nuc is a valid element.
+/// \param nuc a possible element
+/// \return a bool
+bool iselement(std::string nuc);
+bool iselement(const char* nuc);
+bool iselement(int nuc);
+
+/// \}
+/// \name Identifier Form Functions
+/// \{
+/// The 'id' nuclide naming convention is the canonical form for representing
+/// nuclides in PyNE. This is termed a ZAS, or ZZZAAASSSS, representation because
+/// It stores 3 Z-number digits, 3 A-number digits, followed by 4 S-number digits
+/// which the nucleus excitation state.
+///
+/// The id() function will always return an nuclide in id form, if successful.
+/// If the input nuclide is in id form already, then this is function does no
+/// work. For all other formats, the id() function provides a best-guess based
+/// on a heirarchy of other formats that is used to resolve ambiguities between
+/// naming conventions. For integer input the form resolution order is:
+///   - id
+///   - zz (elemental z-num only given)
+///   - zzaaam
+///   - cinder (aaazzzm)
+///   - mcnp
+///   - zzaaa
+/// For string (or char *) input the form resolution order is as follows:
+///   - ZZ-LL-AAAM
+///   - Integer form in a string representation, uses interger resolution
+///   - NIST
+///   - name form
+///   - Serpent
+///   - LL (element symbol)
+/// For well-defined situations where you know ahead of time what format the
+/// nuclide is in, you should use the various form_to_id() functions, rather
+/// than the id() function which is meant to resolve possibly ambiquous cases.
+/// \param nuc a nuclide
+/// \return nucid 32-bit integer identifier
+int id(int nuc);
+int id(const char* nuc);
+int id(std::string nuc);
+/// \}
+
+/// \name Name Form Functions
+/// \{
+/// The 'name' nuclide naming convention is the more common, human readable
+/// notation. The chemical symbol (one or two characters long) is first, followed
+/// by the nucleon number. Lastly if the nuclide is metastable, the letter M is
+/// concatenated to the end. For example, ‘H-1’ and ‘Am242M’ are both valid.
+/// Note that nucname will always return name form with dashes removed, the
+/// chemical symbol used for letter casing (ie 'Pu'), and a trailing upercase 'M'
+/// for a metastable flag. The name() function first converts functions to id form
+/// using the id() function. Thus the form order resolution for id() also applies
+/// here.
+/// \param nuc a nuclide
+/// \return a string nuclide identifier.
+std::string name(int nuc);
+std::string name(const char* nuc);
+std::string name(std::string nuc);
+/// \}
+
+/// \name Z-Number Functions
+/// \{
+/// The Z-number, or charge number, represents the number of protons in a
+/// nuclide.  This function returns that number.
+/// \param nuc a nuclide
+/// \return an integer Z-number.
+int znum(int nuc);
+int znum(const char* nuc);
+int znum(std::string nuc);
+/// \}
+
+/// \name A-Number Functions
+/// \{
+/// The A-number, or nucleon number, represents the number of protons and
+/// neutrons in a nuclide.  This function returns that number.
+/// \param nuc a nuclide
+/// \return an integer A-number.
+int anum(int nuc);
+int anum(const char* nuc);
+int anum(std::string nuc);
+/// \}
+
+/// \name S-Number Functions
+/// \{
+/// The S-number, or excitation state number, represents the excitation
+/// level of a nuclide.  Normally, this is zero.  This function returns
+/// that number.
+/// \param nuc a nuclide
+/// \return an integer A-number.
+int snum(int nuc);
+int snum(const char* nuc);
+int snum(std::string nuc);
+/// \}
+
+/// \name ZZAAAM Form Functions
+/// \{
+/// The ZZAAAM nuclide naming convention is the former canonical form for
+/// nuclides in PyNE. This places the charge of the nucleus out front, then has
+/// three digits for the atomic mass number, and ends with a metastable flag
+/// (0 = ground, 1 = first excited state, 2 = second excited state, etc).
+/// Uranium-235 here would be expressed as ‘922350’.
+/// \param nuc a nuclide
+/// \return an integer nuclide identifier.
+int zzaaam(int nuc);
+int zzaaam(const char* nuc);
+int zzaaam(std::string nuc);
+/// \}
+
+/// \name ZZAAAM Form to Identifier Form Functions
+/// \{
+/// This converts from the ZZAAAM nuclide naming convention
+/// to the id canonical form  for nuclides in PyNE.
+/// \param nuc a nuclide in ZZAAAM form.
+/// \return an integer id nuclide identifier.
+int zzaaam_to_id(int nuc);
+int zzaaam_to_id(const char* nuc);
+int zzaaam_to_id(std::string nuc);
+/// \}
 
 
-  /// \name ZZZAAA Form Functions
-  /// \{
-  /// The ZZZAAA nuclide naming convention is a form in which the nuclides three
-  ///digit ZZZ number is followed by the 3 digit AAA number.  If the ZZZ number
-  ///is 2 digits, the preceding zeros are not included.
-  /// Uranium-235 here would be expressed as ‘92235’.
-  /// \param nuc a nuclide
-  /// \return an integer nuclide identifier.
-  int zzzaaa(int nuc);
-  int zzzaaa(const char * nuc);
-  int zzzaaa(std::string nuc);
-  /// \}
+/// \name ZZZAAA Form Functions
+/// \{
+/// The ZZZAAA nuclide naming convention is a form in which the nuclides three
+///digit ZZZ number is followed by the 3 digit AAA number.  If the ZZZ number
+///is 2 digits, the preceding zeros are not included.
+/// Uranium-235 here would be expressed as ‘92235’.
+/// \param nuc a nuclide
+/// \return an integer nuclide identifier.
+int zzzaaa(int nuc);
+int zzzaaa(const char* nuc);
+int zzzaaa(std::string nuc);
+/// \}
 
 
-  /// \name ZZZAAA Form to Identifier Form Functions
-  /// \{
-  /// This converts from the ZZZAAA nuclide naming convention
-  /// to the id canonical form  for nuclides in PyNE.
-  /// \param nuc a nuclide in ZZZAAA form.
-  /// \return an integer id nuclide identifier.
-  int zzzaaa_to_id(int nuc);
-  int zzzaaa_to_id(const char * nuc);
-  int zzzaaa_to_id(std::string nuc);
-  /// \}
+/// \name ZZZAAA Form to Identifier Form Functions
+/// \{
+/// This converts from the ZZZAAA nuclide naming convention
+/// to the id canonical form  for nuclides in PyNE.
+/// \param nuc a nuclide in ZZZAAA form.
+/// \return an integer id nuclide identifier.
+int zzzaaa_to_id(int nuc);
+int zzzaaa_to_id(const char* nuc);
+int zzzaaa_to_id(std::string nuc);
+/// \}
 
 
-  /// \name ZZLLAAAM Form Functions
-  /// \{
-  /// The ZZLLAAAM nuclide naming convention is a form in which the nuclides
-  /// AA number is followed by the redundant two LL characters, followed by
-  /// the nuclides ZZZ number.  Can also be followed with a metastable flag.
-  /// Uranium-235 here would be expressed as ‘92-U-235’.
-  /// \param nuc a nuclide
-  /// \return an integer nuclide identifier.
-  std::string zzllaaam(int nuc);
-  std::string zzllaaam(const char * nuc);
-  std::string zzllaaam(std::string nuc);
-  /// \}
+/// \name ZZLLAAAM Form Functions
+/// \{
+/// The ZZLLAAAM nuclide naming convention is a form in which the nuclides
+/// AA number is followed by the redundant two LL characters, followed by
+/// the nuclides ZZZ number.  Can also be followed with a metastable flag.
+/// Uranium-235 here would be expressed as ‘92-U-235’.
+/// \param nuc a nuclide
+/// \return an integer nuclide identifier.
+std::string zzllaaam(int nuc);
+std::string zzllaaam(const char* nuc);
+std::string zzllaaam(std::string nuc);
+/// \}
 
 
-  /// \name ZZLLAAAM Form to Identifier Form Functions
-  /// \{
-  /// This converts from the ZZLLAAAM nuclide naming convention
-  /// to the id canonical form  for nuclides in PyNE.
-  /// \param nuc a nuclide in ZZLLAAAM form.
-  /// \return an integer id nuclide identifier.
-  //int zzllaaam_to_id(int nuc);
-  int zzllaaam_to_id(const char * nuc);
-  int zzllaaam_to_id(std::string nuc);
-  /// \}
+/// \name ZZLLAAAM Form to Identifier Form Functions
+/// \{
+/// This converts from the ZZLLAAAM nuclide naming convention
+/// to the id canonical form  for nuclides in PyNE.
+/// \param nuc a nuclide in ZZLLAAAM form.
+/// \return an integer id nuclide identifier.
+//int zzllaaam_to_id(int nuc);
+int zzllaaam_to_id(const char* nuc);
+int zzllaaam_to_id(std::string nuc);
+/// \}
 
 
-  /// \name MCNP Form Functions
-  /// \{
-  /// This is the naming convention used by the MCNP suite of codes.
-  /// The MCNP format for entering nuclides is unfortunately non-standard.
-  /// In most ways it is similar to zzaaam form, except that it lacks the metastable
-  /// flag. For information on how metastable isotopes are named, please consult the
-  /// MCNP documentation for more information.
-  /// \param nuc a nuclide
-  /// \return a string nuclide identifier.
-  int mcnp(int nuc);
-  int mcnp(const char * nuc);
-  int mcnp(std::string nuc);
-  /// \}
+/// \name MCNP Form Functions
+/// \{
+/// This is the naming convention used by the MCNP suite of codes.
+/// The MCNP format for entering nuclides is unfortunately non-standard.
+/// In most ways it is similar to zzaaam form, except that it lacks the metastable
+/// flag. For information on how metastable isotopes are named, please consult the
+/// MCNP documentation for more information.
+/// \param nuc a nuclide
+/// \return a string nuclide identifier.
+int mcnp(int nuc);
+int mcnp(const char* nuc);
+int mcnp(std::string nuc);
+/// \}
 
-  /// \name MCNP Form to Identifier Form Functions
-  /// \{
-  /// This converts from the MCNP nuclide naming convention
-  /// to the id canonical form  for nuclides in PyNE.
-  /// \param nuc a nuclide in MCNP form.
-  /// \return an integer id nuclide identifier.
-  int mcnp_to_id(int nuc);
-  int mcnp_to_id(const char * nuc);
-  int mcnp_to_id(std::string nuc);
-  /// \}
+/// \name MCNP Form to Identifier Form Functions
+/// \{
+/// This converts from the MCNP nuclide naming convention
+/// to the id canonical form  for nuclides in PyNE.
+/// \param nuc a nuclide in MCNP form.
+/// \return an integer id nuclide identifier.
+int mcnp_to_id(int nuc);
+int mcnp_to_id(const char* nuc);
+int mcnp_to_id(std::string nuc);
+/// \}
 
-  /// \name OPENMC Form Functions
-  /// \{
-  /// This is the naming convention used by the OpenMC code.
-  /// The OpenMC format for entering nuclides uses a GND format.
-  /// For information on how metastable isotopes are named, please consult the
-  /// OpenMC documentation for more information.
-  /// \param nuc a nuclide
-  /// \return a string nuclide identifier.
-  std::string openmc(int nuc);
-  std::string openmc(const char * nuc);
-  std::string openmc(std::string nuc);
-  /// \}
+/// \name OPENMC Form Functions
+/// \{
+/// This is the naming convention used by the OpenMC code.
+/// The OpenMC format for entering nuclides uses a GND format.
+/// For information on how metastable isotopes are named, please consult the
+/// OpenMC documentation for more information.
+/// \param nuc a nuclide
+/// \return a string nuclide identifier.
+std::string openmc(int nuc);
+std::string openmc(const char* nuc);
+std::string openmc(std::string nuc);
+/// \}
 
-  /// \name OPENMC Form to Identifier Form Functions
-  /// \{
-  /// This converts from the OPENMC nuclide naming convention
-  /// to the id canonical form  for nuclides in PyNE.
-  /// \param nuc a nuclide in OPENMC form.
-  /// \return an integer id nuclide identifier.
-  int openmc_to_id(const char * nuc);
-  int openmc_to_id(std::string nuc);
-  /// \}
+/// \name OPENMC Form to Identifier Form Functions
+/// \{
+/// This converts from the OPENMC nuclide naming convention
+/// to the id canonical form  for nuclides in PyNE.
+/// \param nuc a nuclide in OPENMC form.
+/// \return an integer id nuclide identifier.
+int openmc_to_id(const char* nuc);
+int openmc_to_id(std::string nuc);
+/// \}
 
-  /// \name FLUKA Form Functions
-  /// \{
-  /// This is the naming convention used by the FLUKA suite of codes.
-  /// The FLUKA format for entering nuclides requires some knowledge of FLUKA
-  /// The nuclide in must cases should be the atomic # times 10000000.
-  /// The exceptions are for FLUKA's named isotopes
-  /// See the FLUKA Manual for more information.
-  /// \param nuc a nuclide
-  /// \return the received FLUKA name
-  std::string fluka(int nuc);
-  /// \}
+/// \name FLUKA Form Functions
+/// \{
+/// This is the naming convention used by the FLUKA suite of codes.
+/// The FLUKA format for entering nuclides requires some knowledge of FLUKA
+/// The nuclide in must cases should be the atomic # times 10000000.
+/// The exceptions are for FLUKA's named isotopes
+/// See the FLUKA Manual for more information.
+/// \param nuc a nuclide
+/// \return the received FLUKA name
+std::string fluka(int nuc);
+/// \}
 
-  /// \name FLUKA Form to Identifier Form Functions
-  /// \{
-  /// This converts from the FLUKA name to the
-  /// id canonical form  for nuclides in PyNE.
-  /// \param name a fluka name
-  /// \return an integer id nuclide identifier.
-  int fluka_to_id(std::string name);
-  int fluka_to_id(char * name);
-  /// \}
+/// \name FLUKA Form to Identifier Form Functions
+/// \{
+/// This converts from the FLUKA name to the
+/// id canonical form  for nuclides in PyNE.
+/// \param name a fluka name
+/// \return an integer id nuclide identifier.
+int fluka_to_id(std::string name);
+int fluka_to_id(char* name);
+/// \}
 
-  /// \name Serpent Form Functions
-  /// \{
-  /// This is the string-based naming convention used by the Serpent suite of codes.
-  /// The serpent naming convention is similar to name form. However, only the first
-  /// letter in the chemical symbol is uppercase, the dash is always present, and the
-  /// the meta-stable flag is lowercase. For instance, ‘Am-242m’ is the valid serpent
-  /// notation for this nuclide.
-  /// \param nuc a nuclide
-  /// \return a string nuclide identifier.
-  std::string serpent(int nuc);
-  std::string serpent(const char * nuc);
-  std::string serpent(std::string nuc);
-  /// \}
+/// \name Serpent Form Functions
+/// \{
+/// This is the string-based naming convention used by the Serpent suite of codes.
+/// The serpent naming convention is similar to name form. However, only the first
+/// letter in the chemical symbol is uppercase, the dash is always present, and the
+/// the meta-stable flag is lowercase. For instance, ‘Am-242m’ is the valid serpent
+/// notation for this nuclide.
+/// \param nuc a nuclide
+/// \return a string nuclide identifier.
+std::string serpent(int nuc);
+std::string serpent(const char* nuc);
+std::string serpent(std::string nuc);
+/// \}
 
-  /// \name Serpent Form to Identifier Form Functions
-  /// \{
-  /// This converts from the Serpent nuclide naming convention
-  /// to the id canonical form  for nuclides in PyNE.
-  /// \param nuc a nuclide in Serpent form.
-  /// \return an integer id nuclide identifier.
-  //int serpent_to_id(int nuc);  Should be ZAID
-  int serpent_to_id(const char * nuc);
-  int serpent_to_id(std::string nuc);
-  /// \}
+/// \name Serpent Form to Identifier Form Functions
+/// \{
+/// This converts from the Serpent nuclide naming convention
+/// to the id canonical form  for nuclides in PyNE.
+/// \param nuc a nuclide in Serpent form.
+/// \return an integer id nuclide identifier.
+//int serpent_to_id(int nuc);  Should be ZAID
+int serpent_to_id(const char* nuc);
+int serpent_to_id(std::string nuc);
+/// \}
 
-  /// \name NIST Form Functions
-  /// \{
-  /// This is the string-based naming convention used by NIST.
-  /// The NIST naming convention is also similar to the Serpent form. However, this
-  /// convention contains no metastable information. Moreover, the A-number comes
-  /// before the element symbol. For example, ‘242Am’ is the valid NIST notation.
-  /// \param nuc a nuclide
-  /// \return a string nuclide identifier.
-  std::string nist(int nuc);
-  std::string nist(const char * nuc);
-  std::string nist(std::string nuc);
-  /// \}
+/// \name NIST Form Functions
+/// \{
+/// This is the string-based naming convention used by NIST.
+/// The NIST naming convention is also similar to the Serpent form. However, this
+/// convention contains no metastable information. Moreover, the A-number comes
+/// before the element symbol. For example, ‘242Am’ is the valid NIST notation.
+/// \param nuc a nuclide
+/// \return a string nuclide identifier.
+std::string nist(int nuc);
+std::string nist(const char* nuc);
+std::string nist(std::string nuc);
+/// \}
 
-  /// \name NIST Form to Identifier Form Functions
-  /// \{
-  /// This converts from the NIST nuclide naming convention
-  /// to the id canonical form  for nuclides in PyNE.
-  /// \param nuc a nuclide in NIST form.
-  /// \return an integer id nuclide identifier.
-  //int serpent_to_id(int nuc);  NON-EXISTANT
-  int nist_to_id(const char * nuc);
-  int nist_to_id(std::string nuc);
-  /// \}
+/// \name NIST Form to Identifier Form Functions
+/// \{
+/// This converts from the NIST nuclide naming convention
+/// to the id canonical form  for nuclides in PyNE.
+/// \param nuc a nuclide in NIST form.
+/// \return an integer id nuclide identifier.
+//int serpent_to_id(int nuc);  NON-EXISTANT
+int nist_to_id(const char* nuc);
+int nist_to_id(std::string nuc);
+/// \}
 
-  /// \name CINDER Form Functions
-  /// \{
-  /// This is the naming convention used by the CINDER burnup library.
-  /// The CINDER format is similar to zzaaam form except that the placement of the
-  /// Z- and A-numbers are swapped. Therefore, this format is effectively aaazzzm.
-  /// For example, ‘2420951’ is the valid cinder notation for ‘AM242M’.
-  /// \param nuc a nuclide
-  /// \return a string nuclide identifier.
-  int cinder(int nuc);
-  int cinder(const char * nuc);
-  int cinder(std::string nuc);
-  /// \}
+/// \name CINDER Form Functions
+/// \{
+/// This is the naming convention used by the CINDER burnup library.
+/// The CINDER format is similar to zzaaam form except that the placement of the
+/// Z- and A-numbers are swapped. Therefore, this format is effectively aaazzzm.
+/// For example, ‘2420951’ is the valid cinder notation for ‘AM242M’.
+/// \param nuc a nuclide
+/// \return a string nuclide identifier.
+int cinder(int nuc);
+int cinder(const char* nuc);
+int cinder(std::string nuc);
+/// \}
 
-  /// \name Cinder Form to Identifier Form Functions
-  /// \{
-  /// This converts from the Cinder nuclide naming convention
-  /// to the id canonical form  for nuclides in PyNE.
-  /// \param nuc a nuclide in Cinder form.
-  /// \return an integer id nuclide identifier.
-  int cinder_to_id(int nuc);
-  int cinder_to_id(const char * nuc);
-  int cinder_to_id(std::string nuc);
-  /// \}
+/// \name Cinder Form to Identifier Form Functions
+/// \{
+/// This converts from the Cinder nuclide naming convention
+/// to the id canonical form  for nuclides in PyNE.
+/// \param nuc a nuclide in Cinder form.
+/// \return an integer id nuclide identifier.
+int cinder_to_id(int nuc);
+int cinder_to_id(const char* nuc);
+int cinder_to_id(std::string nuc);
+/// \}
 
-  /// \name ALARA Form Functions
-  /// \{
-  /// This is the format used in the ALARA activation code elements library.
-  /// For elements, the form is "ll" where ll is the atomic symbol. For isotopes
-  /// the form is "ll:AAA". No metastable isotope flag is used.
-  /// \param nuc a nuclide
-  /// \return a string nuclide identifier.
-  std::string alara(int nuc);
-  std::string alara(const char * nuc);
-  std::string alara(std::string nuc);
-  /// \}
+/// \name ALARA Form Functions
+/// \{
+/// This is the format used in the ALARA activation code elements library.
+/// For elements, the form is "ll" where ll is the atomic symbol. For isotopes
+/// the form is "ll:AAA". No metastable isotope flag is used.
+/// \param nuc a nuclide
+/// \return a string nuclide identifier.
+std::string alara(int nuc);
+std::string alara(const char* nuc);
+std::string alara(std::string nuc);
+/// \}
 
-  /// \name ALARA Form to Identifier Form Functions
-  /// \{
-  /// This converts from the ALARA nuclide naming convention
-  /// to the id canonical form  for nuclides in PyNE.
-  /// \param nuc a nuclide in ALARA form.
-  /// \return an integer id nuclide identifier.
-  //int alara_to_id(int nuc); NOT POSSIBLE
-  int alara_to_id(const char * nuc);
-  int alara_to_id(std::string nuc);
-  /// \}
+/// \name ALARA Form to Identifier Form Functions
+/// \{
+/// This converts from the ALARA nuclide naming convention
+/// to the id canonical form  for nuclides in PyNE.
+/// \param nuc a nuclide in ALARA form.
+/// \return an integer id nuclide identifier.
+//int alara_to_id(int nuc); NOT POSSIBLE
+int alara_to_id(const char* nuc);
+int alara_to_id(std::string nuc);
+/// \}
 
-  /// \name SZA Form Functions
-  /// \{
-  /// This is the new format for ACE data tables in the form SSSZZZAAA.
-  /// The first three digits represent the excited state (000 = ground,
-  /// 001 = first excited state, 002 = second excited state, etc).
-  /// The second three digits are the atomic number and the last three
-  /// digits are the atomic mass. Prepending zeros can be omitted, making
-  /// the SZA form equal to the MCNP form for non-excited nuclides.
-  /// \param nuc a nuclide
-  /// \return a string nuclide identifier.
-  int sza(int nuc);
-  int sza(const char * nuc);
-  int sza(std::string nuc);
-  /// \}
+/// \name SZA Form Functions
+/// \{
+/// This is the new format for ACE data tables in the form SSSZZZAAA.
+/// The first three digits represent the excited state (000 = ground,
+/// 001 = first excited state, 002 = second excited state, etc).
+/// The second three digits are the atomic number and the last three
+/// digits are the atomic mass. Prepending zeros can be omitted, making
+/// the SZA form equal to the MCNP form for non-excited nuclides.
+/// \param nuc a nuclide
+/// \return a string nuclide identifier.
+int sza(int nuc);
+int sza(const char* nuc);
+int sza(std::string nuc);
+/// \}
 
-  /// \name SZA Form to Identifier Form Functions
-  /// \{
-  /// This converts from the SZA nuclide naming convention
-  /// to the id canonical form  for nuclides in PyNE.
-  /// \param nuc a nuclide in SZA form.
-  /// \return an integer id nuclide identifier.
-  int sza_to_id(int nuc);
-  int sza_to_id(const char * nuc);
-  int sza_to_id(std::string nuc);
-  /// \}
+/// \name SZA Form to Identifier Form Functions
+/// \{
+/// This converts from the SZA nuclide naming convention
+/// to the id canonical form  for nuclides in PyNE.
+/// \param nuc a nuclide in SZA form.
+/// \return an integer id nuclide identifier.
+int sza_to_id(int nuc);
+int sza_to_id(const char* nuc);
+int sza_to_id(std::string nuc);
+/// \}
 
-  /// \name Ground State Form Functions
-  /// \{
-  /// This form stores the nuclide in id form, but removes
-  /// the state information about the nuclide.  I is in the same
-  /// form as ID, but the four last digits are all zeros.
-  /// \param nuc a nuclide
-  /// \return a integer groundstate id
-  inline int groundstate(int nuc) {return (id(nuc) / 10000 ) * 10000;}
-  inline int groundstate(std::string nuc) {return groundstate(id(nuc));}
-  inline int groundstate(const char * nuc) {return groundstate(std::string(nuc));}
-  /// \}
+/// \name Ground State Form Functions
+/// \{
+/// This form stores the nuclide in id form, but removes
+/// the state information about the nuclide.  I is in the same
+/// form as ID, but the four last digits are all zeros.
+/// \param nuc a nuclide
+/// \return a integer groundstate id
+inline int groundstate(int nuc) {return (id(nuc) / 10000) * 10000;}
+inline int groundstate(std::string nuc) {return groundstate(id(nuc));}
+inline int groundstate(const char* nuc) {return groundstate(std::string(nuc));}
+/// \}
 
-  /// \name State Map functions
-  /// \{
-  /// These convert from/to decay state ids (used in decay data)
-  /// to metastable ids (the PyNE default). If the cooresponding value cannot
-  /// be found, -1 is returned.
-  void _load_state_map();
-  int state_id_to_id(int state);
-  int id_to_state_id(int nuc_id);
-  extern std::map<int, int> state_id_map;
-  /// \}
+/// \name State Map functions
+/// \{
+/// These convert from/to decay state ids (used in decay data)
+/// to metastable ids (the PyNE default). If the cooresponding value cannot
+/// be found, -1 is returned.
+void _load_state_map();
+int state_id_to_id(int state);
+int id_to_state_id(int nuc_id);
+extern std::map<int, int> state_id_map;
+/// \}
 
-  /// \name ENSDF Form Functions
-  /// \{
-  /// This converts id's stored using standard ensdf syntax to nuc_id's
-  /// \param ensdf nuc string
-  /// \return PyNE nuc_id
-  int ensdf_to_id(const char * nuc);
-  int ensdf_to_id(std::string nuc);
-  /// \}
+/// \name ENSDF Form Functions
+/// \{
+/// This converts id's stored using standard ensdf syntax to nuc_id's
+/// \param ensdf nuc string
+/// \return PyNE nuc_id
+int ensdf_to_id(const char* nuc);
+int ensdf_to_id(std::string nuc);
+/// \}
 
 }
 }
@@ -4878,10 +4856,10 @@ class JSON_API CustomWriter : public Writer {
 #include <set>
 #include <stdio.h>
 #include <stdlib.h>
-#include <sstream>	// std::ostringstream
+#include <sstream>  // std::ostringstream
 
 #if !defined(JSON_IS_AMALGAMATION)
-  #define JSON_IS_AMALGAMATION
+#define JSON_IS_AMALGAMATION
 #endif
 
 #ifndef PYNE_IS_AMALGAMATED
@@ -4894,361 +4872,357 @@ class JSON_API CustomWriter : public Writer {
 #include "decay.h"
 #endif
 
-namespace pyne
-{
-  // Set Type Definitions
-  typedef std::map<int, double> comp_map; ///< Nuclide-mass composition map type
-  typedef comp_map::iterator comp_iter;   ///< Nuclide-mass composition iter type
+namespace pyne {
+// Set Type Definitions
+typedef std::map<int, double> comp_map; ///< Nuclide-mass composition map type
+typedef comp_map::iterator comp_iter;   ///< Nuclide-mass composition iter type
 
-  #ifdef PYNE_IS_AMALGAMATED
-  namespace decayers {
-    extern comp_map decay(comp_map, double);
-  }  // namespace decayers
-  #endif
+#ifdef PYNE_IS_AMALGAMATED
+namespace decayers {
+extern comp_map decay(comp_map, double);
+}  // namespace decayers
+#endif
 
 
-  // These 37 strings are predefined FLUKA materials.
-  // Materials not on this list requires a MATERIAL card.
-  static std::string fluka_mat_strings[] = {
-   "BLCKHOLE", "VACUUM",   "HYDROGEN", "HELIUM",   "BERYLLIU", "CARBON",
-   "NITROGEN", "OXYGEN",   "MAGNESIU", "ALUMINUM", "IRON",     "COPPER",
-   "SILVER",   "SILICON",  "GOLD",     "MERCURY",  "LEAD",     "TANTALUM",
-   "SODIUM",   "ARGON",    "CALCIUM",  "TIN",      "TUNGSTEN", "TITANIUM",
-   "NICKEL",   "WATER",    "POLYSTYR", "PLASCINT", "PMMA",     "BONECOMP",
-   "BONECORT", "MUSCLESK", "MUSCLEST", "ADTISSUE", "KAPTON", "POLYETHY", "AIR"
-  };
+// These 37 strings are predefined FLUKA materials.
+// Materials not on this list requires a MATERIAL card.
+static std::string fluka_mat_strings[] = {
+  "BLCKHOLE", "VACUUM",   "HYDROGEN", "HELIUM",   "BERYLLIU", "CARBON",
+  "NITROGEN", "OXYGEN",   "MAGNESIU", "ALUMINUM", "IRON",     "COPPER",
+  "SILVER",   "SILICON",  "GOLD",     "MERCURY",  "LEAD",     "TANTALUM",
+  "SODIUM",   "ARGON",    "CALCIUM",  "TIN",      "TUNGSTEN", "TITANIUM",
+  "NICKEL",   "WATER",    "POLYSTYR", "PLASCINT", "PMMA",     "BONECOMP",
+  "BONECORT", "MUSCLESK", "MUSCLEST", "ADTISSUE", "KAPTON", "POLYETHY", "AIR"
+};
 
-  static int FLUKA_MAT_NUM = 37;
+static int FLUKA_MAT_NUM = 37;
 
-  /// Material composed of nuclides.
-  class Material
-  {
-  protected:
+/// Material composed of nuclides.
+class Material {
+ protected:
 
-    /// Computes the total mass stored in the composition.
-    double get_comp_sum ();
+  /// Computes the total mass stored in the composition.
+  double get_comp_sum();
 
-  public:
+ public:
 
-    // Material Constructors
-    Material ();  ///< empty constructor
-    /// Constructor from composition map
-    /// \param cm composition map
-    /// \param m mass value, the mass is set to the sum of the values in the
-    ///          composition if \a m is negative.
-    /// \param d density value
-    /// \param apm atoms per mole
-    /// \param attributes initial metadata
-    Material(comp_map cm, double m=-1.0, double d=-1.0, double apm=-1.0,
-             Json::Value attributes=Json::Value(Json::objectValue));
-    /// Constructor from file
-    /// \param filename path to file on disk, this file may be either in plaintext
-    ///                 or HDF5 format.
-    /// \param m mass value, the mass is set to the sum of the values in the
-    ///          composition if \a m is negative,
-    ///          may be overridden by the value from disk.
-    /// \param d density value,
-    ///          may be overridden by the value from disk.
-    /// \param apm atoms per mole,
-    ///          may be overridden by the value from disk.
-    /// \param attributes initial metadata,
-    ///          may be overridden by the value from disk.
-    Material(char * filename, double m=-1.0, double d=-1.0, double apm=-1.0,
-             Json::Value attributes=Json::Value(Json::objectValue));
-    /// Constructor from file
-    /// \param filename path to file on disk, this file may be either in plaintext
-    ///                 or HDF5 format.
-    /// \param m mass value, the mass is set to the sum of the values in the
-    ///          composition if \a m is negative,
-    ///          may be overridden by the value from disk.
-    /// \param d density value,
-    ///          may be overridden by the value from disk.
-    /// \param apm atoms per mole,
-    ///          may be overridden by the value from disk.
-    /// \param attributes initial metadata,
-    ///          may be overridden by the value from disk.
-    Material(std::string filename, double m=-1.0, double d=-1.0, double apm=-1.0,
-             Json::Value attributes=Json::Value(Json::objectValue));
-    ~Material (); ///< default destructor
+  // Material Constructors
+  Material();   ///< empty constructor
+  /// Constructor from composition map
+  /// \param cm composition map
+  /// \param m mass value, the mass is set to the sum of the values in the
+  ///          composition if \a m is negative.
+  /// \param d density value
+  /// \param apm atoms per mole
+  /// \param attributes initial metadata
+  Material(comp_map cm, double m = -1.0, double d = -1.0, double apm = -1.0,
+           Json::Value attributes = Json::Value(Json::objectValue));
+  /// Constructor from file
+  /// \param filename path to file on disk, this file may be either in plaintext
+  ///                 or HDF5 format.
+  /// \param m mass value, the mass is set to the sum of the values in the
+  ///          composition if \a m is negative,
+  ///          may be overridden by the value from disk.
+  /// \param d density value,
+  ///          may be overridden by the value from disk.
+  /// \param apm atoms per mole,
+  ///          may be overridden by the value from disk.
+  /// \param attributes initial metadata,
+  ///          may be overridden by the value from disk.
+  Material(char* filename, double m = -1.0, double d = -1.0, double apm = -1.0,
+           Json::Value attributes = Json::Value(Json::objectValue));
+  /// Constructor from file
+  /// \param filename path to file on disk, this file may be either in plaintext
+  ///                 or HDF5 format.
+  /// \param m mass value, the mass is set to the sum of the values in the
+  ///          composition if \a m is negative,
+  ///          may be overridden by the value from disk.
+  /// \param d density value,
+  ///          may be overridden by the value from disk.
+  /// \param apm atoms per mole,
+  ///          may be overridden by the value from disk.
+  /// \param attributes initial metadata,
+  ///          may be overridden by the value from disk.
+  Material(std::string filename, double m = -1.0, double d = -1.0, double apm = -1.0,
+           Json::Value attributes = Json::Value(Json::objectValue));
+  ~Material();  ///< default destructor
 
-    /// Normalizes the mass values in the composition.
-    void norm_comp ();
+  /// Normalizes the mass values in the composition.
+  void norm_comp();
 
-    // Persistence functions.
+  // Persistence functions.
 
-    /// Loads the matrial composition from an HDF5 file according to the layout
-    /// defined by protocol 0.  This protocol is depratacted.
-    /// \param db HDF5 id for the open HDF5 file.
-    /// \param datapath Path to the base node for the material in \a db.
-    /// \param row The index to read out, may be negative.
-    void _load_comp_protocol0(hid_t db, std::string datapath, int row);
+  /// Loads the matrial composition from an HDF5 file according to the layout
+  /// defined by protocol 0.  This protocol is depratacted.
+  /// \param db HDF5 id for the open HDF5 file.
+  /// \param datapath Path to the base node for the material in \a db.
+  /// \param row The index to read out, may be negative.
+  void _load_comp_protocol0(hid_t db, std::string datapath, int row);
 
-    /// Loads the matrial composition from an HDF5 file according to the layout
-    /// defined by protocol 1.  This protocol should be used in favor of protocol 0.
-    /// \param db HDF5 id for the open HDF5 file.
-    /// \param datapath Path to the base node for the material in \a db.
-    /// \param row The index to read out, may be negative.
-    void _load_comp_protocol1(hid_t db, std::string datapath, int row);
+  /// Loads the matrial composition from an HDF5 file according to the layout
+  /// defined by protocol 1.  This protocol should be used in favor of protocol 0.
+  /// \param db HDF5 id for the open HDF5 file.
+  /// \param datapath Path to the base node for the material in \a db.
+  /// \param row The index to read out, may be negative.
+  void _load_comp_protocol1(hid_t db, std::string datapath, int row);
 
-    /// Loads a material from an HDF5 file into this object.
-    /// \param filename Path on disk to the HDF5 file.
-    /// \param datapath Path to the the material in the file.
-    /// \param row The index to read out, may be negative.
-    /// \param protocol Flag for layout of material on disk.
-    void from_hdf5(char * filename, char * datapath, int row=-1, int protocol=1);
+  /// Loads a material from an HDF5 file into this object.
+  /// \param filename Path on disk to the HDF5 file.
+  /// \param datapath Path to the the material in the file.
+  /// \param row The index to read out, may be negative.
+  /// \param protocol Flag for layout of material on disk.
+  void from_hdf5(char* filename, char* datapath, int row = -1, int protocol = 1);
 
-    /// Loads a material from an HDF5 file into this object.
-    /// \param filename Path on disk to the HDF5 file.
-    /// \param datapath Path to the the material in the file.
-    /// \param row The index to read out, may be negative.
-    /// \param protocol Flag for layout of material on disk.
-    void from_hdf5(std::string filename, std::string datapath="/material",
-                                                          int row=-1, int protocol=1);
+  /// Loads a material from an HDF5 file into this object.
+  /// \param filename Path on disk to the HDF5 file.
+  /// \param datapath Path to the the material in the file.
+  /// \param row The index to read out, may be negative.
+  /// \param protocol Flag for layout of material on disk.
+  void from_hdf5(std::string filename, std::string datapath = "/material",
+                 int row = -1, int protocol = 1);
 
-    /// Writes this material out to an HDF5 file.
-    /// This happens according to protocol 1.
-    /// \param filename Path on disk to the HDF5 file.
-    /// \param datapath Path to the the material in the file.
-    /// \param nucpath Path to the nuclides set in the file.
-    /// \param row The index to read out, may be negative. Also note that this is a
-    ///            float.  A value of -0.0 indicates that the material should be
-    ///            appended to the end of the dataset.
-    /// \param chunksize The chunksize for all material data on disk.
-    void write_hdf5(char * filename, char * datapath, char * nucpath, float row=-0.0,
-                                                                    int chunksize=100);
-    /// Writes this material out to an HDF5 file.
-    /// This happens according to protocol 1.
-    /// \param filename Path on disk to the HDF5 file.
-    /// \param datapath Path to the the material in the file.
-    /// \param nucpath Path to the nuclides set in the file.
-    /// \param row The index to read out, may be negative. Also note that this is a
-    ///            float.  A value of -0.0 indicates that the material should be
-    ///            appended to the end of the dataset.
-    /// \param chunksize The chunksize for all material data on disk.
-    void write_hdf5(std::string filename, std::string datapath="/material",
-                    std::string nucpath="/nucid", float row=-0.0, int chunksize=100);
+  /// Writes this material out to an HDF5 file.
+  /// This happens according to protocol 1.
+  /// \param filename Path on disk to the HDF5 file.
+  /// \param datapath Path to the the material in the file.
+  /// \param nucpath Path to the nuclides set in the file.
+  /// \param row The index to read out, may be negative. Also note that this is a
+  ///            float.  A value of -0.0 indicates that the material should be
+  ///            appended to the end of the dataset.
+  /// \param chunksize The chunksize for all material data on disk.
+  void write_hdf5(char* filename, char* datapath, char* nucpath, float row = -0.0,
+                  int chunksize = 100);
+  /// Writes this material out to an HDF5 file.
+  /// This happens according to protocol 1.
+  /// \param filename Path on disk to the HDF5 file.
+  /// \param datapath Path to the the material in the file.
+  /// \param nucpath Path to the nuclides set in the file.
+  /// \param row The index to read out, may be negative. Also note that this is a
+  ///            float.  A value of -0.0 indicates that the material should be
+  ///            appended to the end of the dataset.
+  /// \param chunksize The chunksize for all material data on disk.
+  void write_hdf5(std::string filename, std::string datapath = "/material",
+                  std::string nucpath = "/nucid", float row = -0.0, int chunksize = 100);
 
-    /// Return an openmc xml material element as a string
-    std::string openmc(std::string fact_type = "mass");
+  /// Return an openmc xml material element as a string
+  std::string openmc(std::string fact_type = "mass");
 
-    /// Return an mcnp input deck record as a string
-    std::string mcnp(std::string frac_type = "mass");
-    ///
-    /// Return a fluka input deck MATERIAL card as a string
-    std::string fluka(int id, std::string frac_type = "mass");
-    /// Convenience function to tell whether a given name needs a material card
-    bool not_fluka_builtin(std::string fluka_name);
-    /// High level call to get details and call material_component(..)
-    std::string fluka_material_str(int id);
-    /// Intermediate level call to prepare final info and call material_line(..)
-    std::string fluka_material_component(int fid, int nucid,
-                                         std::string fluka_name);
-    /// Format information into a FLUKA material card
-    std::string fluka_material_line(int znum, double atomic_mass,
-                              int fid, std::string fluka_name);
-    /// Convenience function to format a single fluka field
-    std::string fluka_format_field(float field);
-    /// Return FLUKA compound card and the material card for the named compound
-    /// but not the material cards of the components
-    std::string fluka_compound_str(int id, std::string frac_type = "mass");
+  /// Return an mcnp input deck record as a string
+  std::string mcnp(std::string frac_type = "mass");
+  ///
+  /// Return a fluka input deck MATERIAL card as a string
+  std::string fluka(int id, std::string frac_type = "mass");
+  /// Convenience function to tell whether a given name needs a material card
+  bool not_fluka_builtin(std::string fluka_name);
+  /// High level call to get details and call material_component(..)
+  std::string fluka_material_str(int id);
+  /// Intermediate level call to prepare final info and call material_line(..)
+  std::string fluka_material_component(int fid, int nucid,
+                                       std::string fluka_name);
+  /// Format information into a FLUKA material card
+  std::string fluka_material_line(int znum, double atomic_mass,
+                                  int fid, std::string fluka_name);
+  /// Convenience function to format a single fluka field
+  std::string fluka_format_field(float field);
+  /// Return FLUKA compound card and the material card for the named compound
+  /// but not the material cards of the components
+  std::string fluka_compound_str(int id, std::string frac_type = "mass");
 
-    /// Reads data from a plaintext file at \a filename into this Material instance.
-    void from_text(char * filename);
-    /// Reads data from a plaintext file at \a filename into this Material instance.
-    void from_text(std::string filename);
+  /// Reads data from a plaintext file at \a filename into this Material instance.
+  void from_text(char* filename);
+  /// Reads data from a plaintext file at \a filename into this Material instance.
+  void from_text(std::string filename);
 
-    /// Writes the Material out to a simple plaintext file readable by from_text().
-    void write_text(char * filename);
-    /// Writes the Material out to a simple plaintext file readable by from_text().
-    void write_text(std::string filename);
+  /// Writes the Material out to a simple plaintext file readable by from_text().
+  void write_text(char* filename);
+  /// Writes the Material out to a simple plaintext file readable by from_text().
+  void write_text(std::string filename);
 
-    /// Loads a JSON instance tree into this Material.
-    void load_json(Json::Value);
-    /// Dumps the Material out to a JSON instance tree.
-    Json::Value dump_json();
-    /// Reads data from a JSON file at \a filename into this Material instance.
-    void from_json(char * filename);
-    /// Reads data from a JSON file at \a filename into this Material instance.
-    void from_json(std::string filname);
-    /// Writes the Material out to a JSON file
-    void write_json(char * filename);
-    /// Writes the Material out to a JSON file
-    void write_json(std::string filename);
+  /// Loads a JSON instance tree into this Material.
+  void load_json(Json::Value);
+  /// Dumps the Material out to a JSON instance tree.
+  Json::Value dump_json();
+  /// Reads data from a JSON file at \a filename into this Material instance.
+  void from_json(char* filename);
+  /// Reads data from a JSON file at \a filename into this Material instance.
+  void from_json(std::string filname);
+  /// Writes the Material out to a JSON file
+  void write_json(char* filename);
+  /// Writes the Material out to a JSON file
+  void write_json(std::string filename);
 
-    // Fundemental mass stream data
-    /// composition, maps nuclides in id form to normalized mass weights.
-    comp_map comp;
-    double mass;  ///< mass (in arbitrary units) of the Material.
-    double density; ///< density (in arbitrary units) of the Material.
-    double atoms_per_molecule; ///< The number of atoms per molecule.
-    /// container for arbitrary metadata, following the JSON rules.
-    Json::Value metadata;
+  // Fundemental mass stream data
+  /// composition, maps nuclides in id form to normalized mass weights.
+  comp_map comp;
+  double mass;  ///< mass (in arbitrary units) of the Material.
+  double density; ///< density (in arbitrary units) of the Material.
+  double atoms_per_molecule; ///< The number of atoms per molecule.
+  /// container for arbitrary metadata, following the JSON rules.
+  Json::Value metadata;
 
-    // Material function definitions
-    void normalize ();  ///< Normalizes the mass.
-    /// Returns a composition map that has been unnormalized by multiplying each
-    /// mass weight by the actual mass of the material.
-    comp_map mult_by_mass();
-    /// Calculates the atomic weight of this material based on the composition
-    /// and the number of atoms per mol.  If \a apm is non-negative then it is
-    /// used (and stored on the instance) as the atoms_per_molecule for this calculation.
-    /// If \a apm and atoms_per_molecule on this instance are both negative, then the best
-    /// guess value calculated from the normailized composition is used here.
-    double molecular_mass(double apm=-1.0);
-    /// Calculates the activity of a material based on the composition and each
-    /// nuclide's mass, decay_const, and atmoic_mass.
-    comp_map activity();
-    /// Calculates the decay heat of a material based on the composition and
-    /// each nuclide's mass, q_val, decay_const, and atomic_mass. This assumes
-    /// input mass of grams. Return values is in megawatts.
-    comp_map decay_heat();
-    /// Caclulates the dose per gram using the composition of the the
-    /// material, the dose type desired, and the source for dose factors
-    ///   dose_type is one of:
-    ///     ext_air -- returns mrem/h per g per m^3
-    ///     ext_soil -- returns mrem/h per g per m^2
-    ///     ingest -- returns mrem per g
-    ///     inhale -- returns mrem per g
-    ///   source is:
-    ///     {EPA=0, DOE=1, GENII=2}, default is EPA
-    comp_map dose_per_g(std::string dose_type, int source=0);
-    /// Returns a copy of the current material where all natural elements in the
-    /// composition are expanded to their natural isotopic abundances.
-    Material expand_elements(std::set<int> exception_ids);
-    // Wrapped version to facilitate calling from python
-    Material expand_elements(int **int_ptr_arry = NULL);
-    // Returns a copy of the current material where all the isotopes of the elements
-    // are added up, atomic-fraction-wise, unless they are in the exception set
-    Material collapse_elements(std::set<int> exception_znum);
-    // Wrapped version to facilitate calling from python
-    Material collapse_elements(int **int_ptr_arry);
-    // void print_material( pyne::Material test_mat);
-    /// Computes, sets, and returns the mass density when \a num_dens is greater
-    /// than or equal zero.  If \a num_dens is negative, this simply returns the
-    /// current value of the density member variable.  You may also use / set the
-    /// atoms per molecule (atoms_per_molecule) in this function using \a apm.
-    double mass_density(double num_dens=-1.0, double apm=-1.0);
-    /// Computes and returns the number density of the material using the
-    /// mass density if \a mass_dens is greater than or equal to zero.  If
-    /// \a mass_dens is negative, the denisty member variable is used instead.
-    /// You may also use / set the atoms per molecule (atoms_per_molecule) in this
-    /// function using \a apm.
-    double number_density(double mass_dens=-1.0, double apm=-1.0);
+  // Material function definitions
+  void normalize();   ///< Normalizes the mass.
+  /// Returns a composition map that has been unnormalized by multiplying each
+  /// mass weight by the actual mass of the material.
+  comp_map mult_by_mass();
+  /// Calculates the atomic weight of this material based on the composition
+  /// and the number of atoms per mol.  If \a apm is non-negative then it is
+  /// used (and stored on the instance) as the atoms_per_molecule for this calculation.
+  /// If \a apm and atoms_per_molecule on this instance are both negative, then the best
+  /// guess value calculated from the normailized composition is used here.
+  double molecular_mass(double apm = -1.0);
+  /// Calculates the activity of a material based on the composition and each
+  /// nuclide's mass, decay_const, and atmoic_mass.
+  comp_map activity();
+  /// Calculates the decay heat of a material based on the composition and
+  /// each nuclide's mass, q_val, decay_const, and atomic_mass. This assumes
+  /// input mass of grams. Return values is in megawatts.
+  comp_map decay_heat();
+  /// Caclulates the dose per gram using the composition of the the
+  /// material, the dose type desired, and the source for dose factors
+  ///   dose_type is one of:
+  ///     ext_air -- returns mrem/h per g per m^3
+  ///     ext_soil -- returns mrem/h per g per m^2
+  ///     ingest -- returns mrem per g
+  ///     inhale -- returns mrem per g
+  ///   source is:
+  ///     {EPA=0, DOE=1, GENII=2}, default is EPA
+  comp_map dose_per_g(std::string dose_type, int source = 0);
+  /// Returns a copy of the current material where all natural elements in the
+  /// composition are expanded to their natural isotopic abundances.
+  Material expand_elements(std::set<int> exception_ids);
+  // Wrapped version to facilitate calling from python
+  Material expand_elements(int** int_ptr_arry = NULL);
+  // Returns a copy of the current material where all the isotopes of the elements
+  // are added up, atomic-fraction-wise, unless they are in the exception set
+  Material collapse_elements(std::set<int> exception_znum);
+  // Wrapped version to facilitate calling from python
+  Material collapse_elements(int** int_ptr_arry);
+  // void print_material( pyne::Material test_mat);
+  /// Computes, sets, and returns the mass density when \a num_dens is greater
+  /// than or equal zero.  If \a num_dens is negative, this simply returns the
+  /// current value of the density member variable.  You may also use / set the
+  /// atoms per molecule (atoms_per_molecule) in this function using \a apm.
+  double mass_density(double num_dens = -1.0, double apm = -1.0);
+  /// Computes and returns the number density of the material using the
+  /// mass density if \a mass_dens is greater than or equal to zero.  If
+  /// \a mass_dens is negative, the denisty member variable is used instead.
+  /// You may also use / set the atoms per molecule (atoms_per_molecule) in this
+  /// function using \a apm.
+  double number_density(double mass_dens = -1.0, double apm = -1.0);
 
-    // Sub-Stream Computation
-    /// Creates a sub-Material with only the nuclides present in \a nucset.
-    /// Elements of this set may be either in id form or simple Z numbers.
-    Material sub_mat(std::set<int> nucset);
-    /// Creates a sub-Material with only the nuclides present in \a nucset.
-    /// Elements of this set may be in any form.
-    Material sub_mat(std::set<std::string> nucset);
+  // Sub-Stream Computation
+  /// Creates a sub-Material with only the nuclides present in \a nucset.
+  /// Elements of this set may be either in id form or simple Z numbers.
+  Material sub_mat(std::set<int> nucset);
+  /// Creates a sub-Material with only the nuclides present in \a nucset.
+  /// Elements of this set may be in any form.
+  Material sub_mat(std::set<std::string> nucset);
 
-    /// Creates a new Material with the mass weights for all nuclides in \a nucset
-    /// set to \a value.
-    /// Elements of \a nucset may be either in id form or simple Z numbers.
-    Material set_mat(std::set<int> nucset, double value);
-    /// Creates a new Material with the mass weights for all nuclides in \a nucset
-    /// set to \a value.  Elements of \a nucset may be in any form.
-    Material set_mat(std::set<std::string> nucset, double value);
+  /// Creates a new Material with the mass weights for all nuclides in \a nucset
+  /// set to \a value.
+  /// Elements of \a nucset may be either in id form or simple Z numbers.
+  Material set_mat(std::set<int> nucset, double value);
+  /// Creates a new Material with the mass weights for all nuclides in \a nucset
+  /// set to \a value.  Elements of \a nucset may be in any form.
+  Material set_mat(std::set<std::string> nucset, double value);
 
-    /// Creates a new Material with the all nuclides in \a nucset removed.
-    /// Elements of \a nucset may be either in id form or simple Z numbers.
-    Material del_mat(std::set<int> nucset);
-    /// Creates a new Material with the all nuclides in \a nucset removed.
-    /// Elements of \a nucset may be in any form.
-    Material del_mat(std::set<std::string> nucset);
+  /// Creates a new Material with the all nuclides in \a nucset removed.
+  /// Elements of \a nucset may be either in id form or simple Z numbers.
+  Material del_mat(std::set<int> nucset);
+  /// Creates a new Material with the all nuclides in \a nucset removed.
+  /// Elements of \a nucset may be in any form.
+  Material del_mat(std::set<std::string> nucset);
 
-    /// Creates a sub-Material based on a range of id-form integers.
-    Material sub_range(int lower=0, int upper=10000000);
-    /// Creates a new Material with the mass weights for all nuclides in the id
-    /// range set to \a value.
-    Material set_range(int lower=0, int upper=10000000, double value=0.0);
-    /// Creates a new Material with the all nuclides in the id range removed.
-    Material del_range(int lower=0, int upper=10000000);
+  /// Creates a sub-Material based on a range of id-form integers.
+  Material sub_range(int lower = 0, int upper = 10000000);
+  /// Creates a new Material with the mass weights for all nuclides in the id
+  /// range set to \a value.
+  Material set_range(int lower = 0, int upper = 10000000, double value = 0.0);
+  /// Creates a new Material with the all nuclides in the id range removed.
+  Material del_range(int lower = 0, int upper = 10000000);
 
-    /// Creates a sub-Material of only the given element. Assumes element is
-    /// id form.
-    Material sub_elem(int element);
-    /// Creates a sub-Material of only lanthanides.
-    Material sub_lan();
-    /// Creates a sub-Material of only actinides.
-    Material sub_act();
-    /// Creates a sub-Material of only transuranics.
-    Material sub_tru();
-    /// Creates a sub-Material of only minor actinides.
-    Material sub_ma();
-    /// Creates a sub-Material of only fission products.
-    Material sub_fp();
+  /// Creates a sub-Material of only the given element. Assumes element is
+  /// id form.
+  Material sub_elem(int element);
+  /// Creates a sub-Material of only lanthanides.
+  Material sub_lan();
+  /// Creates a sub-Material of only actinides.
+  Material sub_act();
+  /// Creates a sub-Material of only transuranics.
+  Material sub_tru();
+  /// Creates a sub-Material of only minor actinides.
+  Material sub_ma();
+  /// Creates a sub-Material of only fission products.
+  Material sub_fp();
 
-    // Atom fraction functions
-    /// Returns a mapping of the nuclides in this material to their atom fractions.
-    /// This calculation is based off of the material's molecular weight.
-    std::map<int, double> to_atom_frac();
-    /// Sets the composition, mass, and atoms_per_molecule of this material to those
-    /// calculated from \a atom_fracs, a mapping of nuclides to atom fractions values.
-    void from_atom_frac(std::map<int, double> atom_fracs);
+  // Atom fraction functions
+  /// Returns a mapping of the nuclides in this material to their atom fractions.
+  /// This calculation is based off of the material's molecular weight.
+  std::map<int, double> to_atom_frac();
+  /// Sets the composition, mass, and atoms_per_molecule of this material to those
+  /// calculated from \a atom_fracs, a mapping of nuclides to atom fractions values.
+  void from_atom_frac(std::map<int, double> atom_fracs);
 
-    /// Returns a mapping of the nuclides in this material to their atom densities.
-    /// This calculation is based off of the material's density.
-    std::map<int, double> to_atom_dens();
+  /// Returns a mapping of the nuclides in this material to their atom densities.
+  /// This calculation is based off of the material's density.
+  std::map<int, double> to_atom_dens();
 
-    // Radioactive Material functions
-    /// Returns a list of gamma-rays energies in keV and intensities in
-    /// decays/s/atom material unnormalized
-    std::vector<std::pair<double, double> > gammas();
-    /// Returns a list of x-rays average energies in keV and intensities in
-    /// decays/s material unnormalized
-    std::vector<std::pair<double, double> > xrays();
-    /// Returns a list of photon energies in keV and intensities in
-    /// decays/s/atom material unnormalized
-    std::vector<std::pair<double, double> > photons(bool norm);
-    /// Takes a list of photon energies and intensities and normalizes them
-    /// so the sum of the intensities is one
-    std::vector<std::pair<double, double> > normalize_radioactivity(
+  // Radioactive Material functions
+  /// Returns a list of gamma-rays energies in keV and intensities in
+  /// decays/s/atom material unnormalized
+  std::vector<std::pair<double, double> > gammas();
+  /// Returns a list of x-rays average energies in keV and intensities in
+  /// decays/s material unnormalized
+  std::vector<std::pair<double, double> > xrays();
+  /// Returns a list of photon energies in keV and intensities in
+  /// decays/s/atom material unnormalized
+  std::vector<std::pair<double, double> > photons(bool norm);
+  /// Takes a list of photon energies and intensities and normalizes them
+  /// so the sum of the intensities is one
+  std::vector<std::pair<double, double> > normalize_radioactivity(
       std::vector<std::pair<double, double> > unnormed);
 
-    /// Decays this material for a given amount of time in seconds
-    Material decay(double t);
+  /// Decays this material for a given amount of time in seconds
+  Material decay(double t);
 
-    /// Transmutes the material via the CRAM method.
-    /// \param A The transmutation matrix [unitless]
-    /// \param order The CRAM approximation order (default 14).
-    /// \return A new material which has been transmuted.
-    Material cram(std::vector<double> A, const int order=14);
+  /// Transmutes the material via the CRAM method.
+  /// \param A The transmutation matrix [unitless]
+  /// \param order The CRAM approximation order (default 14).
+  /// \return A new material which has been transmuted.
+  Material cram(std::vector<double> A, const int order = 14);
 
-    // Overloaded Operators
-    /// Adds mass to a material instance.
-    Material operator+ (double);
-    /// Adds two materials together.
-    Material operator+ (Material);
-    /// Multiplies a material's mass.
-    Material operator* (double);
-    /// Divides a material's mass.
-    Material operator/ (double);
-  };
+  // Overloaded Operators
+  /// Adds mass to a material instance.
+  Material operator+ (double);
+  /// Adds two materials together.
+  Material operator+ (Material);
+  /// Multiplies a material's mass.
+  Material operator* (double);
+  /// Divides a material's mass.
+  Material operator/ (double);
+};
 
-  /// Converts a Material to a string stream representation for canonical writing.
-  /// This operator is also defined on inheritors of std::ostream
-  std::ostream& operator<< (std::ostream& os, Material mat);
+/// Converts a Material to a string stream representation for canonical writing.
+/// This operator is also defined on inheritors of std::ostream
+std::ostream& operator<< (std::ostream& os, Material mat);
 
-  /// A stuct for reprensenting fundemental data in a material.
-  /// Useful for HDF5 representations.
-  typedef struct material_data {
-    double mass;  ///< material mass
-    double density; ///< material density
-    double atoms_per_mol; ///< material atoms per mole
-    double comp[1]; ///< array of material composition mass weights.
-  } material_data;
+/// A stuct for reprensenting fundemental data in a material.
+/// Useful for HDF5 representations.
+typedef struct material_data {
+  double mass;  ///< material mass
+  double density; ///< material density
+  double atoms_per_mol; ///< material atoms per mole
+  double comp[1]; ///< array of material composition mass weights.
+} material_data;
 
-  /// Custom exception for invalid HDF5 protocol numbers
-  class MaterialProtocolError: public std::exception
-  {
-    /// marginally helpful error message.
-    virtual const char* what() const throw()
-    {
-      return "Invalid loading protocol number; please use 0 or 1.";
-    }
-  };
+/// Custom exception for invalid HDF5 protocol numbers
+class MaterialProtocolError: public std::exception {
+  /// marginally helpful error message.
+  virtual const char* what() const throw() {
+    return "Invalid loading protocol number; please use 0 or 1.";
+  }
+};
 
 // End pyne namespace
 }

--- a/src/uwuw/tests/uwuw_unit_tests.cpp
+++ b/src/uwuw/tests/uwuw_unit_tests.cpp
@@ -156,6 +156,6 @@ TEST_F(UWUWTest, mat_write) {
   expected_rep << "</material>\n";
 
   EXPECT_EQ(expected_rep.str(), openmc_rep);
-  
+
   return;
 }

--- a/src/uwuw/tests/uwuw_unit_tests.cpp
+++ b/src/uwuw/tests/uwuw_unit_tests.cpp
@@ -4,6 +4,7 @@
 #include <cassert>
 
 #include <iostream>
+#include <sstream>
 #include <unistd.h>
 #include <stdio.h>
 
@@ -136,3 +137,25 @@ TEST_F(UWUWTest, material_datapath) {
   return;
 }
 
+TEST_F(UWUWTest, mat_write) {
+
+  pyne::comp_map nucvec;
+  nucvec[pyne::nucname::id("H1")] = 2.0;
+  nucvec[pyne::nucname::id("O16")] = 1.0;
+  pyne::Material mat = pyne::Material(nucvec, -1.0, 1.0);
+  mat.metadata["name"] = "Water";
+  mat.metadata["mat_number"] = 1;
+  // check openmc material write
+  std::string openmc_rep = mat.openmc();
+  std::cout << openmc_rep << std::endl;
+  std::stringstream expected_rep;
+  expected_rep << "<material id=\"1\" >\n";
+  expected_rep << "  <density value=\"1.\" units=\"g/cc\" />\n";
+  expected_rep << "  <nuclide name=\"H1\" wo=\"6.6667e-01\" />\n";
+  expected_rep << "  <nuclide name=\"O16\" wo=\"3.3333e-01\" />\n";
+  expected_rep << "</material>\n";
+
+  EXPECT_EQ(expected_rep.str(), openmc_rep);
+  
+  return;
+}


### PR DESCRIPTION
## Description
This PR updates the amalgamated PyNE source code in DAGMC to include methods for writing PyNE materials/material libraries to an OpenMC format.

## Motivation and Context
To support the UWUW workflow for DAGMC problems in OpenMC.

## Changes
Several methods are added to the PyNE material and nucname classes to support writing of OpenMC xml elements.

Addition of the C++11 standard to the DAGMC project.

## Other Information
Should we add C++11 for all of DAGMC at this point? Is there a reason not to?

If we don't want to use it globally in the project, can we use this standard in our compilation of `libpyne`?