### PR TITLE
Adding option to read starting weights from mesh

### DIFF
--- a/news/PR-0611.rst
+++ b/news/PR-0611.rst
@@ -1,0 +1,16 @@
+**Added:** None
+
+**Changed:**
+source_sampling.h
+source_sampling.cpp
+
+* Throw a fatal error if trying to build static executables but not static
+  libraries, or shared executables but not shared libraries
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/src/mcnp/mcnp5/pyne_source/source_sampling.cpp
+++ b/src/mcnp/mcnp5/pyne_source/source_sampling.cpp
@@ -205,7 +205,7 @@ void pyne::Sampler::mesh_tag_data(moab::Range ves,
 				moab::MB_TYPE_DOUBLE,
 				bias_tag);
     std::vector<double> u_weights(num_ves * num_e_groups);
-    rval = mesh->tag_get_data(src_tag, ves, &u_weights[0]);
+    rval = mesh->tag_get_data(bias_tag, ves, &u_weights[0]);
     if (rval != moab::MB_SUCCESS)
       throw std::runtime_error("Problem getting weight tag data.");
     biased_weights.resize(num_ves * num_e_groups);

--- a/src/mcnp/mcnp5/pyne_source/source_sampling.cpp
+++ b/src/mcnp/mcnp5/pyne_source/source_sampling.cpp
@@ -207,10 +207,10 @@ void pyne::Sampler::mesh_tag_data(moab::Range ves,
     std::vector<double> u_weights(num_ves * num_e_groups);
     rval = mesh->tag_get_data(src_tag, ves, &u_weights[0]);
     if (rval != moab::MB_SUCCESS)
-      throw std::runtime_error("Problem getting source tag data.");
+      throw std::runtime_error("Problem getting weight tag data.");
     biased_weights.resize(num_ves * num_e_groups);
     for (i = 0; i < num_ves * num_e_groups; ++i) {
-      biased_weights[i] = b_weights[i];
+      biased_weights[i] = u_weights[i];
     }
     at = new AliasTable(pdf);
   } else {

--- a/src/mcnp/mcnp5/pyne_source/source_sampling.h
+++ b/src/mcnp/mcnp5/pyne_source/source_sampling.h
@@ -47,7 +47,8 @@ extern "C" {
 namespace pyne {
 
 /// MCNP interface for source sampling setup
-/// \param mode The sampling mode: 1 = analog, 2 = uniform, 3 = user-specified
+/// \param mode The sampling mode: 0 = analog, 1 = uniform, 2 = user-biased,
+/// and 3 = user-weight  
 void sampling_setup_(int* mode);
 /// MCNP interface to sample particle birth parameters after sampling setup
 /// \param rands Six pseudo-random numbers supplied from the Fortran side.
@@ -120,7 +121,7 @@ class Sampler {
   ///                       If 1 (i.e. spatial biasing only), all energy groups
   ///                       within a mesh volume element are sampled equally.
   /// \param uweight If false, weights are calculated as pdf/biased_pdf.
-  /// If true, supplied weights are read from mesh.
+  ///                If true, supplied weights are read from mesh.
   Sampler(std::string filename,
           std::string src_tag_name,
           std::vector<double> e_bounds,

--- a/src/mcnp/mcnp5/pyne_source/source_sampling.h
+++ b/src/mcnp/mcnp5/pyne_source/source_sampling.h
@@ -4,22 +4,23 @@
 /// \brief Mesh-based Monte Carlo source sampling.
 ///
 /// The Sampler class is used for Monte Carlo source sampling from mesh-based
-/// sources.  The source density distribution and optional biased source density
+/// sources. The source density distribution and optional biased source density
 /// distribution are defined on a MOAB mesh. Upon instantiation, a Sampler
 /// object reads this mesh and creates an alias table for randomly sampling
 /// particle birth parameters. The particle_birth member function is supplied
 /// with 6 pseudo-random numbers and returns the position, energy, and weight
 /// of a particle upon birth.
-/// There are three sampling modes: analog, uniform, and user-speficied
-/// In analog sampling, no source biasing is used and birth weights
-/// are all 1. In uniform sampling, the position of the particle (but not the
-/// energy) is sampled uniformly and weights are adjusted accordingly. In
-/// user-speficied mode, a supplied biased source density distribution is used
-/// for sampling and particle weights are adjusted accordingly. The biased
-/// source density distribution must have the same number of energy groups as
-/// the unbiased distribution. Alternatively, it may have exactly 1 energy
-/// group, in which case only spatial biasing is done, and energies are sampled
-/// in analog.
+/// There are four sampling modes: analog, uniform, user-biased, and user-weight.
+/// In analog sampling, no source biasing is used and birth weights are all 1.
+/// In uniform sampling, the position of the particle (but not the energy) is
+/// sampled uniformly and weights are adjusted accordingly. In user-biased mode,
+/// a supplied biased source density distribution is used for sampling and particle
+/// weights are adjusted accordingly. The biased source density distribution must
+/// have the same number of energy groups as the unbiased distribution. Alternatively,
+/// it may have exactly 1 energy group, in which case only spatial biasing is done,
+/// and energies are sampled in analog. In user-weight mode, supplied particles weights
+/// are used with sampling performed using the unbiased source density distribution.
+/// This mode is used for error propagation from mesh-based sources via random sampling.
 
 #ifndef PYNE_6OR6BJURKJHHTOFWXO2VMQM5EY
 #define PYNE_6OR6BJURKJHHTOFWXO2VMQM5EY
@@ -90,7 +91,7 @@ class AliasTable {
 };
 
 /// Problem modes
-enum Mode {USER, ANALOG, UNIFORM};
+ enum Mode {UWEIGHT, UBIASED, ANALOG, UNIFORM};
 
 /// Mesh based Monte Carlo source sampling.
 class Sampler {
@@ -118,10 +119,13 @@ class Sampler {
   ///                       number of energy groups as <src_tag_name> or 1.
   ///                       If 1 (i.e. spatial biasing only), all energy groups
   ///                       within a mesh volume element are sampled equally.
+  /// \param uweight If false, weights are calculated as pdf/biased_pdf.
+  /// If true, supplied weights are read from mesh.
   Sampler(std::string filename,
           std::string src_tag_name,
           std::vector<double> e_bounds,
-          std::string bias_tag_name);
+          std::string bias_tag_name,
+	  bool uweight);
   /// Samples particle birth parameters
   /// \param rands Six pseudo-random numbers in range [0, 1].
   /// \return A vector containing the x position, y, position, z, point, energy


### PR DESCRIPTION
This PR updates pyne-source sampling routine to allow for user supplied starting particles weights. The provided starting particles weights are mainly used for error propagation from mesh-based sources to sdr via random sampling in the R2S workflow. 
While this update will mainly be used as part of the thesis research of @moatazharb , it can also be used in cased both the biased source density distribution and weights are supplied by the user in which case this additional mode will be identical to the mode in which a user supplies both the source and biased source distributions.

## Changes
> source_sampling.h
- updated description of code.
- corrected number of modes as on the idum first entry on mcnp input 0 refers to analog, 1 to uniform, etc.. In a comment line analog was referred to by 1 mistakenly. 
 > source_sampling.cpp
- Added mode "3" to source_sampling.cpp
- changed some conventions; from "USER" to "UBIASED" and "UWEIGHT". The former refers to a User supplied BIASED source density distribution along with the unbiased, while the later refers to a User supplied WEIGHT along with the source density distribution. 

@ljacobson64 @gonuke I know that dagmc on chtc is rebuilt per new merged PRs. This is important to finish the thesis, so ... :)