### PR TITLE
add news checker in the CI-test

### DIFF
--- a/news/news_test.rst
+++ b/news/news_test.rst
@@ -1,0 +1,12 @@
+**Added:** None
+* script and CI implementation ensuring at least 1 news file have been recreated
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/news/news_test.sh
+++ b/news/news_test.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# folder to look for addition
+folder=$1
+
+# default main repo setup
+master_repo="https://github.com/svalinn/dagmc.git"
+default_branch="develop"
+
+
+# setup temp remote 
+git_remote_name=ci_news_`git log --pretty=format:'%h' -n 1`
+git remote add ${git_remote_name} ${master_repo}
+git fetch ${git_remote_name}
+
+# diff against temp remote
+added_news_file=$((`git diff ${git_remote_name}/${default_branch} --name-only $folder |wc -l`))
+
+# cleaning temp remote
+git remote remove ${git_remote_name}
+
+
+# analysing the diff and returning accordingly
+if [ $added_news_file -eq 0 ]; then
+    exit 1
+fi


### PR DESCRIPTION
## Description
Add a news checker to ensure at least one news file is associated with a PR

## Motivation and Context
We are relying on those news files, let's enforce them
## Changes
just add a small script...
