### PR TITLE
Adding line to remove LD_LIBRARY_PATH from test environment.

### DIFF
--- a/cmake/DAGMC_macros.cmake
+++ b/cmake/DAGMC_macros.cmake
@@ -284,6 +284,7 @@ macro (dagmc_install_test test_name ext)
   endif ()
   install(TARGETS ${test_name} DESTINATION ${INSTALL_TESTS_DIR})
   add_test(NAME ${test_name} COMMAND ${test_name})
+  set_property(TEST ${test_name} PROPERTY ENVIRONMENT "LD_LIBRARY_PATH=''")
 endmacro ()
 
 # Install a file needed for unit testing


### PR DESCRIPTION
Please follow these guidelines when making a Pull Request.
This template was adapted from [here](https://github.com/stevemao/github-issue-templates/edit/master/questions-answers/PULL_REQUEST_TEMPLATE.md) and [here](https://github.com/stevemao/github-issue-templates/edit/master/conversational/PULL_REQUEST_TEMPLATE.md).

## Description
Fix to CTest environment.

## Motivation and Context
Currently, the result of running `make test` will rely on an installed version of DAGMC in `LD_LIBRARY_PATH` if present. This change ensures that the the version of DAGMC in the build directory is used in the test target.

## Changes
A small change to the DAGMC CMake macros.
