### PR TITLE
Make the MW_REG_TEST_MODELS_URL variable available to the docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,7 @@ before_install:
     MOAB_VERSION=${MOAB_VERSION}
     TRAVIS_REPO_SLUG=${TRAVIS_REPO_SLUG}
     TRAVIS_PULL_REQUEST=${TRAVIS_PULL_REQUEST}
+    MW_REG_TEST_MODELS_URL=${MW_REG_TEST_MODELS_URL}
     docker_env=${docker_env}" > ${travis_env}
   # Get the docker image
   - docker pull ${docker_image}

--- a/news/PR-0621.rst
+++ b/news/PR-0621.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* Make the MW_REG_TEST_MODELS_URL variable available to the docker image
+
+**Security:** None


### PR DESCRIPTION
This fixes the problem where all the nightly CI builds were failing. [This Travis build](https://travis-ci.org/svalinn/DAGMC/builds/510079202) shows that this PR fixes the issue.