### PR TITLE
Apply code review changes to make_watertight files

### DIFF
--- a/news/PR-0666.rst
+++ b/news/PR-0666.rst
@@ -1,0 +1,21 @@
+**Added:** None
+
+**Changed:** None
+
+- Applied changes from PullRequest to make_watertight files
+
+  - remove commented code blocks that are either outdated or are debug statements
+  - improvements to some logic for clarity
+  - use of standard library containers to avoid potential memory leaks in Arc.cpp/Gen.cpp
+  - improvements to struct/variable names
+  - declared variables for "magic numbers"
+  - passing by const reference where possible to avoid unnecessary memory allocation
+  - removed an unused function (Arc::create_loops_from_oriented_edges_fast)
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/src/make_watertight/Arc.cpp
+++ b/src/make_watertight/Arc.cpp
@@ -125,7 +125,8 @@ moab::ErrorCode Arc::remove_opposite_pairs_of_edges_fast(moab::Range& edges, con
 
   // populate edge array, used only for searching
   unsigned n_orig_edges = edges.size();
-  edge* my_edges = new edge[n_orig_edges];
+  std::vector<Edge> my_edges(n_orig_edges);
+  // edge* my_edges = new edge[n_orig_edges];
   unsigned j = 0;
   for (moab::Range::const_iterator i = edges.begin(); i != edges.end(); ++i) {
     // get the endpoints of the edge
@@ -151,7 +152,7 @@ moab::ErrorCode Arc::remove_opposite_pairs_of_edges_fast(moab::Range& edges, con
   }
 
   // sort edge array
-  qsort(my_edges, n_orig_edges, sizeof(struct edge), compare_edge);
+  qsort(my_edges.data(), n_orig_edges, sizeof(struct Edge), compare_edge);
 
   // find duplicate edges
   j = 0;
@@ -171,7 +172,6 @@ moab::ErrorCode Arc::remove_opposite_pairs_of_edges_fast(moab::Range& edges, con
       edges = subtract(edges, duplicate_edges);
       rval = MBI()->delete_entities(duplicate_edges);
       if (moab::MB_SUCCESS != rval) {
-        delete[] my_edges;
         MB_CHK_SET_ERR(moab::MB_FAILURE, "cannot delete edge");
       }
       if (debug) {
@@ -183,7 +183,6 @@ moab::ErrorCode Arc::remove_opposite_pairs_of_edges_fast(moab::Range& edges, con
     j = i;
   }
 
-  delete[] my_edges;
   return moab::MB_SUCCESS;
 }
 
@@ -257,7 +256,7 @@ moab::ErrorCode Arc::create_loops_from_oriented_edges_fast(moab::Range edges,
                                                            std::vector< std::vector<moab::EntityHandle> >& loops_of_edges,
                                                            const bool debug) {
   // place all edges in map
-  std::multimap<moab::EntityHandle, edge> my_edges;
+  std::multimap<moab::EntityHandle, Edge> my_edges;
   moab::ErrorCode rval;
   for (moab::Range::const_iterator i = edges.begin(); i != edges.end(); ++i) {
     // get the endpoints of the edge
@@ -268,11 +267,11 @@ moab::ErrorCode Arc::create_loops_from_oriented_edges_fast(moab::Range edges,
       MB_CHK_SET_ERR(moab::MB_FAILURE, "could not get connectivity");
     }
     // store the edges
-    edge temp;
+    Edge temp;
     temp.edge = *i;
     temp.v0   = endpts[0];
     temp.v1   = endpts[1];
-    my_edges.insert(std::pair<moab::EntityHandle, edge>(temp.v0, temp));
+    my_edges.insert(std::pair<moab::EntityHandle, Edge>(temp.v0, temp));
   }
   std::cout << "error: function not complete" << std::endl;
   return moab::MB_FAILURE;

--- a/src/make_watertight/Arc.cpp
+++ b/src/make_watertight/Arc.cpp
@@ -126,7 +126,6 @@ moab::ErrorCode Arc::remove_opposite_pairs_of_edges_fast(moab::Range& edges, con
   // populate edge array, used only for searching
   unsigned n_orig_edges = edges.size();
   std::vector<Edge> my_edges(n_orig_edges);
-  // edge* my_edges = new edge[n_orig_edges];
   unsigned j = 0;
   for (moab::Range::const_iterator i = edges.begin(); i != edges.end(); ++i) {
     // get the endpoints of the edge

--- a/src/make_watertight/Arc.cpp
+++ b/src/make_watertight/Arc.cpp
@@ -217,7 +217,6 @@ moab::ErrorCode Arc::get_next_oriented_edge(const moab::Range edges,
       std::cout << "result=" << result
                 << " could not get connectivity of edge" << std::endl;
       return result;
-      //print_edge( *i );
     }
     assert(moab::MB_SUCCESS == result);
     assert(2 == n_verts);
@@ -245,37 +244,11 @@ moab::ErrorCode Arc::get_next_oriented_edge(const moab::Range edges,
     std::cout << "get_next_oriented_edge: " << adj_edges.size() <<
               " possible edges indicates a pinch point." << std::endl;
     result = MBI()->list_entity(end_verts[1]);
-    //assert(moab::MB_SUCCESS == result);
-    //return moab::MB_MULTIPLE_ENTITIES_FOUND;
+    if (result != moab::MB_SUCCESS) {
+      return moab::MB_MULTIPLE_ENTITIES_FOUND;
+    }
     next_edge = adj_edges.front();
   }
-  return moab::MB_SUCCESS;
-}
-
-moab::ErrorCode Arc::create_loops_from_oriented_edges_fast(moab::Range edges,
-                                                           std::vector< std::vector<moab::EntityHandle> >& loops_of_edges,
-                                                           const bool debug) {
-  // place all edges in map
-  std::multimap<moab::EntityHandle, Edge> my_edges;
-  moab::ErrorCode rval;
-  for (moab::Range::const_iterator i = edges.begin(); i != edges.end(); ++i) {
-    // get the endpoints of the edge
-    const moab::EntityHandle* endpts;
-    int n_verts;
-    rval = MBI()->get_connectivity(*i, endpts, n_verts);
-    if (moab::MB_SUCCESS != rval || 2 != n_verts) {
-      MB_CHK_SET_ERR(moab::MB_FAILURE, "could not get connectivity");
-    }
-    // store the edges
-    Edge temp;
-    temp.edge = *i;
-    temp.v0   = endpts[0];
-    temp.v1   = endpts[1];
-    my_edges.insert(std::pair<moab::EntityHandle, Edge>(temp.v0, temp));
-  }
-  std::cout << "error: function not complete" << std::endl;
-  return moab::MB_FAILURE;
-
   return moab::MB_SUCCESS;
 }
 
@@ -343,25 +316,20 @@ moab::ErrorCode Arc::create_loops_from_oriented_edges(moab::Range edges,
         return result;
       }
 
-      // if the next edge was found
-      if (0 != next_edge) {
-        // add it to the loop
-        loop_of_edges.push_back(next_edge);
-        if (debug)
-          std::cout << "push_back: " << next_edge << std::endl;
-        n_edges_out++;
+      // if the next edge was not found, we're done
+      if (0 == next_edge) { break; }
 
-        // remove the edge from the possible edges
-        edges.erase(next_edge);
+      // add it to the loop
+      loop_of_edges.push_back(next_edge);
+      if (debug)
+        std::cout << "push_back: " << next_edge << std::endl;
+      n_edges_out++;
 
-        // set the new reference vertex
-        edge = next_edge;
+      // remove the edge from the possible edges
+      edges.erase(next_edge);
 
-        // if another edge was not found
-      } else {
-        break;
-
-      }
+      // set the new reference vertex
+      edge = next_edge;
     }
 
     // check to ensure the arc is closed
@@ -514,9 +482,13 @@ moab::ErrorCode Arc::merge_curves(moab::Range curve_sets, const double facet_tol
     moab::EntityHandle back_endpt  = curve[curve.size() - 1];
     // ADD CODE TO HANDLE SPECIAL CASES!!
     if (front_endpt == back_endpt) { // special case
+      std::cerr << "Warning: Special case hit in merge_curves: ";
       if (0 == gen->length(curve)) { // point curve
+        std::cerr << "point curve";
       } else {                      // circle
+        std::cerr << "circle";
       }
+      std::cerr << std::endl;
     } else {                        // normal curve
       endpoints.insert(front_endpt);
       endpoints.insert(back_endpt);
@@ -526,7 +498,7 @@ moab::ErrorCode Arc::merge_curves(moab::Range curve_sets, const double facet_tol
   // add endpoints to kd-tree. Tree must track ownership to know when verts are
   // merged away (deleted).
 
-  moab::AdaptiveKDTree kdtree(MBI()); //, 0, MESHSET_TRACK_OWNER);
+  moab::AdaptiveKDTree kdtree(MBI());
   moab::EntityHandle root;
 
   //set tree options
@@ -663,7 +635,7 @@ moab::ErrorCode Arc::merge_curves(moab::Range curve_sets, const double facet_tol
         result = zip->merge_verts(curve_i_verts.back(), curve_j_verts.back(),
                                   curve_i_verts, curve_j_verts);
         if (moab::MB_SUCCESS != result)
-          std::cout << result << std::endl;
+          std::cout << "Failed to merge vertices with error: " << result << std::endl;
         assert(moab::MB_SUCCESS == result);
       }
 

--- a/src/make_watertight/Arc.cpp
+++ b/src/make_watertight/Arc.cpp
@@ -637,7 +637,7 @@ moab::ErrorCode Arc::merge_curves(moab::Range curve_sets, const double facet_tol
         result = zip->merge_verts(curve_i_verts.back(), curve_j_verts.back(),
                                   curve_i_verts, curve_j_verts);
         if (moab::MB_SUCCESS != result)
-          std::cout << "Failed to merge vertices with error: " << result << std::endl;
+          std::cerr << "Failed to merge vertices with error: " << result << std::endl;
         assert(moab::MB_SUCCESS == result);
       }
 
@@ -683,4 +683,3 @@ moab::ErrorCode Arc::merge_curves(moab::Range curve_sets, const double facet_tol
   }
   return moab::MB_SUCCESS;
 }
-

--- a/src/make_watertight/Arc.cpp
+++ b/src/make_watertight/Arc.cpp
@@ -317,7 +317,9 @@ moab::ErrorCode Arc::create_loops_from_oriented_edges(moab::Range edges,
       }
 
       // if the next edge was not found, we're done
-      if (0 == next_edge) { break; }
+      if (0 == next_edge) {
+        break;
+      }
 
       // add it to the loop
       loop_of_edges.push_back(next_edge);

--- a/src/make_watertight/Arc.hpp
+++ b/src/make_watertight/Arc.hpp
@@ -70,7 +70,7 @@ class Arc {
 
   /// goes through curve_sets and finds any curves with coincident ( dist. apart <= FACET_TOL) front and back points.
   /// it then merges the curves topologically. Any merged curves aren't deleted until prepare surfaces.
-  moab::ErrorCode merge_curves(moab::Range curve_sets, const double facet_tol,
+  moab::ErrorCode merge_curves(moab::Range curve_sets, const double FACET_TOL,
                                moab::Tag idTag, moab::Tag merge_tag, const bool debug);
 };
 

--- a/src/make_watertight/Arc.hpp
+++ b/src/make_watertight/Arc.hpp
@@ -50,9 +50,6 @@ class Arc {
                                                  moab::EntityHandle& edge_out,
                                                  moab::EntityHandle& vertex_out);
 
-  moab::ErrorCode create_loops_from_oriented_edges_fast(moab::Range edges,
-                                                        std::vector< std::vector<moab::EntityHandle> >& loops_of_edges,
-                                                        const bool debug);
   moab::ErrorCode create_loops_from_oriented_edges(moab::Range edges,
                                                    std::vector< std::vector<moab::EntityHandle> >& loops_of_edges,
                                                    const bool debug);

--- a/src/make_watertight/Arc.hpp
+++ b/src/make_watertight/Arc.hpp
@@ -73,7 +73,7 @@ class Arc {
 
   /// goes through curve_sets and finds any curves with coincident ( dist. apart <= FACET_TOL) front and back points.
   /// it then merges the curves topologically. Any merged curves aren't deleted until prepare surfaces.
-  moab::ErrorCode merge_curves(moab::Range curve_sets, const double FACET_TOL,
+  moab::ErrorCode merge_curves(moab::Range curve_sets, const double facet_tol,
                                moab::Tag idTag, moab::Tag merge_tag, const bool debug);
 };
 

--- a/src/make_watertight/CMakeLists.txt
+++ b/src/make_watertight/CMakeLists.txt
@@ -1,4 +1,3 @@
-message("")
 
 file(GLOB SRC_FILES "*.cpp")
 file(GLOB PUB_HEADERS "*.hpp")

--- a/src/make_watertight/CMakeLists.txt
+++ b/src/make_watertight/CMakeLists.txt
@@ -1,3 +1,4 @@
+message("")
 
 file(GLOB SRC_FILES "*.cpp")
 file(GLOB PUB_HEADERS "*.hpp")

--- a/src/make_watertight/CheckWatertight.cpp
+++ b/src/make_watertight/CheckWatertight.cpp
@@ -81,16 +81,6 @@ moab::ErrorCode CheckWatertight::check_mesh_for_watertightness(moab::EntityHandl
   if (moab::MB_SUCCESS != result) { // failed to get edge data
     return result; // failed
   }
-//10/11/13
-//removed as a result of the change from the gen::find_skin function to the moab::Skinner:find_skin function
-  /*
-    result = MBI()->delete_entities( edges ); //otherwise delete all edge
-
-    if(moab::MB_SUCCESS != result) // failed to delete edge data
-      {
-        return result; // failed
-      }
-  */
   // loop over each volume meshset
   int vol_counter = 0;
   for (moab::Range::iterator i = vol_sets.begin(); i != vol_sets.end(); ++i) {
@@ -128,7 +118,6 @@ moab::ErrorCode CheckWatertight::check_mesh_for_watertightness(moab::EntityHandl
     }
 
     // save the edges in a vector that is large enough to avoid resizing
-    // presumably some kind of efficiency thing?? ad ??
     std::vector<coords_and_id> the_coords_and_id;
     the_coords_and_id.reserve(n_tris);
 
@@ -224,20 +213,6 @@ moab::ErrorCode CheckWatertight::check_mesh_for_watertightness(moab::EntityHandl
         temp.matched = false;
         the_coords_and_id.push_back(temp);
       }
-      //10/10/13
-      // Removed the following to avoid altering the data set at all
-      // -No need to delete skin_edges with the moab:Skinner find_skin function
-      // -skin_edges size will be reset to zero upon new moab::Range skin_edges; call
-      // clean up the edges for the next find_skin call
-      //result = MBI()->delete_entities( skin_edges );
-      //if(moab::MB_SUCCESS != result) return result;
-
-      //10/10/13
-      // - No ned to ensure edges aren't in the meshset with moab::Skinner find_skin function
-      //int n_edges;
-      //result = MBI()->get_number_entities_by_type(0, moab::MBEDGE, n_edges );
-      //if(moab::MB_SUCCESS != result) return result;
-      //if(0 != n_edges) MB_CHK_SET_ERR(moab::MB_MULTIPLE_ENTITIES_FOUND,"n_edges not equal to zero");
     }
 
     // sort the edges by the first vert. The first vert has a lower handle than the second.
@@ -271,7 +246,6 @@ moab::ErrorCode CheckWatertight::check_mesh_for_watertightness(moab::EntityHandl
               the_coords_and_id[j].vert2 == the_coords_and_id[k].vert2) {
             the_coords_and_id[j].matched = true;
             the_coords_and_id[k].matched = true;
-            //std::cout<< "matched by handle" << std::endl;
             break;
           }
         } else {
@@ -292,7 +266,6 @@ moab::ErrorCode CheckWatertight::check_mesh_for_watertightness(moab::EntityHandl
           if (d0 < tol * tol && d1 < tol * tol) {
             the_coords_and_id[j].matched = true;
             the_coords_and_id[k].matched = true;
-            //std::cout<< "matched by proximity" << std::endl;
             break;
           }
           // Due to the sort, once the x-coords are out of tolerance, a match

--- a/src/make_watertight/CheckWatertight.hpp
+++ b/src/make_watertight/CheckWatertight.hpp
@@ -78,26 +78,23 @@ inline int compare_by_coords(const void* a, const void* b) {
             if (ia->z2 == ib->z2) {
               return ia->surf_id - ib->surf_id;
             } else {
-              return (ia->z2 > ib->z2) - (ia->z2 < ib->z2);
+              return (ia->z2 > ib->z2) ? 1 : -1;
             }
           } else {
-            return (ia->y2 > ib->y2) - (ia->y2 < ib->y2);
+            return (ia->y2 > ib->y2) ? 1 : -1;
           }
         } else {
-          return (ia->x2 > ib->x2) - (ia->x2 < ib->x2);
+          return (ia->x2 > ib->x2) ? 1 : -1;
         }
       } else {
-        return (ia->z1 > ib->z1) - (ia->z1 < ib->z1);
+        return (ia->z1 > ib->z1) ? 1 : -1;
       }
     } else {
-      return (ia->y1 > ib->y1) - (ia->y1 < ib->y1);;
+      return (ia->y1 > ib->y1) ? 1 : -1;
     }
   } else {
-    return (ia->x1 > ib->x1) - (ia->x1 < ib->x1);
+    return (ia->x1 > ib->x1) ? 1 : -1;
   }
-  /* float comparison: returns negative if b > a
-     and positive if a > b. We multiplied result by 100.0
-     to preserve decimal fraction */
 }
 
 #endif

--- a/src/make_watertight/Cleanup.cpp
+++ b/src/make_watertight/Cleanup.cpp
@@ -223,7 +223,9 @@ moab::ErrorCode Cleanup::delete_small_edges(const moab::Range& surfaces, const d
       // check to see if the endpoints part of the skin
       bool endpt0_is_skin = !adj_skin_edges0.empty();
       bool endpt1_is_skin = !adj_skin_edges1.empty();
-      if (endpt0_is_skin && endpt1_is_skin) { continue; }
+      if (endpt0_is_skin && endpt1_is_skin) {
+        continue;
+      }
 
       // Keep the skin endpt, and delete the other endpt
       moab::EntityHandle keep_endpt, delete_endpt;

--- a/src/make_watertight/Cleanup.cpp
+++ b/src/make_watertight/Cleanup.cpp
@@ -115,7 +115,6 @@ moab::ErrorCode Cleanup::delete_small_edges(const moab::Range& surfaces, const d
 
     // get the skin first, because my find_skin does not check before creating edges.
     moab::Range skin_edges;
-    //result = gen->find_skin( tris, 1, skin_edges, false );
     moab::Skinner tool(MBI());
     result = tool.find_skin(0, tris, 1, skin_edges, false);
     assert(moab::MB_SUCCESS == result);
@@ -152,7 +151,7 @@ moab::ErrorCode Cleanup::delete_small_edges(const moab::Range& surfaces, const d
         MBI()->list_entities(duplicate_edges);
       assert(1 == duplicate_edges.size());
 
-      // if the edge length is less than MERGE_TOL do nothing
+      // if the edge length is less than FACET_TOL do nothing
       if (FACET_TOL < gen->dist_between_verts(endpts[0], endpts[1]))
         continue;
 
@@ -208,11 +207,6 @@ moab::ErrorCode Cleanup::delete_small_edges(const moab::Range& surfaces, const d
       }
       assert(3 <= adj_edges0.size());
       moab::Range adj_skin_edges0 = intersect(adj_edges0, skin_edges);
-      bool endpt0_is_skin;
-      if (adj_skin_edges0.empty())
-        endpt0_is_skin = false;
-      else
-        endpt0_is_skin = true;
 
       moab::Range adj_edges1;
       result = MBI()->get_adjacencies(&endpts[1], 1, 1, true, adj_edges1);
@@ -225,13 +219,11 @@ moab::ErrorCode Cleanup::delete_small_edges(const moab::Range& surfaces, const d
       }
       assert(3 <= adj_edges1.size());
       moab::Range adj_skin_edges1 = intersect(adj_edges1, skin_edges);
-      bool endpt1_is_skin;
-      if (adj_skin_edges1.empty())
-        endpt1_is_skin = false;
-      else
-        endpt1_is_skin = true;
-      if (endpt0_is_skin && endpt1_is_skin)
-        continue;
+
+      // check to see if the endpoints part of the skin
+      bool endpt0_is_skin = !adj_skin_edges0.empty();
+      bool endpt1_is_skin = !adj_skin_edges1.empty();
+      if (endpt0_is_skin && endpt1_is_skin) { continue; }
 
       // Keep the skin endpt, and delete the other endpt
       moab::EntityHandle keep_endpt, delete_endpt;

--- a/src/make_watertight/Gen.cpp
+++ b/src/make_watertight/Gen.cpp
@@ -57,8 +57,7 @@ void Gen::moab_printer(moab::ErrorCode error_code) {
   }
   if (error_code == moab::MB_FAILURE) {
     std::cerr << "ERROR: moab::MB_FAILURE" << std::endl;
-  }
-  else {
+  } else {
     std::cerr << "ERROR CODE NOT RECOGNIZED" << std::endl;
   }
   return;

--- a/src/make_watertight/Gen.cpp
+++ b/src/make_watertight/Gen.cpp
@@ -1283,8 +1283,8 @@ moab::ErrorCode Gen::dist_between_arcs(bool debug,
 // qsort struct comparision function
 // If the first handle is the same, compare the second
 int compare_edge(const void* a, const void* b) {
-  struct edge* ia = (struct edge*)a;
-  struct edge* ib = (struct edge*)b;
+  struct Edge* ia = (struct Edge*)a;
+  struct Edge* ib = (struct Edge*)b;
   if (ia->v0 == ib->v0) {
     return (int)(ia->v1 - ib->v1);
   } else {
@@ -1329,7 +1329,7 @@ moab::ErrorCode Gen::find_skin(moab::Range tris, const int dim,
   assert(0 == n_edges);
 
   // Get connectivity. Do not create edges.
-  edge* edges = new edge[3 * tris.size()];
+  std::vector<Edge> edges(3 * tris.size());
   int n_verts;
   int ii = 0;
   for (moab::Range::iterator i = tris.begin(); i != tris.end(); i++) {
@@ -1362,7 +1362,7 @@ moab::ErrorCode Gen::find_skin(moab::Range tris, const int dim,
 
   // Sort by first handle, then second handle. Do not sort the extra edge on the
   // back.
-  qsort(edges, 3 * tris.size(), sizeof(struct edge), compare_edge);
+  qsort(edges.data(), 3 * tris.size(), sizeof(struct Edge), compare_edge);
 
   // Go through array, saving edges that are not paired.
   for (unsigned int i = 0; i < 3 * tris.size(); i++) {
@@ -1398,7 +1398,6 @@ moab::ErrorCode Gen::find_skin(moab::Range tris, const int dim,
       skin_edges.insert(edge);
     }
   }
-  delete[] edges;
   return moab::MB_SUCCESS;
 }
 

--- a/src/make_watertight/Gen.cpp
+++ b/src/make_watertight/Gen.cpp
@@ -58,6 +58,9 @@ void Gen::moab_printer(moab::ErrorCode error_code) {
   if (error_code == moab::MB_FAILURE) {
     std::cerr << "ERROR: moab::MB_FAILURE" << std::endl;
   }
+  else {
+    std::cerr << "ERROR CODE NOT RECOGNIZED" << std::endl;
+  }
   return;
 }
 
@@ -69,7 +72,7 @@ void Gen::print_vertex_cubit(const moab::EntityHandle vertex) {
 
   moab::ErrorCode result;
   double coords[3];
-  int n_precision = 20;
+  const int n_precision = 20;
   result = MBI()->get_coords(&vertex, 1, coords);
   assert(moab::MB_SUCCESS == result);
   std::cout << "  create vertex "
@@ -214,7 +217,7 @@ void Gen::print_loop(const std::vector<moab::EntityHandle> loop_of_verts) {
 /// For efficiency: only get_coords on the reference vertex once
 ///                 if specified, limit search length along curve
 moab::ErrorCode Gen::find_closest_vert(const moab::EntityHandle reference_vert,
-                                       const std::vector<moab::EntityHandle> arc_of_verts,
+                                       const std::vector<moab::EntityHandle>& arc_of_verts,
                                        unsigned& position,
                                        const double dist_limit) {
   moab::ErrorCode rval;
@@ -264,7 +267,7 @@ moab::ErrorCode Gen::find_closest_vert(const moab::EntityHandle reference_vert,
 // This ensure that both are returned as candidates.
 moab::ErrorCode Gen::find_closest_vert(const double tol,
                                        const moab::EntityHandle reference_vert,
-                                       const std::vector<moab::EntityHandle> loop_of_verts,
+                                       const std::vector<moab::EntityHandle>& loop_of_verts,
                                        std::vector<unsigned>& positions,
                                        std::vector<double>& dists) {
 
@@ -305,7 +308,7 @@ moab::ErrorCode Gen::merge_vertices(moab::Range verts /* in */, const double tol
   const double SQR_TOL = tol * tol;
   // Clean up the created tree, and track verts so that if merged away they are
   // removed from the tree.
-  moab::AdaptiveKDTree kdtree(MBI()); //, true, 0, moab::MESHSET_TRACK_OWNER);
+  moab::AdaptiveKDTree kdtree(MBI());
   // initialize the KD Tree
   moab::EntityHandle root;
   const char settings[] = "MAX_PER_LEAF=6;MAX_DEPTH=50;SPLITS_PER_DIR=1;PLANE_SET=2;MESHSET_FLAGS=0x1;TAG_NAME=0";
@@ -327,8 +330,12 @@ moab::ErrorCode Gen::merge_vertices(moab::Range verts /* in */, const double tol
       std::vector<moab::EntityHandle> leaf_verts;
       result = MBI()->get_entities_by_type(leaves_out[j], moab::MBVERTEX, leaf_verts);
       assert(moab::MB_SUCCESS == result);
-      if (100 < leaf_verts.size())
+
+      // write number of leaf verts to screen if there is an abnormally high number of them
+      const int large_leaf_limit = 100;
+      if (leaf_verts.size() > large_leaf_limit)
         std::cout << "*i=" << *i << " leaf_verts.size()=" << leaf_verts.size() << std::endl;
+
       for (unsigned int k = 0; k < leaf_verts.size(); k++) {
         if (leaf_verts[k] == *i)
           continue;
@@ -357,7 +364,7 @@ moab::ErrorCode Gen::merge_vertices(moab::Range verts /* in */, const double tol
 
 moab::ErrorCode Gen::squared_dist_between_verts(const moab::EntityHandle v0,
                                                 const moab::EntityHandle v1,
-                                                double& d) {
+                                                double& squared_dist) {
   moab::ErrorCode result;
   moab::CartVect coords0, coords1;
   result = MBI()->get_coords(&v0, 1, coords0.array());
@@ -373,7 +380,7 @@ moab::ErrorCode Gen::squared_dist_between_verts(const moab::EntityHandle v0,
     return result;
   }
   const moab::CartVect diff = coords0 - coords1;
-  d = diff.length_squared();
+  squared_dist = diff.length_squared();
   return moab::MB_SUCCESS;
 }
 
@@ -427,7 +434,6 @@ double Gen::length(std::vector<moab::EntityHandle> edges) {
     return 0;
 
   moab::ErrorCode result;
-  std::vector<moab::EntityHandle>::iterator i;
   double dist = 0;
   moab::EntityType type = MBI()->type_from_handle(edges[0]);
 
@@ -435,7 +441,7 @@ double Gen::length(std::vector<moab::EntityHandle> edges) {
   // NOTE: The curve sets from ReadCGM do not contain duplicate endpoints for loops!
   moab::EntityType end_type = MBI()->type_from_handle(edges.back());
   if (type != end_type) {
-    for (std::vector<moab::EntityHandle>::iterator i = edges.begin(); i != edges.end(); i++) {
+    for (auto i = edges.begin(); i != edges.end(); i++) {
       if (moab::MBVERTEX == MBI()->type_from_handle(*i)) {
         i = edges.erase(i) - 1;
       }
@@ -447,7 +453,7 @@ double Gen::length(std::vector<moab::EntityHandle> edges) {
   if (moab::MBEDGE == type) {
     if (edges.empty())
       return 0.0;
-    for (i = edges.begin(); i != edges.end(); i++) {
+    for (auto i = edges.begin(); i != edges.end(); i++) {
       int n_verts;
       const moab::EntityHandle* conn;
       result = MBI()->get_connectivity(*i, conn, n_verts);
@@ -463,7 +469,7 @@ double Gen::length(std::vector<moab::EntityHandle> edges) {
     if (2 > edges.size())
       return 0.0;
     moab::EntityHandle front_vert = edges.front();
-    for (i = edges.begin() + 1; i != edges.end(); i++) {
+    for (auto i = edges.begin() + 1; i != edges.end(); i++) {
       dist += dist_between_verts(front_vert, *i);
       front_vert = *i;
     }
@@ -510,7 +516,6 @@ bool Gen::edges_adjacent(moab::EntityHandle edge0, moab::EntityHandle edge1) {
 // get the direction unit vector from one vertex to another vertex
 moab::ErrorCode Gen::get_direction(const moab::EntityHandle from_vert, const moab::EntityHandle to_vert,
                                    moab::CartVect& dir) {
-  // double d[3];
   moab::ErrorCode result;
   moab::CartVect coords0, coords1;
   result = MBI()->get_coords(&from_vert, 1, coords0.array());
@@ -821,11 +826,6 @@ bool Gen::collinear(const moab::EntityHandle a, const moab::EntityHandle b,
     return false;
 }
 
-// Exclusive or: T iff exactly one argument is true
-bool logical_xor(const bool x, const bool y) {
-  return (x || y) && !(x && y);
-}
-
 bool Gen::intersect_prop(const moab::EntityHandle a, const moab::EntityHandle b,
                          const moab::EntityHandle c, const moab::EntityHandle d,
                          const moab::CartVect n) {
@@ -835,8 +835,8 @@ bool Gen::intersect_prop(const moab::EntityHandle a, const moab::EntityHandle b,
       collinear(c, d, b, n)) {
     return false;
   } else {
-    return logical_xor(left(a, b, c, n), left(a, b, d, n)) &&
-           logical_xor(left(c, d, a, n), left(c, d, b, n));
+    return (left(a, b, c, n) != left(a, b, d, n)) &&
+           (left(c, d, a, n) != left(c, d, b, n));
   }
 }
 
@@ -1246,18 +1246,11 @@ moab::ErrorCode Gen::dist_between_arcs(bool debug,
     }
   }
 
-  for (unsigned int i = 0; i < mgd_params.size(); i++) {
-
-  }
-
   // Insert new points to match the other arcs points, by parameter.
   for (unsigned int i = 0; i < 2; i++) {
     for (unsigned int j = 0; j < mgd_params.size(); j++) {
-      //std::cout << "params[" << i << "][" << j << "]=" << params[i][j]
-      //          << " mgd_params[" << j << "]=" << mgd_params[j] << std::endl;
       if (params[i][j] > mgd_params[j]) {
         double ratio = (mgd_params[j] - params[i][j - 1]) / (params[i][j] - params[i][j - 1]);
-        //std::cout << "j=" << j << " ratio=" << ratio << std::endl;
         moab::CartVect pt = coords[i][j - 1] + ratio * (coords[i][j] - coords[i][j - 1]);
         coords[i].insert(coords[i].begin() + j, pt);
         params[i].insert(params[i].begin() + j, mgd_params[j]);
@@ -1533,7 +1526,11 @@ moab::ErrorCode Gen::get_signed_volume(const moab::EntityHandle surf_set, double
   return moab::MB_SUCCESS;
 }
 
-moab::ErrorCode Gen::measure(const moab::EntityHandle set, const moab::Tag geom_tag, double& size, bool debug,  bool verbose) {
+moab::ErrorCode Gen::measure(const moab::EntityHandle set,
+                             const moab::Tag geom_tag,
+                             double& measurement,
+                             bool debug,
+                             bool verbose) {
   moab::ErrorCode result;
   int dim;
   result = MBI()->tag_get_data(geom_tag, &set, 1, &dim);
@@ -1546,17 +1543,17 @@ moab::ErrorCode Gen::measure(const moab::EntityHandle set, const moab::Tag geom_
     std::vector<moab::EntityHandle> vctr;
     result = get_meshset(set, vctr);
     assert(moab::MB_SUCCESS == result);
-    size = length(vctr);
+    measurement = length(vctr);
 
   } else if (2 == dim) {
     moab::Range tris;
     result = MBI()->get_entities_by_type(set, moab::MBTRI, tris);
     assert(moab::MB_SUCCESS == result);
-    size = triangle_area(tris);
+    measurement = triangle_area(tris);
 
   } else if (3 == dim) {
 
-    result = measure_volume(set, size, debug, verbose);
+    result = measure_volume(set, measurement, debug, verbose);
 
     if (moab::MB_SUCCESS != result) {
       std::cout << "result=" << result << " vol_id="
@@ -1758,10 +1755,8 @@ moab::ErrorCode Gen::remove_surf_sense_data(moab::EntityHandle del_surf, bool de
   moab::Range del_surf_curves;
   result = MBI() -> get_child_meshsets(del_surf, del_surf_curves);
   MB_CHK_SET_ERR(result, "could not get the curves of the surface to delete");
-  if (debug)
-    std::cout << "got the curves" << std::endl;
-
   if (debug) {
+    std::cout << "got the curves" << std::endl;
     std::cout << "number of curves to the deleted surface = " << del_surf_curves.size() << std::endl;
     for (unsigned int index = 0 ; index < del_surf_curves.size() ; index++) {
       std::cout << "deleted surface's child curve id " << index << " = " << geom_id_by_handle(del_surf_curves[index]) << std::endl;

--- a/src/make_watertight/Gen.hpp
+++ b/src/make_watertight/Gen.hpp
@@ -54,13 +54,13 @@ class Gen {
   void print_loop(const std::vector<moab::EntityHandle> loop_of_verts);
 
   moab::ErrorCode find_closest_vert(const moab::EntityHandle reference_vert,
-                                    const std::vector<moab::EntityHandle> arc_of_verts,
+                                    const std::vector<moab::EntityHandle>& arc_of_verts,
                                     unsigned& position,
                                     const double dist_limit);
 
   moab::ErrorCode find_closest_vert(const double tol,
                                     const moab::EntityHandle reference_vert,
-                                    const std::vector<moab::EntityHandle> loop_of_verts,
+                                    const std::vector<moab::EntityHandle>& loop_of_verts,
                                     std::vector<unsigned>& positions,
                                     std::vector<double>&   dists);
 

--- a/src/make_watertight/Gen.hpp
+++ b/src/make_watertight/Gen.hpp
@@ -267,7 +267,7 @@ class Gen {
 };
 
 
-struct edge {
+struct Edge {
   moab::EntityHandle edge, v0, v1;
 };
 

--- a/src/make_watertight/MakeWatertight.cpp
+++ b/src/make_watertight/MakeWatertight.cpp
@@ -267,7 +267,6 @@ moab::ErrorCode MakeWatertight::create_arc_pair(const double FACET_TOL,
       std::cout << "warning11: curve is degenerate" << std::endl;
     if (debug) {
       std::cout << "  adj curve " << gen->geom_id_by_handle(curve_sets[i]) << ":" << std::endl;
-      //gen->print_loop( temp_curve );
     }
 
     // Get the curve-surface relative sense. From CGMA/builds/dbg/include/CubitDefines,
@@ -577,7 +576,6 @@ moab::ErrorCode MakeWatertight::seal_arc_pair(const bool debug,
       //   advance the curve ahead. We need to merge all the verts between the
       //   current skin vert and the curve vert that we are merging to. This
       //   could be more than one!
-      //} else if(FACET_TOL > fabs(c_dist-s_dist)) {
     } else if (TOL_SQR > es_dist) {
       // merge the verts if they are not the same
       moab::EntityHandle keep_vert  = edge[e_pos];
@@ -1338,13 +1336,10 @@ moab::ErrorCode MakeWatertight::get_geom_size_before_sealing(const moab::Range g
   for (int dim = 1 ; dim < 4 ; ++dim) {
     for (moab::Range::iterator i = geom_sets[dim].begin() ; i != geom_sets[dim].end() ; i++) {
       double size;
-      //std::cout << "dim = " << dim << " *i =" << *i << std::endl;
       rval = gen->measure(*i, geom_tag, size, debug, verbose);
-      //std::cout << " here in gen mesaure" << std::endl;
       MB_CHK_SET_ERR(rval, "could not measure");
 
       rval = MBI()->tag_set_data(size_tag, &(*i), 1, &size);
-      //std::cout << " here in set tag data" << std::endl;
       MB_CHK_SET_ERR(rval, "could not set size tag");
     }
   }

--- a/src/make_watertight/MakeWatertight.cpp
+++ b/src/make_watertight/MakeWatertight.cpp
@@ -724,7 +724,7 @@ moab::ErrorCode MakeWatertight::seal_arc_pair(const bool debug,
       std::cout << "skin:" << std::endl;
       gen->print_loop(skin);
     }
-    //return moab::MB_FAILURE;
+    return moab::MB_FAILURE;
   }
 
   if (debug) {
@@ -1520,7 +1520,7 @@ moab::ErrorCode MakeWatertight::delete_merged_curves(moab::Range& existing_curve
   result = MBI()->delete_entities(curves_to_delete);
   assert(moab::MB_SUCCESS == result);
   if (result != moab::MB_SUCCESS) {
-    std::cout << "Houston, we have a problem" << std::endl;
+    std::cout << "Failed to delete curves" << std::endl;
   }
   existing_curve_sets = subtract(existing_curve_sets, curves_to_delete);
   if (debug)

--- a/src/make_watertight/MakeWatertight.cpp
+++ b/src/make_watertight/MakeWatertight.cpp
@@ -1520,7 +1520,7 @@ moab::ErrorCode MakeWatertight::delete_merged_curves(moab::Range& existing_curve
   result = MBI()->delete_entities(curves_to_delete);
   assert(moab::MB_SUCCESS == result);
   if (result != moab::MB_SUCCESS) {
-    std::cout << "Failed to delete curves" << std::endl;
+    std::cerr << "Failed to delete curves" << std::endl;
   }
   existing_curve_sets = subtract(existing_curve_sets, curves_to_delete);
   if (debug)


### PR DESCRIPTION
Applying the changes from the professional code review (#660) to the `make_watertight` related files. The changes are as follows:

  - remove commented code blocks that are either outdated or are debug statements
  - improvements to some logic for clarity
  - use of standard library containers to avoid potential memory leaks in Arc.cpp/Gen.cpp
  - improvements to struct/variable names
  - declared variables for "magic numbers"
  - passing by const reference where possible to avoid unnecessary memory allocation
  - removed an unused function (`Arc::create_loops_from_oriented_edges_fast`)

I'm not going to link each comment from the original PR here due to the sheer number of them, but I'm happy to answer any questions about the changes and hunt them down for reference as needed.
