### PR TITLE
Updates to make_watertight variables

### DIFF
--- a/news/PR-0672.rst
+++ b/news/PR-0672.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** None
+
+  - Updates to variable names in make_watergight files
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/src/make_watertight/Arc.hpp
+++ b/src/make_watertight/Arc.hpp
@@ -68,9 +68,9 @@ class Arc {
                               std::vector<moab::EntityHandle>& arc0,
                               std::vector<moab::EntityHandle>& arc1);
 
-  /// goes through curve_sets and finds any curves with coincident ( dist. apart <= FACET_TOL) front and back points.
+  /// goes through curve_sets and finds any curves with coincident ( dist. apart <= facet_tol) front and back points.
   /// it then merges the curves topologically. Any merged curves aren't deleted until prepare surfaces.
-  moab::ErrorCode merge_curves(moab::Range curve_sets, const double FACET_TOL,
+  moab::ErrorCode merge_curves(moab::Range curve_sets, const double facet_tol,
                                moab::Tag idTag, moab::Tag merge_tag, const bool debug);
 };
 

--- a/src/make_watertight/Cleanup.cpp
+++ b/src/make_watertight/Cleanup.cpp
@@ -85,7 +85,7 @@ moab::ErrorCode Cleanup::delete_small_edge_and_tris(const moab::EntityHandle ver
   return moab::MB_SUCCESS;
 }
 
-moab::ErrorCode Cleanup::delete_small_edges(const moab::Range& surfaces, const double FACET_TOL) {
+moab::ErrorCode Cleanup::delete_small_edges(const moab::Range& surfaces, const double facet_tol) {
   // PROBLEM: THIS IS INVALID BECAUSE TRIS CAN HAVE LONG EDGES BUT
   // SMALL AREA. All three pts are in a line. This is the nature of
   // faceting vs. meshing.
@@ -151,8 +151,8 @@ moab::ErrorCode Cleanup::delete_small_edges(const moab::Range& surfaces, const d
         MBI()->list_entities(duplicate_edges);
       assert(1 == duplicate_edges.size());
 
-      // if the edge length is less than FACET_TOL do nothing
-      if (FACET_TOL < gen->dist_between_verts(endpts[0], endpts[1]))
+      // if the edge length is less than facet_tol do nothing
+      if (facet_tol < gen->dist_between_verts(endpts[0], endpts[1]))
         continue;
 
       // quick check

--- a/src/make_watertight/Gen.cpp
+++ b/src/make_watertight/Gen.cpp
@@ -273,7 +273,7 @@ moab::ErrorCode Gen::find_closest_vert(const double tol,
   moab::ErrorCode rval;
   positions.clear();
   dists.clear();
-  const double TOL_SQR = tol * tol;
+  const double tol_sqr = tol * tol;
   unsigned min_pos;
   double sqr_min_dist = std::numeric_limits<double>::max();
   for (unsigned int i = 0; i < loop_of_verts.size(); i++) {
@@ -281,11 +281,11 @@ moab::ErrorCode Gen::find_closest_vert(const double tol,
     rval = squared_dist_between_verts(reference_vert, loop_of_verts[i], sqr_dist);
     MB_CHK_SET_ERR(rval, "could not get dist");
     if (sqr_dist < sqr_min_dist) {
-      if (sqr_dist >= TOL_SQR) {
+      if (sqr_dist >= tol_sqr) {
         sqr_min_dist = sqr_dist;
         min_pos = i;
       } else {
-        sqr_min_dist = TOL_SQR;
+        sqr_min_dist = tol_sqr;
         positions.push_back(i);
         dists.push_back(sqrt(sqr_dist));
       }
@@ -1950,6 +1950,7 @@ moab::ErrorCode Gen::get_sealing_mesh_tags(double& facet_tol,
   if (result != moab::MB_SUCCESS) {
     moab_printer(result);
   }
+
   // PROBLEM: MOAB is not consistent with file_set behavior. The tag may not be
   // on the file_set.
   moab::Range file_set;

--- a/src/make_watertight/MakeWatertight.hpp
+++ b/src/make_watertight/MakeWatertight.hpp
@@ -53,11 +53,11 @@ class MakeWatertight {
                                  moab::Tag geom_tag,
                                  moab::Tag id_tag,
                                  moab::Tag merge_tag,
-                                 const double FACET_TOL,
+                                 const double facet_tol,
                                  const bool debug,
                                  bool verbose = true);
 
-  moab::ErrorCode create_arc_pair(const double FACET_TOL,
+  moab::ErrorCode create_arc_pair(const double facet_tol,
                                   const moab::EntityHandle surf_set,
                                   std::vector<moab::EntityHandle>& skin_loop,
                                   std::vector<moab::EntityHandle>& curve_sets,
@@ -69,14 +69,14 @@ class MakeWatertight {
                                   std::vector<moab::EntityHandle>& skin_arc);
 
   moab::ErrorCode seal_arc_pair(const bool debug,
-                                const double FACET_TOL,
+                                const double facet_tol,
                                 const moab::Tag normal_tag,
                                 std::vector<moab::EntityHandle>& edge, /* in */
                                 std::vector<moab::EntityHandle>& skin /* in/out */,
                                 const int surf_id);
 
   moab::ErrorCode seal_loop(bool debug,
-                            const double FACET_TOL,
+                            const double facet_tol,
                             const moab::Tag normal_tag,
                             const moab::Tag orig_curve_tag,
                             const moab::EntityHandle surf_set,
@@ -90,8 +90,8 @@ class MakeWatertight {
                                    moab::Tag normal_tag,
                                    moab::Tag merge_tag,
                                    moab::Tag orig_curve_tag,
-                                   const double SME_RESABS_TOL,
-                                   const double FACET_TOL,
+                                   const double sme_resabs_tol,
+                                   const double facet_tol,
                                    const bool debug,
                                    bool verbose = true);
 
@@ -114,7 +114,7 @@ class MakeWatertight {
   moab::ErrorCode get_geom_size_after_sealing(const moab::Range geom_sets[],
                                               const moab::Tag geom_tag,
                                               const moab::Tag size_tag,
-                                              const double FACET_TOL,
+                                              const double facet_tol,
                                               bool debug,
                                               bool verbose);
 
@@ -136,9 +136,9 @@ class MakeWatertight {
   /// The vertex loops are returned in the vector array, skin.
   moab::ErrorCode create_skin_vert_loops(moab::Range& skin_edges, moab::Range tris, std::vector < std::vector <moab::EntityHandle> >& skin, int surf_id, bool& cont, bool debug);
 
-  /// merges any skin vertices closer in proximity than the SME_RESABS_TOL.
+  /// merges any skin vertices closer in proximity than the sme_resabs_tol.
   /// It then checks the skins for any degenerate edges resultant of vertex merging.
-  moab::ErrorCode merge_skin_verts(moab::Range& skin_verts, moab::Range& skin_edges, double SME_RESABS_TOL, int surf_id, bool cont, bool debug);
+  moab::ErrorCode merge_skin_verts(moab::Range& skin_verts, moab::Range& skin_edges, double sme_resabs_tol, int surf_id, bool cont, bool debug);
 
   /// runs the make_watertight algorithm on each set of skin_loops for the surface, surf.
   moab::ErrorCode seal_surface_loops(moab::EntityHandle surf,
@@ -147,7 +147,7 @@ class MakeWatertight {
                                      std::vector<moab::EntityHandle> curves,
                                      moab::Tag normal_tag,
                                      moab::Tag orig_curve_tag,
-                                     double FACET_TOL,
+                                     double facet_tol,
                                      int surf_id,
                                      bool debug);
 

--- a/src/make_watertight/Zip.cpp
+++ b/src/make_watertight/Zip.cpp
@@ -426,7 +426,7 @@ moab::ErrorCode Zip::remove_inverted_tris(moab::Tag normal_tag, moab::Range tris
 }
 
 // we do not merge edges, just vert. check the verts
-moab::ErrorCode Zip::test_zipping(const double FACET_TOL,
+moab::ErrorCode Zip::test_zipping(const double facet_tol,
                                   const std::vector< std::vector<moab::EntityHandle> > arcs) {
   moab::ErrorCode result;
 
@@ -451,7 +451,7 @@ moab::ErrorCode Zip::test_zipping(const double FACET_TOL,
 
     // check for edge of zero dist
     double d = gen->dist_between_verts(arcs[0][i], arcs[0][i + 1]);
-    if (FACET_TOL >= d) {
+    if (facet_tol >= d) {
       std::cout << "edge length=" << d << " betwee pos " << i << " and " << i + 1
                 << " with verts " << arcs[0][i] << " and " << arcs[0][i + 1] << std::endl;
       return moab::MB_FAILURE;

--- a/src/make_watertight/Zip.hpp
+++ b/src/make_watertight/Zip.hpp
@@ -52,7 +52,7 @@ class Zip {
   moab::ErrorCode remove_inverted_tris(moab::Tag normal_tag, moab::Range tris, const bool debug);
 
   /// tests the watertightness of all arcs in the vector-array of moab entity handles arcs
-  moab::ErrorCode test_zipping(const double FACET_TOL,
+  moab::ErrorCode test_zipping(const double facet_tol,
                                const std::vector< std::vector<moab::EntityHandle> > arcs);
 
 

--- a/src/make_watertight/app/make_watertight.cpp
+++ b/src/make_watertight/app/make_watertight.cpp
@@ -3,9 +3,6 @@
 //         output_file h5m filename (optional),
 // output: watertight h5m
 
-// make CXXFLAGS=-g for debug
-// make CXXFLAGS=-pg for profiling
-
 #include <iostream>
 #include <sstream>
 #include <iomanip>


### PR DESCRIPTION
This is a follow-up to #666 addressing a comment  from #660 related to our `make_watertight` files. Primarily, it updates any non-global/non-static variables with capitalized names to a lower case version. 

There are also couple of small changes related to cleanup or clarity in comments.