### PR TITLE
OpenMC Model Prep Documentation

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -23,9 +23,8 @@ Direct Accelerated Geometry Monte Carlo (DAGMC) is a software package that
 allows users to perform Monte Carlo radiation transport directly on CAD models.
 
 DAGMC has been integrated into a variety of Monte Carlo radiation codes
-including MCNP5_, MCNP6_, Geant4_, FLUKA_, Tripoli4_, and Shift_. There are also
-efforts planned to integrate DAGMC into other codes such as Serpent2_, OpenMC_,
-Phits_, and Frensie.
+including MCNP5_, MCNP6_, Geant4_, FLUKA_, Tripoli4_, OpenMC_, and Shift_. There are also
+efforts planned to integrate DAGMC into other codes such as Serpent2_, Phits_, and Frensie.
 
 DAGMC currently relies on using the solid modeling software Cubit_ or its
 commercial counterpart, Trelis_, to prepare solid models. These packages can be

--- a/doc/install/dagmc.rst
+++ b/doc/install/dagmc.rst
@@ -14,4 +14,5 @@ codes at a time.
     dag-shift
     dag-tripoli4
     dag_multiple
+    openmc
     cmake_options

--- a/doc/install/openmc.rst
+++ b/doc/install/openmc.rst
@@ -1,10 +1,11 @@
-.. |DAG-Code| replace:: OpenMC
+.. |DAG-Code| replace:: DAGMC
 ..  _OpenMC: https://mit-crpg.github.io/openmc
 
 Installing for use with OpenMC
 ==============================
 
-**Note: DagMC can also be built with support for other physics codes while being installed as a dependency for OpenMC.**
+**Note: DagMC can simultaneously be built with support for other physics codes
+while being installed as a dependency for OpenMC.**
 
 This document explains how to install DAGMC for use with OpenMC, assuming you have
 already installed the required `dependencies <dependencies.html>`_.
@@ -15,7 +16,8 @@ with OpenMC.
 
 .. include:: get_dagmc.txt
 
-.. include:: configure_dag-code-header.txt
+.. include:: configure_dag-code_header.txt
+
 
 Installing DAGMC as a dependency of OpenMC
 ------------------------------------------

--- a/doc/install/openmc.rst
+++ b/doc/install/openmc.rst
@@ -1,10 +1,11 @@
 .. |DAG-Code| replace:: OpenMC
+..  _OpenMC: https://mit-crpg.github.io/openmc
 
 .. include:: header.txt
 
-DAGMC is a dependency of OpenMC. Therefore, the install process for this code
-only generates and installs the DAGMC libraries to be used during compilation of
-OpenMC.
+DAGMC is an optional dependency of OpenMC_. Therefore, the install process for
+this code only generates and installs the DAGMC libraries necessary for linkage
+with OpenMC.
 
 .. include:: get_dagmc.txt
 
@@ -22,6 +23,14 @@ From the build directory, run::
 If the CMake configuration proceeded successfully, you are now ready to install
 DAGMC.
 
-..  include:: build_dagmc.txt
+Use Make to install the DAGMC libraries.
+::
+
+    $ make
+    $ make install
+
+If the build was successful, the binaries, libraries, header files, and tests
+will be installed to the ``bin``, ``lib``, ``include``, and ``tests``
+subdirectories of ``$INSTALL_PATH`` respectively.
 
 ..  include:: test_dagmc.txt

--- a/doc/install/openmc.rst
+++ b/doc/install/openmc.rst
@@ -1,0 +1,27 @@
+.. |DAG-Code| replace:: OpenMC
+
+.. include:: header.txt
+
+DAGMC is a dependency of OpenMC. Therefore, the install process for this code
+only generates and installs the DAGMC libraries to be used during compilation of
+OpenMC.
+
+.. include:: get_dagmc.txt
+
+.. include:: configure_dag-code-header.txt
+
+Installing DAGMC as a dependency of OpenMC
+------------------------------------------
+
+From the build directory, run::
+
+    $ cmake .. -DMOAB_DIR=$HOME/dagmc_bld/MOAB \
+               -DBUILD_TALLY=ON \
+               -DCMAKE_INSTALL_PATH=$INSTALL_PATH
+
+If the CMake configuration proceeded successfully, you are now ready to install
+DAGMC.
+
+..  include:: build_dagmc.txt
+
+..  include:: test_dagmc.txt

--- a/doc/install/openmc.rst
+++ b/doc/install/openmc.rst
@@ -1,7 +1,13 @@
 .. |DAG-Code| replace:: OpenMC
 ..  _OpenMC: https://mit-crpg.github.io/openmc
 
-.. include:: header.txt
+Installing for use with OpenMC
+==============================
+
+**Note: DagMC can also be built with support for other physics codes while being installed as a dependency for OpenMC.**
+
+This document explains how to install DAGMC for use with OpenMC, assuming you have
+already installed the required `dependencies <dependencies.html>`_.
 
 DAGMC is an optional dependency of OpenMC_. Therefore, the install process for
 this code only generates and installs the DAGMC libraries necessary for linkage

--- a/doc/usersguide/codes/dag-mcnp.rst
+++ b/doc/usersguide/codes/dag-mcnp.rst
@@ -75,7 +75,7 @@ geometric shape can be used for this, but a cubic shell is preferred. The
 graveyard represents the outside world, and any particle that enters it will be
 terminated.
 
-To create a graveyard volume, create two volumes in Cubit with the same shape
+To create a graveyard volume, create two volumes in Cubit/Trelis with the same shape
 and same center with one slightly larger than the other, making sure that both
 bound the entire problem geometry. Then, subtract the smaller one from the
 larger one. The remaining volume is the graveyard.

--- a/doc/usersguide/codes/index.rst
+++ b/doc/usersguide/codes/index.rst
@@ -7,3 +7,4 @@ Monte Carlo code-specific steps
     dag-mcnp
     fludag
     dag-tripoli4
+    openmc

--- a/doc/usersguide/codes/openmc.rst
+++ b/doc/usersguide/codes/openmc.rst
@@ -18,11 +18,11 @@ Geometry metadata
 The DAGMC geometry file can be used to define material assignments, boundary
 conditions, and temperatures.
 
-Materials and densities
------------------------
+Materials
+---------
 
 The generic workflow description includes details on :ref:`grouping-basics`, but
-a specific naming convention is required for DAG-OpenMC. To define materials,
+a specific naming convention is required for OpenMC. To define materials,
 the material ID must be provided in the group name. The format for the group
 name is as follows: ``mat:[matid]``.
 
@@ -70,13 +70,13 @@ surround the entire geometry with a shell of finite thickness. Any
 geometric shape can be used, but a cubic shell is recommended. This
 volume represents the boundary between the problem and the outside world.
 
-To create a containing volume, create two volumes in Cubit with the same shape
-and same center with one slightly larger than the other, making sure that both
-bound the entire problem geometry. Then, subtract the smaller one from the
+To create a containing volume, create two volumes in Cubit/Trelis with the same
+shape and same center with one slightly larger than the other, making sure that
+both bound the entire problem geometry. Then, subtract the smaller one from the
 larger one. The result is a containing volume for the problem.
 
 As mentioned above, this volume's surfaces should be assigned either vacuum or
-reflective boundary conditions as is appropriate for the problem.
+reflective boundary conditions according to the problem requirements.
 
 For example, consider a geometry containing 99 volumes, all of which fit inside
 a cube of side length 99 cm centered at the origin. The following commands would
@@ -94,11 +94,12 @@ Temperatures
 ~~~~~~~~~~~~
 
 Cell temperatures can be defined in OpenMC using a similar syntax to boundary
-conditions but with the "temp" keyword:
+conditions but with "temp" as the keyword:
 ::
     CUBIT> group "temp:100" add vol x
 
-All temperatures are assumed to be in Kelvin.
+**All temperatures are assumed to be in Kelvin when loaded in OpenMC.**
+
 
 Implicit complement materials
 -----------------------------
@@ -124,7 +125,7 @@ Running DAG-OpenMC
 The command for running OpenMC is identical to an OpenMC run using native
 geometry. Certain modifications to the OpenMC input files are required,
 however. The element ``<dagmc>true</dagmc>`` must be present in the
-``settings.xml`` file, and the DAGMC geometry must be named of symbolically
+``settings.xml`` file, and the DAGMC geometry must be named or symbolically
 linked as ``dagmc.h5m``.
 
 ..  toctree::

--- a/doc/usersguide/codes/openmc.rst
+++ b/doc/usersguide/codes/openmc.rst
@@ -96,6 +96,7 @@ conditions but with "temp" as the keyword.
 
 To assign a temperature of 900K to a volume one can use the following command.
 ::
+
     CUBIT> group "temp:900" add vol x
 
 **Note: all temperatures are assumed to be in units of Kelvin in OpenMC.**

--- a/doc/usersguide/codes/openmc.rst
+++ b/doc/usersguide/codes/openmc.rst
@@ -1,10 +1,11 @@
 ..  _OpenMC: https://mit-crpg.github.io/openmc
 
+**Note: OpenMC supports the recommended** :ref:`UWUW`
+
+|
+
 Code-Specific steps for OpenMC
 ==================================
-
-**Note: DAGMC simulations in OpenMC also support the `UWUW <../uw2.html>`_
- workflow.**
 
 There are two varieties of code-specific steps for OpenMC_:
 

--- a/doc/usersguide/codes/openmc.rst
+++ b/doc/usersguide/codes/openmc.rst
@@ -41,10 +41,8 @@ then add them to a group called, "mat:Vacuum":
 
     CUBIT> group "mat:Vacuum" add vol 4 to 18
 
-Boundary conditions
--------------------
-
-**Surface boundary conditions**
+Surface boundary conditions
+----------------------------
 
 The following boundary conditions available in OpenMC are supported in
 DAGMC. These are:
@@ -59,24 +57,22 @@ reflecting surfaces. This command would achieve that:
 
     CUBIT> group "boundary:Reflecting" add surf 10 11
 
-Surfaces without a specified boundary condition will be set to ``transmission``.
+**Note: surfaces without a specified boundary condition will be set to ``transmission``.**
 
-**Vacuum boundaries: defining the problem boundary**
+Problem boundary
+----------------
 
 The DAGMC model should have a "containing volume" which bounds the volumes of
-interest. This volume should have surfaces that either remove particles from the
-problem or reflect them back toward regions of interest. This volume should
-surround the entire geometry with a shell of finite thickness. Any
-geometric shape can be used, but a cubic shell is recommended. This
-volume represents the boundary between the problem and the outside world.
+interest. This volume represents a particle "graveyard" or a region where
+particles are removed from the simulation upon entry. This volume should
+surround the entire geometry with a shell of finite thickness. Any geometric
+shape can be used, but a cubic shell is recommended. This volume represents the
+boundary between the problem and the outside world.
 
 To create a containing volume, create two volumes in Cubit/Trelis with the same
 shape and same center with one slightly larger than the other, making sure that
 both bound the entire problem geometry. Then, subtract the smaller one from the
 larger one. The result is a containing volume for the problem.
-
-As mentioned above, this volume's surfaces should be assigned either vacuum or
-reflective boundary conditions according to the problem requirements.
 
 For example, consider a geometry containing 99 volumes, all of which fit inside
 a cube of side length 99 cm centered at the origin. The following commands would
@@ -86,19 +82,22 @@ create a valid graveyard for this problem:
     CUBIT> create brick x 100             # This will be volume 100
     CUBIT> create brick x 105             # This will be volume 101
     CUBIT> subtract vol 100 from vol 101  # This will produce volume 102
-    CUBIT> list volume 102 geom
-    # collect surfaces of 102 from output #
-    CUBIT> group "boundary:Vacuum" add <volume 102 surfaces>
+    CUBIT> group "mat:Graveyard" add volume 102
+
+A volume in the ``mat:Graveyard`` group will be assigned a void material and its
+surfaces will be given vacuum boundary conditions when the OpenMC simulation is
+initialized.
 
 Temperatures
 ~~~~~~~~~~~~
 
 Cell temperatures can be defined in OpenMC using a similar syntax to boundary
-conditions but with "temp" as the keyword:
+conditions but with "temp" as the keyword. To assign a temperature of 900K to
+a volume one can use the following command.
 ::
-    CUBIT> group "temp:100" add vol x
+    CUBIT> group "temp:900" add vol x
 
-**All temperatures are assumed to be in Kelvin when loaded in OpenMC.**
+**Note: all temperatures are assumed to be in Kelvin when loaded in OpenMC.**
 
 
 Implicit complement materials
@@ -108,14 +107,14 @@ If you would like to assign a material to the implicit complement, a special
 procedure is needed. Since the implicit complement doesn't exist before running
 DAGMC, and DAGMC can only recognize groups that contain an entity, the material
 for the implicit complement must be specified as if it were being specified for
-the containing volume. For example, if you would like the implicit complement to
-be modeled as material 9, and the containing volume is
-volume 102, the following command should be used:
+the graveyard volume. For example, if you would like the implicit complement to
+be modeled as material 9, and the graveyard volume is volume 102, the following
+command should be used:
 ::
 
     CUBIT> group "mat:9_comp" add vol 102
 
-DAGMC will recognize that volume 102 is the containing volume, and the ``_comp``
+DAGMC will recognize that volume 102 is the graveyard volume, and the ``_comp``
 keyword will trigger it to assign the specified material and density to the
 implicit complement rather than the containing volume.
 
@@ -126,7 +125,8 @@ The command for running OpenMC is identical to an OpenMC run using native
 geometry. Certain modifications to the OpenMC input files are required,
 however. The element ``<dagmc>true</dagmc>`` must be present in the
 ``settings.xml`` file, and the DAGMC geometry must be named or symbolically
-linked as ``dagmc.h5m``.
+linked as ``dagmc.h5m`` in the directory where the ``openmc`` command is
+executed.
 
 ..  toctree::
     :hidden:

--- a/doc/usersguide/codes/openmc.rst
+++ b/doc/usersguide/codes/openmc.rst
@@ -64,12 +64,12 @@ Problem boundary
 
 The DAGMC model should have a "containing volume" which bounds the volumes of
 interest. This volume represents a particle "graveyard" or a region where
-particles are removed from the simulation upon entry. This volume should
-surround the entire geometry with a shell of finite thickness. Any geometric
-shape can be used, but a cubic shell is recommended. This volume represents the
-boundary between the problem and the outside world.
+particles are removed from the simulation upon entry. This volume represents the
+boundary between the problem and the outside world.  This volume should surround
+the entire geometry with a shell of finite thickness. Any geometric shape can be
+used, but a cubic shell is recommended to maximize performance.
 
-To create a containing volume, create two volumes in Cubit/Trelis with the same
+To create a containing volume, make two volumes in Cubit/Trelis with the same
 shape and same center with one slightly larger than the other, making sure that
 both bound the entire problem geometry. Then, subtract the smaller one from the
 larger one. The result is a containing volume for the problem.
@@ -89,23 +89,23 @@ surfaces will be given vacuum boundary conditions when the OpenMC simulation is
 initialized.
 
 Temperatures
-~~~~~~~~~~~~
+------------
 
-Cell temperatures can be defined in OpenMC using a similar syntax to boundary
-conditions but with "temp" as the keyword. To assign a temperature of 900K to
-a volume one can use the following command.
+Volume temperatures can be defined in OpenMC using a similar syntax to materials or boundary
+conditions but with "temp" as the keyword.
+
+To assign a temperature of 900K to a volume one can use the following command.
 ::
     CUBIT> group "temp:900" add vol x
 
-**Note: all temperatures are assumed to be in Kelvin when loaded in OpenMC.**
-
+**Note: all temperatures are assumed to be in units of Kelvin in OpenMC.**
 
 Implicit complement materials
 -----------------------------
 
 If you would like to assign a material to the implicit complement, a special
 procedure is needed. Since the implicit complement doesn't exist before running
-DAGMC, and DAGMC can only recognize groups that contain an entity, the material
+DAGMC and DAGMC can only recognize groups that contain an entity, the material
 for the implicit complement must be specified as if it were being specified for
 the graveyard volume. For example, if you would like the implicit complement to
 be modeled as material 9, and the graveyard volume is volume 102, the following

--- a/doc/usersguide/codes/openmc.rst
+++ b/doc/usersguide/codes/openmc.rst
@@ -57,7 +57,7 @@ reflecting surfaces. This command would achieve that:
 
     CUBIT> group "boundary:Reflecting" add surf 10 11
 
-**Note: surfaces without a specified boundary condition will be set to ``transmission``.**
+**Note: surfaces without a specified boundary condition will be set to** ``transmission`` **.**
 
 Problem boundary
 ----------------

--- a/doc/usersguide/codes/openmc.rst
+++ b/doc/usersguide/codes/openmc.rst
@@ -1,0 +1,132 @@
+..  _OpenMC: https://mit-crpg.github.io/openmc
+
+Code-Specific steps for OpenMC
+==================================
+
+**Note: DAGMC simulations in OpenMC also support the `UWUW <../uw2.html>`_
+ workflow.**
+
+There are two varieties of code-specific steps for OpenMC_:
+
+1.  Defining attributes of the geometry using Cubit/Trelis groups
+2.  Defining DAGMC runtime parameters using the OpenMC input files
+
+Geometry metadata
+~~~~~~~~~~~~~~~~~
+
+The DAGMC geometry file can be used to define material assignments, boundary
+conditions, and temperatures.
+
+Materials and densities
+-----------------------
+
+The generic workflow description includes details on :ref:`grouping-basics`, but
+a specific naming convention is required for DAG-OpenMC. To define materials,
+the material ID must be provided in the group name. The format for the group
+name is as follows: ``mat:[matid]``.
+
+``[matid]`` should be replaced by the material ID that will be specified in the
+``materials.xml`` file.
+
+For example, consider a problem where material 7 should be assigned to volumes 4
+through 18. The following command should be used to specify that information:
+::
+
+    CUBIT> group "mat:7" add vol 4 to 18
+
+All volumes must belong to a group, if you want volumes to be filled with vacuum
+then add them to a group called, "mat:Vacuum":
+::
+
+    CUBIT> group "mat:Vacuum" add vol 4 to 18
+
+Boundary conditions
+-------------------
+
+**Surface boundary conditions**
+
+The following boundary conditions available in OpenMC are supported in
+DAGMC. These are:
+
+- vacuum
+- reflective
+- transmission
+
+For example, suppose you want to specify that surfaces 10 and 11 should be
+reflecting surfaces. This command would achieve that:
+::
+
+    CUBIT> group "boundary:Reflecting" add surf 10 11
+
+Surfaces without a specified boundary condition will be set to ``transmission``.
+
+**Vacuum boundaries: defining the problem boundary**
+
+The DAGMC model should have a "containing volume" which bounds the volumes of
+interest. This volume should have surfaces that either remove particles from the
+problem or reflect them back toward regions of interest. This volume should
+surround the entire geometry with a shell of finite thickness. Any
+geometric shape can be used, but a cubic shell is recommended. This
+volume represents the boundary between the problem and the outside world.
+
+To create a containing volume, create two volumes in Cubit with the same shape
+and same center with one slightly larger than the other, making sure that both
+bound the entire problem geometry. Then, subtract the smaller one from the
+larger one. The result is a containing volume for the problem.
+
+As mentioned above, this volume's surfaces should be assigned either vacuum or
+reflective boundary conditions as is appropriate for the problem.
+
+For example, consider a geometry containing 99 volumes, all of which fit inside
+a cube of side length 99 cm centered at the origin. The following commands would
+create a valid graveyard for this problem:
+::
+
+    CUBIT> create brick x 100             # This will be volume 100
+    CUBIT> create brick x 105             # This will be volume 101
+    CUBIT> subtract vol 100 from vol 101  # This will produce volume 102
+    CUBIT> list volume 102 geom
+    # collect surfaces of 102 from output #
+    CUBIT> group "boundary:Vacuum" add <volume 102 surfaces>
+
+Temperatures
+~~~~~~~~~~~~
+
+Cell temperatures can be defined in OpenMC using a similar syntax to boundary
+conditions but with the "temp" keyword:
+::
+    CUBIT> group "temp:100" add vol x
+
+All temperatures are assumed to be in Kelvin.
+
+Implicit complement materials
+-----------------------------
+
+If you would like to assign a material to the implicit complement, a special
+procedure is needed. Since the implicit complement doesn't exist before running
+DAGMC, and DAGMC can only recognize groups that contain an entity, the material
+for the implicit complement must be specified as if it were being specified for
+the containing volume. For example, if you would like the implicit complement to
+be modeled as material 9, and the containing volume is
+volume 102, the following command should be used:
+::
+
+    CUBIT> group "mat:9_comp" add vol 102
+
+DAGMC will recognize that volume 102 is the containing volume, and the ``_comp``
+keyword will trigger it to assign the specified material and density to the
+implicit complement rather than the containing volume.
+
+Running DAG-OpenMC
+~~~~~~~~~~~~~~~~~~
+
+The command for running OpenMC is identical to an OpenMC run using native
+geometry. Certain modifications to the OpenMC input files are required,
+however. The element ``<dagmc>true</dagmc>`` must be present in the
+``settings.xml`` file, and the DAGMC geometry must be named of symbolically
+linked as ``dagmc.h5m``.
+
+..  toctree::
+    :hidden:
+
+    dag-mcnp_deprecated

--- a/doc/usersguide/index.rst
+++ b/doc/usersguide/index.rst
@@ -30,6 +30,8 @@ much manual data transfer you wish to do.
 +-------------------------+----------------+----------------+
 |  Tripoli4 Materials     | N              |  None          |
 +-------------------------+----------------+----------------+
+|  OpenMC Materials       | N              |  M             |
++-------------------------+----------------+----------------+
 
 **N** not supported, **A** automatic production at run time, **M** manually
 performed

--- a/doc/usersguide/index.rst
+++ b/doc/usersguide/index.rst
@@ -10,7 +10,7 @@ which workflow suits your needs depends on which codes you expect to use and how
 much manual data transfer you wish to do.
 
 +-------------------------+----------------+----------------+
-| Feature                 | UW2 Workflow   | Basic Workflow | 
+| Feature                 | UW2 Workflow   | Basic Workflow |
 +-------------------------+----------------+----------------+
 |  Assignment of Metadata | M              |  M             |
 +-------------------------+----------------+----------------+
@@ -30,7 +30,7 @@ much manual data transfer you wish to do.
 +-------------------------+----------------+----------------+
 |  Tripoli4 Materials     | N              |  None          |
 +-------------------------+----------------+----------------+
-|  OpenMC Materials       | N              |  M             |
+|  OpenMC Materials       | A              |  M             |
 +-------------------------+----------------+----------------+
 
 **N** not supported, **A** automatic production at run time, **M** manually

--- a/doc/usersguide/uw2.rst
+++ b/doc/usersguide/uw2.rst
@@ -169,6 +169,7 @@ To run a OpenMC UWUW simulation, a ``dagmc.h5m`` file containing the UWUW model
 must be present in the OpenMC run directory and a ``dagmc`` element in the
 ``settings.xml`` file must be set to true like so:
 ::
+
    <dagmc>true</dagmc>
 
 OpenMC will then load the geometry and material library when setting up the simulation.

--- a/doc/usersguide/uw2.rst
+++ b/doc/usersguide/uw2.rst
@@ -160,6 +160,17 @@ now run as if it were a standard FLUKA problem
 
     $ $FLUPRO/flutil/rfluka -N0 -M5 -e mainfludag input.inp
 
+OpenMC-specific steps
+~~~~~~~~~~~~~~~~~~~~~
+
+To run a OpenMC UWUW simulation, a ``dagmc.h5m`` file containing the UWUW model
+must be present in the OpenMC run directory and a ``dagmc`` element in the
+``settings.xml`` file must be set to true like so:
+::
+   <dagmc>true</dagmc>
+
+OpenMC will then load the geometry and material library when setting up the simulation.
+
 Geant4-specific steps
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/usersguide/uw2.rst
+++ b/doc/usersguide/uw2.rst
@@ -1,3 +1,5 @@
+..  _UWUW:
+
 University of Wisconsin Unified Workflow (UWUW)
 ===============================================
 

--- a/news/PR-0599.rst
+++ b/news/PR-0599.rst
@@ -1,0 +1,11 @@
+**Added:** Documentation on model prep for OpenMC simulations with a DAGMC geometry.
+
+**Changed:** A small change to a single line of the dag-mcnp model prep file.
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None


### PR DESCRIPTION
## Description
This PR adds documentation on how to prepare a DAGMC model for OpenMC using the legacy-style workflow for material/metadata assignment. It also adds some documentation on how to install DAGMC as an optional dependency of OpenMC.

## Motivation and Context
To provide users with information on how to take advantage of the CAD-Based geometry capability added to OpenMC.

## Changes
Documentation updates - mainly in the user's guide and the install guide.

## Other Information
There is a note at the top of the OpenMC section for model prep encouraging users to go with the UWUW workflow. I'm almost tempted not to even provide a legacy style format for OpenMC simulations, but I think that might be overly restrictive for those who don't necessarily want to invest in using PyNE and have material definitions they trust in their own `materials.xml` file.

