### PR TITLE
Openmc mat assign by name

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -55,5 +55,5 @@ materials and other geometry-related information.
 ..  _Tripoli4: https://rsicc.ornl.gov/codes/ccc/ccc8/ccc-806.html
 ..  _Shift: http://web.ornl.gov/sci/nsed/rnsd/rt
 ..  _Serpent2: http://montecarlo.vtt.fi
-..  _OpenMC: https://mit-crpg.github.io/openmc
+..  _OpenMC: https://openmc.readthedocs.io/en/latest/index.html
 ..  _Phits: http://phits.jaea.go.jp

--- a/doc/usersguide/codes/openmc.rst
+++ b/doc/usersguide/codes/openmc.rst
@@ -63,12 +63,12 @@ OpenMC's ``materials.xml`` file:
 This method for assigning materials is recommended for use with OpenMC as it
 provides a more verbose description of the material definition and purpose.
 
-This method of assignment also allows an easy transition to the UWUW workflow
-for future models. One can embed a PyNE material library in the DAGMC model at
-any point using ``uwuw_preproc`` without modification to the material
-assignments to obtain a working UWUW model, provided that materials with
-corresponding names and appropriate definitions are in the PyNE material
-library.
+This method of assignment also allows for straighforward model conversion to the
+UWUW workflow without material assignment modification, re-faceting, or
+re-sealing. To do this one can simply embed a PyNE material library in the
+original .h5m file at any point using ``uwuw_preproc``. No modification to the
+material assignments is necessary, provided that materials with appropriate
+names and definitions are in the PyNE material library.
 
 **Note: material names must be unique in the materials.xml file for this style**
 **of material assignment to work properly.**

--- a/doc/usersguide/codes/openmc.rst
+++ b/doc/usersguide/codes/openmc.rst
@@ -1,4 +1,4 @@
-..  _OpenMC: https://mit-crpg.github.io/openmc
+..  _OpenMC: https://openmc.readthedocs.io/en/latest/index.html
 
 **Note: OpenMC supports the recommended** :ref:`UWUW`
 
@@ -40,6 +40,38 @@ then add them to a group called, "mat:Vacuum":
 ::
 
     CUBIT> group "mat:Vacuum" add vol 4 to 18
+
+
+Assigning Materials by Name (recommended)
+-----------------------------------------
+
+OpenMC materials can also be assigned by name:
+::
+
+    CUBIT> group "mat:fuel" add vol 4 to 18
+
+For this example, a material with the name attribute "fuel" must be present in
+OpenMC's ``materials.xml`` file:
+::
+   <materials>
+     <material id="40" name="fuel">
+       <density units="g/cc" value="11" />
+       <nuclide ao="1.0" name="U235" />
+     </material>
+   </materials>
+
+This method for assigning materials is recommended for use with OpenMC as it
+provides a more verbose description of the material definition and purpose.
+
+This method of assignment also allows an easy transition to the UWUW workflow
+for future models. One can embed a PyNE material library in the DAGMC model at
+any point using ``uwuw_preproc`` without modification to the material
+assignments to obtain a working UWUW model, provided that materials with
+corresponding names and appropriate definitions are in the PyNE material
+library.
+
+**Note: material names must be unique in the materials.xml file for this style**
+**of material assignment to work properly.**
 
 Surface boundary conditions
 ----------------------------

--- a/doc/usersguide/codes/openmc.rst
+++ b/doc/usersguide/codes/openmc.rst
@@ -18,8 +18,8 @@ Geometry metadata
 The DAGMC geometry file can be used to define material assignments, boundary
 conditions, and temperatures.
 
-Materials
----------
+Material Assignment
+-------------------
 
 The generic workflow description includes details on :ref:`grouping-basics`, but
 a specific naming convention is required for OpenMC. To define materials,
@@ -63,15 +63,18 @@ OpenMC's ``materials.xml`` file:
 This method for assigning materials is recommended for use with OpenMC as it
 provides a more verbose description of the material definition and purpose.
 
-This method of assignment also allows for straighforward model conversion to the
+This method of assignment also allows for straightforward model conversion to the
 UWUW workflow without material assignment modification, re-faceting, or
 re-sealing. To do this one can simply embed a PyNE material library in the
-original .h5m file at any point using ``uwuw_preproc``. No modification to the
+original .h5m file at any point using `uwuw_preproc`. No modification to the
 material assignments is necessary, provided that materials with appropriate
-names and definitions are in the PyNE material library.
+names and definitions are in the PyNE material library. After conversion to a
+UWUW format, the embedded PyNE material library will be used in place of the
+`materials.xml` file.
 
 **Note: material names must be unique in the materials.xml file for this style**
 **of material assignment to work properly.**
+
 
 Surface boundary conditions
 ----------------------------

--- a/news/PR-0616.rst
+++ b/news/PR-0616.rst
@@ -1,0 +1,11 @@
+**Added:** Documentation section on material assignment by name for OpenMC model prep.
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/src/uwuw/uwuw_preprocessor.cpp
+++ b/src/uwuw/uwuw_preprocessor.cpp
@@ -152,7 +152,7 @@ void uwuw_preprocessor::process_materials() {
 
     std::string mat_name = dmd->return_property(*s_it, "mat");
     std::string density  = dmd->return_property(*s_it, "rho");
-
+    mat_name = "mat:"+mat_name;
     // find grave or vacuum
     std::size_t found_grave = mat_name.find("Graveyard");
     std::size_t found_vacuum = mat_name.find("Vacuum");

--- a/src/uwuw/uwuw_preprocessor.cpp
+++ b/src/uwuw/uwuw_preprocessor.cpp
@@ -152,7 +152,7 @@ void uwuw_preprocessor::process_materials() {
 
     std::string mat_name = dmd->return_property(*s_it, "mat");
     std::string density  = dmd->return_property(*s_it, "rho");
-    mat_name = "mat:"+mat_name;
+
     // find grave or vacuum
     std::size_t found_grave = mat_name.find("Graveyard");
     std::size_t found_vacuum = mat_name.find("Vacuum");


### PR DESCRIPTION
## Description
An addition to documentation on model preparation for OpenMC.

## Motivation and Context
A recent [PR](https://github.com/openmc-dev/openmc/pull/1199) into OpenMC allows for materials to be assigned by name rather than ID. This is going to be the recommended workflow for DAG-OpenMC model generation.

## Changes
Updates to the OpenMC section of the documentation.

## Behavior
No behavior is changed.

