### PR TITLE
updated watertight scripts to accept arguments for output filename

### DIFF
--- a/news/PR-0636.rst
+++ b/news/PR-0636.rst
@@ -1,0 +1,14 @@
+**Added:** None
+
+**Changed:** None
+
+* ``dagmc/src/make_watertight``: now accepting output_filename
+* ``dagmc/src/check_watertight``: now accepting output_filename
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+**Security:** None

--- a/src/make_watertight/build/check_watertight.cpp
+++ b/src/make_watertight/build/check_watertight.cpp
@@ -1,6 +1,6 @@
 // ********************************************************************
-// Brandon Smith
-// August 2009
+// Brandon Smith, August 2009
+// Jonathan Shimwell, September 2019
 
 // This is a function to test DagMC-style mesh for watertightness. For
 // now this will be a stand-alone code that uses MOAB. For volumes to
@@ -9,7 +9,10 @@
 // To instead use a geometrical tolerance between two vertices that are
 // considered the same, pass in a tolerance.
 //
-// input:  h5m file name, tolerance(optional)
+// input:  input_file h5m filename, 
+//         output_file h5m filename (optional), 
+//         tolerance(optional), 
+//         verbose(optional)
 // output: list of unmatched facet edges and their parent surfaces, by volume.
 
 // make CXXFLAGS=-g for debug
@@ -40,65 +43,63 @@
 #include "MBTagConventions.hpp"
 #include "moab/Range.hpp"
 #include "moab/Skinner.hpp"
+#include "moab/ProgOptions.hpp"
 
 #include "CheckWatertight.hpp"
 
-int main(int argc, char** argv) {
+int main(int argc, char* argv[]) {
 
-  // ******************************************************************
-  // Load the h5m file and create tags.
-  // ******************************************************************
+  ProgOptions po("check_watertight: a tool for preprocessing DAGMC files to test DagMC-style mesh for watertightness");
+
+  clock_t start_time = clock();
+
+  bool verbose = false;
+  bool check_topology;
+
+  std::string input_file;
+  std::string output_file;
+  double tolerance = -1.0;
+
+  po.addOpt<void>("verbose,v", "Verbose output", &verbose);
+  
+  po.addRequiredArg<std::string>("input_file", "Path to h5m DAGMC file to proccess", &input_file);
+  po.addOpt<std::string>("output_file,o", "Specify the output filename (default is to overwrite in input_file)", &output_file);
+  po.addOpt<double>("tolerance,t", "Specify the tolerance", &tolerance);
+ 
+  po.addOptionHelpHeading("Options for loading files");
+
+  po.parseCommandLine(argc, argv);
+
+  if (output_file == "")
+    output_file = input_file;
 
   static moab::Core instance;
   moab::Interface* mbi = &instance;
 
-  clock_t start_time;
-  start_time = clock();
-  // check input args
-
-  if (argc < 2 || argc > 5) {
-    std::cout << "To check using topology of facet points:              " << std::endl;
-    std::cout << "./check_watertight <filename> <verbose(true or false)>" << std::endl;
-    std::cout << "To check using geometry tolerance of facet points:    " << std::endl;
-    std::cout << "./check_watertight <filename> <verbose(true or false)> <tolerance>" << std::endl;
-    return 1;
-  }
-
-  // load file and get tolerance from input argument
+  // load file
   moab::ErrorCode result;
-  std::string filename = argv[1]; //set filename
   moab::EntityHandle input_set;
   result = mbi->create_meshset(moab::MESHSET_SET, input_set);   //create handle to meshset
   if (moab::MB_SUCCESS != result) {
     return result;
   }
 
-  result = mbi->load_file(filename.c_str(), &input_set);   //load the file into the meshset
+  result = mbi->load_file(input_file.c_str(), &input_set);   //load the file into the meshset
   if (moab::MB_SUCCESS != result) {
     // failed to load the file
     std::cout << "could not load file" << std::endl;
     return result;
   }
 
-  double tol; // tolerance for two verts to be considered the same
-  bool check_topology, verbose;
 
-  if (2 == argc) { // set topological check
-    std::cout << "topology check" << std::endl;
-    check_topology = true;
-    verbose = false;
-  } else if (3 == argc) { // set topological check with different tolerance
-    std::cout << "topology check" << std::endl;
-    check_topology = true;
-    const std::string verbose_string = argv[2];
-    verbose = (0 == verbose_string.compare("true"));
-  } else { // otherwise do geometry check
-    std::cout << "geometry check";
+  if (tolerance == -1.0){
+    std::cout << "geometry check" << std::endl;
     check_topology = false;
-    tol = atof(argv[3]);
-    std::cout << " tolerance=" << tol << std::endl;
-    const std::string verbose_string = argv[2];
-    verbose = (0 == verbose_string.compare("true"));
+  }else if (tolerance > 0){
+    std::cout << "topology check" << std::endl;
+    check_topology = true;
+  }else{
+    MB_CHK_SET_ERR(moab::MB_FAILURE, "tolerance must be positive, current value is " << tolerance);
   }
 
   // replaced much of this code with a more modular version in check_watertight_func for testing purposes
@@ -108,7 +109,7 @@ int main(int argc, char** argv) {
   // is the order of the optional variables going to be a problem?
   // (i.e. we 'skipped' the variable test)
   CheckWatertight cw = CheckWatertight(mbi);
-  result = cw.check_mesh_for_watertightness(input_set, tol, sealed, test, verbose, check_topology);
+  result = cw.check_mesh_for_watertightness(input_set, tolerance, sealed, test, verbose, check_topology);
   MB_CHK_SET_ERR(result, "could not check model for watertightness");
 
   clock_t end_time = clock();

--- a/src/make_watertight/build/check_watertight.cpp
+++ b/src/make_watertight/build/check_watertight.cpp
@@ -1,8 +1,4 @@
 // ********************************************************************
-// Brandon Smith, August 2009
-// Jonathan Shimwell, September 2019
-// Patrick Shriwise, September 2019
-
 // This is a function to test DagMC-style mesh for watertightness. For
 // now this will be a stand-alone code that uses MOAB. For volumes to
 // be watertight, the facet edges of each surface must be matched
@@ -11,6 +7,7 @@
 // considered the same, pass in a tolerance.
 //
 // input:  input_file h5m filename, 
+//         output_file h5m filename (optional), 
 //         tolerance(optional), 
 //         verbose(optional)
 // output: list of unmatched facet edges and their parent surfaces, by volume.
@@ -57,14 +54,19 @@ int main(int argc, char* argv[]) {
   bool check_topology;
 
   std::string input_file;
+  std::string output_file;
   double tolerance = -1.0;
 
   po.addOpt<void>("verbose,v", "Verbose output", &verbose);
   
   po.addRequiredArg<std::string>("input_file", "Path to h5m DAGMC file to proccess", &input_file);
+  po.addOpt<std::string>("output_file,o", "Specify the output filename (default is to overwrite in input_file)", &output_file);
   po.addOpt<double>("tolerance,t", "Specify a coincidence tolerance for triangle vertices. If no tolerance is specified, a more robust, topological check of the DAGMC mesh will occur by default.", &tolerance);
 
   po.parseCommandLine(argc, argv);
+
+  if (output_file == "")
+    output_file = input_file;
 
   static moab::Core instance;
   moab::Interface* mbi = &instance;

--- a/src/make_watertight/build/check_watertight.cpp
+++ b/src/make_watertight/build/check_watertight.cpp
@@ -65,8 +65,6 @@ int main(int argc, char* argv[]) {
   po.addRequiredArg<std::string>("input_file", "Path to h5m DAGMC file to proccess", &input_file);
   po.addOpt<std::string>("output_file,o", "Specify the output filename (default is to overwrite in input_file)", &output_file);
   po.addOpt<double>("tolerance,t", "Specify a coincidence tolerance for triangle vertices. If no tolerance is specified, a more robust, topological check of the DAGMC mesh will occur by default.", &tolerance);
- 
-  po.addOptionHelpHeading("Options for loading files");
 
   po.parseCommandLine(argc, argv);
 

--- a/src/make_watertight/build/check_watertight.cpp
+++ b/src/make_watertight/build/check_watertight.cpp
@@ -6,9 +6,9 @@
 // To instead use a geometrical tolerance between two vertices that are
 // considered the same, pass in a tolerance.
 //
-// input:  input_file h5m filename, 
-//         output_file h5m filename (optional), 
-//         tolerance(optional), 
+// input:  input_file h5m filename,
+//         output_file h5m filename (optional),
+//         tolerance(optional),
 //         verbose(optional)
 // output: list of unmatched facet edges and their parent surfaces, by volume.
 
@@ -58,7 +58,7 @@ int main(int argc, char* argv[]) {
   double tolerance = -1.0;
 
   po.addOpt<void>("verbose,v", "Verbose output", &verbose);
-  
+
   po.addRequiredArg<std::string>("input_file", "Path to h5m DAGMC file to proccess", &input_file);
   po.addOpt<std::string>("output_file,o", "Specify the output filename (default is to overwrite in input_file)", &output_file);
   po.addOpt<double>("tolerance,t", "Specify a coincidence tolerance for triangle vertices. If no tolerance is specified, a more robust, topological check of the DAGMC mesh will occur by default.", &tolerance);
@@ -87,13 +87,13 @@ int main(int argc, char* argv[]) {
   }
 
 
-  if (tolerance == -1.0){
+  if (tolerance == -1.0) {
     std::cout << "geometry check" << std::endl;
     check_topology = false;
-  }else if (tolerance > 0){
+  } else if (tolerance > 0) {
     std::cout << "topology check" << std::endl;
     check_topology = true;
-  }else{
+  } else {
     MB_CHK_SET_ERR(moab::MB_FAILURE, "A proximity tolerance of " << tolerance << " was provided. Please provide a tolerance greater than or equal to zero.");
   }
 

--- a/src/make_watertight/build/check_watertight.cpp
+++ b/src/make_watertight/build/check_watertight.cpp
@@ -99,7 +99,7 @@ int main(int argc, char* argv[]) {
     std::cout << "topology check" << std::endl;
     check_topology = true;
   }else{
-    MB_CHK_SET_ERR(moab::MB_FAILURE, "tolerance must be positive, current value is " << tolerance);
+    MB_CHK_SET_ERR(moab::MB_FAILURE, "A proximity tolerance of " << tolerance << " was provided. Please provide a tolerance greater than or equal to zero.");
   }
 
   // replaced much of this code with a more modular version in check_watertight_func for testing purposes

--- a/src/make_watertight/build/check_watertight.cpp
+++ b/src/make_watertight/build/check_watertight.cpp
@@ -11,7 +11,6 @@
 // considered the same, pass in a tolerance.
 //
 // input:  input_file h5m filename, 
-//         output_file h5m filename (optional), 
 //         tolerance(optional), 
 //         verbose(optional)
 // output: list of unmatched facet edges and their parent surfaces, by volume.
@@ -58,19 +57,14 @@ int main(int argc, char* argv[]) {
   bool check_topology;
 
   std::string input_file;
-  std::string output_file;
   double tolerance = -1.0;
 
   po.addOpt<void>("verbose,v", "Verbose output", &verbose);
   
   po.addRequiredArg<std::string>("input_file", "Path to h5m DAGMC file to proccess", &input_file);
-  po.addOpt<std::string>("output_file,o", "Specify the output filename (default is to overwrite in input_file)", &output_file);
   po.addOpt<double>("tolerance,t", "Specify a coincidence tolerance for triangle vertices. If no tolerance is specified, a more robust, topological check of the DAGMC mesh will occur by default.", &tolerance);
 
   po.parseCommandLine(argc, argv);
-
-  if (output_file == "")
-    output_file = input_file;
 
   static moab::Core instance;
   moab::Interface* mbi = &instance;

--- a/src/make_watertight/build/check_watertight.cpp
+++ b/src/make_watertight/build/check_watertight.cpp
@@ -64,7 +64,7 @@ int main(int argc, char* argv[]) {
   
   po.addRequiredArg<std::string>("input_file", "Path to h5m DAGMC file to proccess", &input_file);
   po.addOpt<std::string>("output_file,o", "Specify the output filename (default is to overwrite in input_file)", &output_file);
-  po.addOpt<double>("tolerance,t", "Specify the tolerance", &tolerance);
+  po.addOpt<double>("tolerance,t", "Specify a coincidence tolerance for triangle vertices. If no tolerance is specified, a more robust, topological check of the DAGMC mesh will occur by default.", &tolerance);
  
   po.addOptionHelpHeading("Options for loading files");
 

--- a/src/make_watertight/build/check_watertight.cpp
+++ b/src/make_watertight/build/check_watertight.cpp
@@ -1,6 +1,7 @@
 // ********************************************************************
 // Brandon Smith, August 2009
 // Jonathan Shimwell, September 2019
+// Patrick Shriwise, September 2019
 
 // This is a function to test DagMC-style mesh for watertightness. For
 // now this will be a stand-alone code that uses MOAB. For volumes to

--- a/src/make_watertight/build/make_watertight.cpp
+++ b/src/make_watertight/build/make_watertight.cpp
@@ -1,8 +1,9 @@
 // ********************************************************************
-// Brandon Smith
-// August, 2009
+// Brandon Smith August, 2009
+// Jonathan Shimwell, September 2019
 
-// input:  h5m filename, tolerance
+// input:  input_file h5m filename,
+//         output_file h5m filename (optional),
 // output: watertight h5m
 
 // make CXXFLAGS=-g for debug
@@ -23,39 +24,33 @@
 #include "moab/Range.hpp"
 #include "moab/Skinner.hpp"
 #include "moab/GeomTopoTool.hpp"
+#include "moab/ProgOptions.hpp"
 
 #include "MakeWatertight.hpp"
 
-moab::ErrorCode write_sealed_file(moab::Interface* mbi, std::string root_filename, double facet_tol, bool is_acis);
+moab::ErrorCode write_sealed_file(moab::Interface* mbi, std::string output_file);
 
-int main(int argc, char** argv) {
+int main(int argc, char* argv[]) {
 
-// ******************************************************************
-// Load the h5m file
-// ******************************************************************
+  ProgOptions po("make_watertight: a tool for preprocessing DAGMC files to seal a faceted h5m file");
 
   clock_t start_time = clock();
 
+  std::string input_file;
+  std::string output_file;
+
+  po.addRequiredArg<std::string>("input_file", "Path to h5m DAGMC file to proccess", &input_file);
+  po.addOpt<std::string>("output_file,o", "Specify the output filename (default watertight_dagmc.h5m)", &output_file);
+ 
+  po.addOptionHelpHeading("Options for loading files");
+
+  po.parseCommandLine(argc, argv);
+
+  if (output_file == "")
+    output_file = "watertight_dagmc.h5m";
+
   static moab::Core instance;
   moab::Interface* mbi = &instance;
-
-  // check input args
-  if (2 > argc || 3 < argc) {
-    std::cout << "To zip a faceted h5m file:" << std::endl;
-    std::cout << "$ ./make_watertight <input_file.h5m>" << std::endl;
-    std::cout << "To facet and zip an ACIS file using the default facet tolerance:" << std::endl;
-    std::cout << "$ ./make_watertight <input_file.sat>" << std::endl;
-    std::cout << "To facet and zip an ACIS file using a specified facet tolerance:" << std::endl;
-    std::cout << "$ ./make_watertight <input_file.sat> <facet_tolerance>" << std::endl;
-    return moab::MB_FAILURE;
-  }
-
-  // The root name does not have an extension
-  std::string input_name = argv[1];
-  std::string root_name = argv[1];
-  int len = root_name.length();
-  root_name.erase(len - 4);
-  bool is_acis;
 
   // load the input file
   moab::ErrorCode result, rval;
@@ -67,15 +62,12 @@ int main(int argc, char** argv) {
 
   std::cout << "Loading input file..." << std::endl;
 
-  // If reading an h5m file, the facet tolerance has already been determined.
-  // Read the facet_tol from the file_set. There should only be one input
-  // argument.
+  // When reading an h5m file, the facet tolerance has already been determined.
+  // Read the facet_tol from the file_set.
 
-  if (std::string::npos != input_name.find("h5m") && (2 == argc)) {
-    rval = mbi->load_file(input_name.c_str(), &input_set);
-    MB_CHK_SET_ERR(rval, "failed to load_file 0");
-    is_acis = false;
-  }
+  rval = mbi->load_file(input_file.c_str(), &input_set);
+  MB_CHK_SET_ERR(rval, "Failed to open file: " << input_file);
+
   //loading completed at this point
   clock_t load_time = clock();
   //seal the input mesh set
@@ -88,7 +80,7 @@ int main(int argc, char** argv) {
   //write file
   clock_t zip_time = clock();
   std::cout << "Writing zipped file..." << std::endl;
-  write_sealed_file(mbi, root_name, facet_tol, is_acis);
+  write_sealed_file(mbi, output_file);
   MB_CHK_SET_ERR(result, "could not write the sealed mesh to a new file");
 
 
@@ -101,18 +93,11 @@ int main(int argc, char** argv) {
   return 0;
 }
 
-moab::ErrorCode write_sealed_file(moab::Interface* mbi, std::string root_filename, double facet_tol, bool is_acis) {
+moab::ErrorCode write_sealed_file(moab::Interface* mbi, std::string output_file) {
 
   moab::ErrorCode result;
-  std::string output_filename;
-  if (is_acis) {
-    std::stringstream facet_tol_ss;
-    facet_tol_ss << facet_tol;
-    output_filename = root_filename + "_" + facet_tol_ss.str() + "_zip.h5m";
-  } else {
-    output_filename = root_filename + "_zip.h5m";
-  }
-  result = mbi->write_mesh(output_filename.c_str());
+
+  result = mbi->write_mesh(output_file.c_str());
   if (moab::MB_SUCCESS != result)
     std::cout << "result= " << result << std::endl;
   assert(moab::MB_SUCCESS == result);

--- a/src/make_watertight/build/make_watertight.cpp
+++ b/src/make_watertight/build/make_watertight.cpp
@@ -24,6 +24,7 @@
 #include "moab/ProgOptions.hpp"
 
 #include "MakeWatertight.hpp"
+#include "CheckWatertight.hpp"
 
 moab::ErrorCode write_sealed_file(moab::Interface* mbi, std::string output_file);
 
@@ -73,17 +74,29 @@ int main(int argc, char* argv[]) {
 
 
   //write file
-  clock_t zip_time = clock();
-  std::cout << "Writing zipped file..." << std::endl;
+  clock_t seal_time = clock();
+  std::cout << "Writing sealed file..." << std::endl;
   write_sealed_file(mbi, output_file);
   MB_CHK_SET_ERR(result, "could not write the sealed mesh to a new file");
 
-
   clock_t write_time = clock();
+
+  bool sealed;
+  CheckWatertight cw = CheckWatertight(mbi);
+  result = cw.check_mesh_for_watertightness(input_set, -1.0, sealed);
+  MB_CHK_SET_ERR(result, "could not check model for watertightness");
+
+  std::cout << "Topological check performed" << std::endl;
+  std::cout << "To perform a tolerance based check run the check_Watertight tool" << std::endl;
+  std::cout << "$ check_watertight <dagmc_file> -t <tolerance> " << std::endl;
+
+
+  clock_t check_time = clock();
   std::cout << "Timing(seconds): loading="
             << (double)(load_time - start_time) / CLOCKS_PER_SEC << ", sealing="
-            << (double)(zip_time  - load_time) / CLOCKS_PER_SEC << ", writing="
-            << (double)(write_time - zip_time) / CLOCKS_PER_SEC << std::endl;
+            << (double)(seal_time  - load_time) / CLOCKS_PER_SEC << ", writing="
+            << (double)(write_time - seal_time) / CLOCKS_PER_SEC << ", checking="
+            << (double)(check_time - write_time) / CLOCKS_PER_SEC << std::endl;
 
   return 0;
 }

--- a/src/make_watertight/build/make_watertight.cpp
+++ b/src/make_watertight/build/make_watertight.cpp
@@ -1,6 +1,7 @@
 // ********************************************************************
 // Brandon Smith August, 2009
 // Jonathan Shimwell, September 2019
+// Patrick Shriwise, September 2019
 
 // input:  input_file h5m filename,
 //         output_file h5m filename (optional),

--- a/src/make_watertight/build/make_watertight.cpp
+++ b/src/make_watertight/build/make_watertight.cpp
@@ -1,8 +1,4 @@
 // ********************************************************************
-// Brandon Smith, August 2009
-// Jonathan Shimwell, September 2019
-// Patrick Shriwise, September 2019
-
 // input:  input_file h5m filename,
 //         output_file h5m filename (optional),
 // output: watertight h5m

--- a/src/make_watertight/build/make_watertight.cpp
+++ b/src/make_watertight/build/make_watertight.cpp
@@ -1,5 +1,5 @@
 // ********************************************************************
-// Brandon Smith August, 2009
+// Brandon Smith, August 2009
 // Jonathan Shimwell, September 2019
 // Patrick Shriwise, September 2019
 
@@ -43,8 +43,6 @@ int main(int argc, char* argv[]) {
   po.addRequiredArg<std::string>("input_file", "Path to h5m DAGMC file to proccess", &input_file);
   po.addOpt<std::string>("output_file,o", "Specify the output filename (default watertight_dagmc.h5m)", &output_file);
  
-  po.addOptionHelpHeading("Options for loading files");
-
   po.parseCommandLine(argc, argv);
 
   if (output_file == "")

--- a/src/make_watertight/build/make_watertight.cpp
+++ b/src/make_watertight/build/make_watertight.cpp
@@ -39,7 +39,7 @@ int main(int argc, char* argv[]) {
 
   po.addRequiredArg<std::string>("input_file", "Path to h5m DAGMC file to proccess", &input_file);
   po.addOpt<std::string>("output_file,o", "Specify the output filename (default watertight_dagmc.h5m)", &output_file);
- 
+
   po.parseCommandLine(argc, argv);
 
   if (output_file == "")


### PR DESCRIPTION
## Description
This update allows users to specify the name of the output file produced when using make_watertight or check_watertight. 

## Motivation and Context
Additional functionality of allowing filename to be specified is handy.
The script arguments can also now be found from the terminal with the standard -h or --help option
The number of lines of code in the scripts were reduced and are now more maintainable due to the use of the more modern argument handling method

## Changes
additional user functionality

## Behavior
make_watertight dagmc.h5m -----> dagmc_.zip.h5m
make_watertight dagmc.h5m -o watertight_dagmc.h5m -----> watertight_dagmc_.zip.h5m

## News file
PR-0636.rst
