### PR TITLE
Adding link on how to build OpenMC with DagMC enabled.

### DIFF
--- a/doc/install/openmc.rst
+++ b/doc/install/openmc.rst
@@ -41,4 +41,17 @@ If the build was successful, the binaries, libraries, header files, and tests
 will be installed to the ``bin``, ``lib``, ``include``, and ``tests``
 subdirectories of ``$INSTALL_PATH`` respectively.
 
+Finally, ensure that the DagMC library is in your ``$LD_LIBRARY_PATH``
+::
+
+   $ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/dagmc_bld/dagmc/lib
+
+Installing OpenMC with DagMC geometry enabled
+---------------------------------------------
+
+To install OpenMC with support for DagMC please refer to OpenMC's installation
+from source instructions `here <OpenMCInstallFromSource_>`_.
+
+..  _OpenMCInstallFromSource: https://openmc.readthedocs.io/en/latest/usersguide/install.html?#installing-from-source
+
 ..  include:: test_dagmc.txt

--- a/news/PR-0625.rst
+++ b/news/PR-0625.rst
@@ -1,0 +1,14 @@
+**Added:**
+
+* Note on adding DagMC libraries to LD_LIBRARY_PATH for OpenMC usage
+* Link to installation instructions for OpenMC with DagMC
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None


### PR DESCRIPTION
## Description
Adding a note about adding the path to DagMC's libraries to the user's `LD_LIBRARY_PATH` in the OpenMC install section and providing a link to the OpenMC documentation related to installing from source and enabling DagMC.

## Changes
Documentation Update

