### PR TITLE
Modification to allow finding of moab on Fedora/Redhat systems where …

### DIFF
--- a/cmake/FindMOAB.cmake
+++ b/cmake/FindMOAB.cmake
@@ -3,7 +3,7 @@ message("")
 # Find MOAB cmake config file
 # Only used to determine the location of the HDF5 with which MOAB was built
 set(MOAB_SEARCH_DIRS)
-file(GLOB MOAB_SEARCH_DIRS ${MOAB_SEARCH_DIRS} "${MOAB_DIR}/lib/cmake/MOAB")
+file(GLOB MOAB_SEARCH_DIRS ${MOAB_SEARCH_DIRS} "${MOAB_DIR}/lib*/cmake/MOAB")
 string(REPLACE "\n" ";" MOAB_SEARCH_DIRS ${MOAB_SEARCH_DIRS})
 find_path(MOAB_CMAKE_CONFIG
   NAMES MOABConfig.cmake


### PR DESCRIPTION
## Description
Changed one line in FindMOAB.cmake to allow finding of MOAB libraries in their default named positions on Fedora systems

## Motivation and Context
Build is currently broken for Fedora/RedHat based systems

## Changes
Bug fix

## Behavior
Current behaviour - broken - New Behaviour - fixed

## Other Information
N/A

## News file
Incoming