### PR TITLE
Move type keywords to FC cards in documentation

### DIFF
--- a/doc/usersguide/tally.rst
+++ b/doc/usersguide/tally.rst
@@ -42,20 +42,20 @@ a tetmesh tally, that the input mesh file is ``mesh.h5m``, and the results
 should be stored in ``mesh_out.h5m``.
 ::
 
-    fmesh4:n geom=dag type=unstr_track
+    fmesh4:n geom=dag
     fc4 dagmc inp=mesh.h5m out=mesh_out.h5m
 
 Other standard MCNP options can also be used, such as energy bins:
 ::
 
-    fmesh4:n geom=dag type=unstr_track
+    fmesh4:n geom=dag
              emesh=1.0 2.0 15.0
     fc4 dagmc inp=mesh.h5m out=mesh_out.h5m
 
 Or tally multipliers:
 ::
 
-    fmesh4:p geom=dag type=unstr_track
+    fmesh4:p geom=dag
     fc4 dagmc inp=mesh.h5m out=mesh_out.h5m
     fm4 -1 0 -5 -6
 

--- a/doc/usersguide/tally.rst
+++ b/doc/usersguide/tally.rst
@@ -43,20 +43,20 @@ should be stored in ``mesh_out.h5m``.
 ::
 
     fmesh4:n geom=dag
-    fc4 dagmc inp=mesh.h5m out=mesh_out.h5m
+    fc4 dagmc type=unstr_track inp=mesh.h5m out=mesh_out.h5m
 
 Other standard MCNP options can also be used, such as energy bins:
 ::
 
     fmesh4:n geom=dag
              emesh=1.0 2.0 15.0
-    fc4 dagmc inp=mesh.h5m out=mesh_out.h5m
+    fc4 dagmc type=unstr_track inp=mesh.h5m out=mesh_out.h5m
 
 Or tally multipliers:
 ::
 
     fmesh4:p geom=dag
-    fc4 dagmc inp=mesh.h5m out=mesh_out.h5m
+    fc4 dagmc type=unstr_track inp=mesh.h5m out=mesh_out.h5m
     fm4 -1 0 -5 -6
 
 ``mbconvert`` can be used to convert the output mesh file to a .vtk file for
@@ -76,22 +76,22 @@ can be found in `Kerry Dunn's Ph.D. thesis <KD_thesis_>`_.
 To call a KDE collision tally, use:
 ::
 
-    fmesh4:p geom=dag type=kde_coll
-    fc4 dagmc inp=mesh.h5m out=mesh_out.h5m
+    fmesh4:p geom=dag
+    fc4 dagmc type=kde_coll inp=mesh.h5m out=mesh_out.h5m
         hx=0.198 hy=0.0663 hz=0.0662
 
 To call a KDE track length tally, use:
 ::
 
-    fmesh4:p geom=dag type=kde_track
-    fc4 dagmc inp=mesh.h5m out=mesh_out.h5m
+    fmesh4:p geom=dag
+    fc4 dagmc type=kde_track inp=mesh.h5m out=mesh_out.h5m
         hx=0.198 hy=0.0663 hz=0.0662
 
 To call a KDE subtrack tally, use:
 ::
 
-    fmesh4:p geom=dag type=kde_subtrack
-    fc4 dagmc inp=mesh.h5m out=mesh_out.h5m
+    fmesh4:p geom=dag
+    fc4 dagmc type=kde_subtrack inp=mesh.h5m out=mesh_out.h5m
         hx=0.1042 hy=0.0833 hz=0.0833
         hx=0.1042 hy=0.0833 hz=0.0833
         subtracks=3 seed=11699913

--- a/news/PR-0600.rst
+++ b/news/PR-0600.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:**
+
+* Keyword type=unstr_track in the documentation.
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/news/PR-0600.rst
+++ b/news/PR-0600.rst
@@ -2,9 +2,9 @@
 
 **Changed:** None
 
-**Deprecated:**
+* Move keyword type to FC card in the document doc/userguide/tally.rst
 
-* Keyword type=unstr_track in the documentation.
+**Deprecated:**
 
 **Removed:** None
 


### PR DESCRIPTION
Please follow these guidelines when making a Pull Request.
This template was adapted from [here](https://github.com/stevemao/github-issue-templates/edit/master/questions-answers/PULL_REQUEST_TEMPLATE.md) and [here](https://github.com/stevemao/github-issue-templates/edit/master/conversational/PULL_REQUEST_TEMPLATE.md).

## Description
Delete obsolete keywork: `type=unstr_track` in the userguide/tally.rst.

## Motivation and Context
For DAGMC calculation using tet mesh, this keyword seems to be no longer used, and this keyword will cause fatal error: ` illegal entry:  type`. 

## Changes
Delete obsolete keyword (documentation update). 

## Behavior
Current behavior: fatal error.  illegal entry:  type
New behavior: fatal error disappeared.

## Other Information
Are the keywords: "type=kde_coll", "type=kde_track", "type=kde_subtrack" still available?

## News file
The news file should be located at the `/news/PR-0600.rst`.  