### PR TITLE
Fix error in documentation where cmake was not pointing to the DAGMC source dir as it should

### DIFF
--- a/doc/install/configure_dag-code_header.txt
+++ b/doc/install/configure_dag-code_header.txt
@@ -5,6 +5,7 @@ First, create and enter the build directory.
 ::
 
     $ cd $HOME/dagmc_bld/DAGMC
+    $ ln -s DAGMC src
     $ mkdir bld
     $ cd bld
 

--- a/doc/install/dag-geant4.rst
+++ b/doc/install/dag-geant4.rst
@@ -41,10 +41,10 @@ The following CMake command will build DAG-Geant4, assuming you built Geant4 as
 specified in the Geant4 build instructions above.
 ::
 
-    $ cmake .. -DMOAB_DIR=$HOME/dagmc_bld/MOAB \
-               -DBUILD_GEANT4=ON \
-               -DGEANT4_DIR=$HOME/dagmc_bld/Geant4 \
-               -DCMAKE_INSTALL_PREFIX=$INSTALL_PATH
+    $ cmake ../src -DMOAB_DIR=$HOME/dagmc_bld/MOAB \
+                   -DBUILD_GEANT4=ON \
+                   -DGEANT4_DIR=$HOME/dagmc_bld/Geant4 \
+                   -DCMAKE_INSTALL_PREFIX=$INSTALL_PATH
 
 If the CMake configuration proceeded successfully, you are now ready to install
 DAGMC.

--- a/doc/install/dag-mcnp.rst
+++ b/doc/install/dag-mcnp.rst
@@ -45,49 +45,49 @@ and/or ``-DMCNP6_DATAPATH`` cmake options must be included instead.
 **Example 1:** Build the DAGMC interfaces and DAG-MCNP5.
 ::
 
-    $ cmake .. -DMOAB_DIR=$HOME/dagmc_bld/MOAB \
-               -DBUILD_MCNP5=ON \
-               -DCMAKE_INSTALL_PREFIX=$INSTALL_PATH
+    $ cmake ../src -DMOAB_DIR=$HOME/dagmc_bld/MOAB \
+                   -DBUILD_MCNP5=ON \
+                   -DCMAKE_INSTALL_PREFIX=$INSTALL_PATH
 
 **Example 2:** Build an MPI version of DAG-MCNP5.
 ::
 
-    $ cmake .. -DMOAB_DIR=$HOME/dagmc_bld/MOAB \
-               -DBUILD_MCNP5=ON \
-               -DBUILD_MCNP_MPI=ON \
-               -DCMAKE_INSTALL_PREFIX=$INSTALL_PATH
+    $ cmake ../src -DMOAB_DIR=$HOME/dagmc_bld/MOAB \
+                   -DBUILD_MCNP5=ON \
+                   -DBUILD_MCNP_MPI=ON \
+                   -DCMAKE_INSTALL_PREFIX=$INSTALL_PATH
 
 **Example 3:** Build the DAGMC interfaces and DAG-MCNP6.
 ::
 
-    $ cmake .. -DMOAB_DIR=$HOME/dagmc_bld/MOAB \
-               -DBUILD_MCNP6=ON \
-               -DCMAKE_INSTALL_PREFIX=$INSTALL_PATH
+    $ cmake ../src -DMOAB_DIR=$HOME/dagmc_bld/MOAB \
+                   -DBUILD_MCNP6=ON \
+                   -DCMAKE_INSTALL_PREFIX=$INSTALL_PATH
 
 **Example 4:** Build an MPI version of DAG-MCNP6.
 ::
 
-    $ cmake .. -DMOAB_DIR=$HOME/dagmc_bld/MOAB \
-               -DBUILD_MCNP6=ON \
-               -DBUILD_MCNP_MPI=ON \
-               -DCMAKE_INSTALL_PREFIX=$INSTALL_PATH
+    $ cmake ../src -DMOAB_DIR=$HOME/dagmc_bld/MOAB \
+                   -DBUILD_MCNP6=ON \
+                   -DBUILD_MCNP_MPI=ON \
+                   -DCMAKE_INSTALL_PREFIX=$INSTALL_PATH
 
 **Example 5:** Build both DAG-MCNP5 and DAG-MCNP6.
 ::
 
-    $ cmake .. -DMOAB_DIR=$HOME/dagmc_bld/MOAB \
-               -DBUILD_MCNP5=ON \
-               -DBUILD_MCNP6=ON \
-               -DCMAKE_INSTALL_PREFIX=$INSTALL_PATH
+    $ cmake ../src -DMOAB_DIR=$HOME/dagmc_bld/MOAB \
+                   -DBUILD_MCNP5=ON \
+                   -DBUILD_MCNP6=ON \
+                   -DCMAKE_INSTALL_PREFIX=$INSTALL_PATH
 
 **Example 6:** Build MPI versions of both DAG-MCNP5 and DAG-MCNP6.
 ::
 
-    $ cmake .. -DMOAB_DIR=$HOME/dagmc_bld/MOAB \
-               -DBUILD_MCNP5=ON \
-               -DBUILD_MCNP6=ON \
-               -DBUILD_MCNP_MPI=ON \
-               -DCMAKE_INSTALL_PREFIX=$INSTALL_PATH
+    $ cmake ../src -DMOAB_DIR=$HOME/dagmc_bld/MOAB \
+                   -DBUILD_MCNP5=ON \
+                   -DBUILD_MCNP6=ON \
+                   -DBUILD_MCNP_MPI=ON \
+                   -DCMAKE_INSTALL_PREFIX=$INSTALL_PATH
 
 If the CMake configuration proceeded successfully, you are now ready to install
 DAGMC.

--- a/doc/install/dag_multiple.rst
+++ b/doc/install/dag_multiple.rst
@@ -23,15 +23,15 @@ The following CMake command will build DAG-Geant4 and FluDAG as well as MPI
 versions of DAG-MCNP5 and DAG-MCNP6.
 ::
 
-    $ cmake .. -DMOAB_DIR=$HOME/dagmc_bld/MOAB \
-               -DBUILD_MCNP5=ON \
-               -DBUILD_MCNP6=ON \
-               -DBUILD_MCNP_MPI=ON \
-               -DBUILD_GEANT4=ON \
-               -DGEANT4_DIR=$HOME/dagmc_bld/Geant4 \
-               -DBUILD_FLUKA=ON \
-               -DFLUKA_DIR=$FLUPRO \
-               -DCMAKE_INSTALL_PREFIX=$INSTALL_PATH
+    $ cmake ../src -DMOAB_DIR=$HOME/dagmc_bld/MOAB \
+                   -DBUILD_MCNP5=ON \
+                   -DBUILD_MCNP6=ON \
+                   -DBUILD_MCNP_MPI=ON \
+                   -DBUILD_GEANT4=ON \
+                   -DGEANT4_DIR=$HOME/dagmc_bld/Geant4 \
+                   -DBUILD_FLUKA=ON \
+                   -DFLUKA_DIR=$FLUPRO \
+                   -DCMAKE_INSTALL_PREFIX=$INSTALL_PATH
 
 If the CMake configuration proceeded successfully, you are now ready to install
 DAGMC.

--- a/doc/install/fludag.rst
+++ b/doc/install/fludag.rst
@@ -27,10 +27,10 @@ The following CMake command will build FluDAG. Note that ``$FLUPRO`` should have
 previously been defined as part of the FLUKA install.
 ::
 
-    $ cmake .. -DMOAB_DIR=$HOME/dagmc_bld/MOAB \
-               -DBUILD_FLUKA=ON \
-               -DFLUKA_DIR=$FLUPRO \
-               -DCMAKE_INSTALL_PREFIX=$INSTALL_PATH
+    $ cmake ../src -DMOAB_DIR=$HOME/dagmc_bld/MOAB \
+                   -DBUILD_FLUKA=ON \
+                   -DFLUKA_DIR=$FLUPRO \
+                   -DCMAKE_INSTALL_PREFIX=$INSTALL_PATH
 
 If the CMake configuration proceeded successfully, you are now ready to install
 DAGMC.

--- a/doc/install/openmc.rst
+++ b/doc/install/openmc.rst
@@ -24,9 +24,9 @@ Installing DAGMC as a dependency of OpenMC
 
 From the build directory, run::
 
-    $ cmake .. -DMOAB_DIR=$HOME/dagmc_bld/MOAB \
-               -DBUILD_TALLY=ON \
-               -DCMAKE_INSTALL_PATH=$INSTALL_PATH
+    $ cmake ../src -DMOAB_DIR=$HOME/dagmc_bld/MOAB \
+                   -DBUILD_TALLY=ON \
+                   -DCMAKE_INSTALL_PATH=$INSTALL_PATH
 
 If the CMake configuration proceeded successfully, you are now ready to install
 DAGMC.

--- a/news/PR-0632.rst
+++ b/news/PR-0632.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+* Fix error in documentation where cmake was not pointing to the DAGMC source dir as it should
+
+**Security:** None


### PR DESCRIPTION
Adds the line `ln -s DAGMC src` and changes all instances of `cmake ..` to `cmake ../src`