### PR TITLE
Shared library/executable testing in CI and update to the Geant4 RPATH

### DIFF
--- a/CI/docker/build_geant4.sh
+++ b/CI/docker/build_geant4.sh
@@ -21,6 +21,7 @@ cmake ../geant4.${geant4_version} -DBUILD_STATIC_LIBS=ON \
              -DCMAKE_BUILD_TYPE=Release \
              -DCMAKE_C_COMPILER=${CC} \
              -DCMAKE_CXX_COMPILER=${CXX} \
+             -DCMAKE_INSTALL_RPATH=${geant4_install_dir}/lib \
              -DCMAKE_INSTALL_PREFIX=${geant4_install_dir}
 make -j${jobs}
 make install

--- a/CI/env.sh
+++ b/CI/env.sh
@@ -8,6 +8,8 @@ export geant4_shasum=4b05b4f7d50945459f8dbe287333b9efb772bd23d50920630d5454ec570
 export build_dir=/root/build/${COMPILER}
 export install_dir=/root/opt/${COMPILER}
 
+export CTEST_OUTPUT_ON_FAILURE=1
+
 if [ "${HDF5_VERSION}" == "system" ]; then
   export hdf5_build_dir=
   export hdf5_install_dir=/usr/lib/x86_64-linux-gnu/hdf5/serial

--- a/CI/env.sh
+++ b/CI/env.sh
@@ -30,6 +30,13 @@ export moab_install_dir=${install_dir}/moab-${MOAB_VERSION}-hdf5-${HDF5_VERSION}
 export dagmc_build_dir=${build_dir}/DAGMC-moab-${MOAB_VERSION}-hdf5-${HDF5_VERSION}
 export dagmc_install_dir=${install_dir}/DAGMC-moab-${MOAB_VERSION}-hdf5-${HDF5_VERSION}
 
+export dagmc_build_dir_shared=${dagmc_build_dir}-shared
+export dagmc_install_dir_shared=${dagmc_install_dir}-shared
+
+export dagmc_build_dir_static=${dagmc_build_dir}-static
+export dagmc_install_dir_static=${dagmc_install_dir}-static
+
+
 if [ "$COMPILER" == "gcc" ]; then
   export  CC=`which gcc`
   export CXX=`which g++`

--- a/CI/travis/build_dagmc.sh
+++ b/CI/travis/build_dagmc.sh
@@ -29,4 +29,9 @@ cmake ../DAGMC -DMOAB_DIR=${moab_install_dir} \
              -DCMAKE_INSTALL_PREFIX=${dagmc_install_dir}
 make -j${jobs}
 make install
+
+# symlink make_watertight test files if present
+cd ${dagmc_build_dir}/bld/src/make_watertight/tests/
+for i in /tmp/*.h5m; do ln -sf $i; done
+
 cd

--- a/CI/travis/build_dagmc.sh
+++ b/CI/travis/build_dagmc.sh
@@ -7,31 +7,44 @@ set -ex
 
 source ${docker_env}
 
-if [ "${TRAVIS_PULL_REQUEST}" == "false" ]; then
-  build_mw_reg_tests=ON
-else
-  build_mw_reg_tests=OFF
-fi
+function build_dagmc() {
 
-rm -rf ${dagmc_build_dir}/bld ${dagmc_install_dir}
-mkdir -p ${dagmc_build_dir}/bld
-cd ${dagmc_build_dir}
-cd bld
-cmake ../DAGMC -DMOAB_DIR=${moab_install_dir} \
-             -DBUILD_GEANT4=ON \
-             -DGEANT4_DIR=${geant4_install_dir} \
-             -DBUILD_CI_TESTS=ON \
-             -DBUILD_MW_REG_TESTS=${build_mw_reg_tests} \
-             -DBUILD_STATIC_EXE=${build_static_exe} \
-             -DCMAKE_C_COMPILER=${CC} \
-             -DCMAKE_CXX_COMPILER=${CXX} \
-             -DCMAKE_Fortran_COMPILER=${FC} \
-             -DCMAKE_INSTALL_PREFIX=${dagmc_install_dir}
-make -j${jobs}
-make install
+  if [ "$1" == "shared" ]; then
+    local build_dir=${dagmc_build_dir_shared}
+    local install_dir=${dagmc_install_dir_shared}
+    local static_exe=OFF
+  else
+    local build_dir=${dagmc_build_dir_static}
+    local install_dir=${dagmc_install_dir_static}
+    local static_exe=ON
+  fi
 
-# symlink make_watertight test files if present
-cd ${dagmc_build_dir}/bld/src/make_watertight/tests/
-for i in /tmp/*.h5m; do ln -sf $i; done
+  if [ "${TRAVIS_PULL_REQUEST}" == "false" ]; then
+    build_mw_reg_tests=ON
+  else
+    build_mw_reg_tests=OFF
+  fi
+
+  rm -rf ${build_dir}/bld ${install_dir}
+  mkdir -p ${build_dir}/bld
+  cd ${build_dir}
+  cd bld
+  cmake ${dagmc_build_dir}/DAGMC -DMOAB_DIR=${moab_install_dir} \
+               -DBUILD_GEANT4=ON \
+               -DGEANT4_DIR=${geant4_install_dir} \
+               -DBUILD_CI_TESTS=ON \
+               -DBUILD_MW_REG_TESTS=${build_mw_reg_tests} \
+               -DBUILD_STATIC_EXE=${static_exe} \
+               -DCMAKE_C_COMPILER=${CC} \
+               -DCMAKE_CXX_COMPILER=${CXX} \
+               -DCMAKE_Fortran_COMPILER=${FC} \
+               -DCMAKE_INSTALL_PREFIX=${install_dir}
+  make -j${jobs}
+  make install
+}
+
+build_dagmc "static"
+
+build_dagmc "shared"
 
 cd

--- a/CI/travis/build_dagmc.sh
+++ b/CI/travis/build_dagmc.sh
@@ -20,9 +20,9 @@ function build_dagmc() {
   fi
 
   if [ "${TRAVIS_PULL_REQUEST}" == "false" ]; then
-    build_mw_reg_tests=ON
+    local build_mw_reg_tests=ON
   else
-    build_mw_reg_tests=OFF
+    local build_mw_reg_tests=OFF
   fi
 
   rm -rf ${build_dir}/bld ${install_dir}

--- a/CI/travis/install.sh
+++ b/CI/travis/install.sh
@@ -11,5 +11,13 @@ if [ "${MOAB_VERSION}" == "master" ] || [ "${MOAB_VERSION}" == "develop" ]; then
   CI/docker/build_moab.sh
 fi
 
+# If this is not a pull request, get files needed for regression tests
+if [ "${TRAVIS_PULL_REQUEST}" == "false" ]; then
+  cd /tmp
+  wget ${MW_REG_TEST_MODELS_URL} -O mw_reg_test_files.tar.gz -o wget.out
+  tar xzvf mw_reg_test_files.tar.gz
+  cd -
+fi
+
 # Build and install DAGMC
 CI/travis/build_dagmc.sh

--- a/CI/travis/install.sh
+++ b/CI/travis/install.sh
@@ -10,3 +10,6 @@ cd ${dagmc_build_dir}/DAGMC
 if [ "${MOAB_VERSION}" == "master" ] || [ "${MOAB_VERSION}" == "develop" ]; then
   CI/docker/build_moab.sh
 fi
+
+# Build and install DAGMC
+CI/travis/build_dagmc.sh

--- a/CI/travis/install.sh
+++ b/CI/travis/install.sh
@@ -10,9 +10,3 @@ cd ${dagmc_build_dir}/DAGMC
 if [ "${MOAB_VERSION}" == "master" ] || [ "${MOAB_VERSION}" == "develop" ]; then
   CI/docker/build_moab.sh
 fi
-
-# Build DAGMC (shared executables)
-build_static_exe=OFF CI/travis/build_dagmc.sh
-
-# Build DAGMC (static executables)
-build_static_exe=ON CI/travis/build_dagmc.sh

--- a/CI/travis/tests.sh
+++ b/CI/travis/tests.sh
@@ -14,13 +14,13 @@ fi
 
 # Build DAGMC and test (shared executables)
 cd ${dagmc_build_dir}/DAGMC
-build_static_exe=OFF docker/build_dagmc.sh
+build_static_exe=OFF CI/travis/build_dagmc.sh
 cd ${dagmc_build_dir}/bld
 make test
 
 # Build DAGMC and test (static executables)
 cd ${dagmc_build_dir}/DAGMC
-build_static_exe=ON docker/build_dagmc.sh
+build_static_exe=ON CI/travis/build_dagmc.sh
 cd ${dagmc_build_dir}/bld
 make test
 

--- a/CI/travis/tests.sh
+++ b/CI/travis/tests.sh
@@ -4,14 +4,42 @@ set -ex
 
 source ${docker_env}
 
+# this command may fail due to lack of Geant4 data
+source ${geant4_install_dir}/bin/geant4.sh || true
+
+# If this is not a pull request, get files needed for regression tests
+if [ "${TRAVIS_PULL_REQUEST}" == "false" ]; then
+  cd /tmp
+  wget ${MW_REG_TEST_MODELS_URL} -O mw_reg_test_files.tar.gz -o wget.out
+  tar xzvf mw_reg_test_files.tar.gz
+  cd -
+fi
+
 cd ${dagmc_build_dir}/DAGMC
+build_static_exe=OFF docker/build_dagmc.sh
+
+cd ${dagmc_build_dir}/bld/src/make_watertight/tests/
+for i in /tmp/*.h5m; do ln -sf $i; done
+cd ${dagmc_build_dir}/bld
+CTEST_OUTPUT_ON_FAILURE=1 make test
+
+# Build DAGMC and test (static executables)
+cd ${dagmc_build_dir}/DAGMC
+build_static_exe=ON docker/build_dagmc.sh
+
+cd ${dagmc_build_dir}/bld/src/make_watertight/tests/
+for i in /tmp/*.h5m; do ln -sf $i; done
+cd ${dagmc_build_dir}/bld
+CTEST_OUTPUT_ON_FAILURE=1 make test
 
 # clean out config test directory for next build
-git clean -dxf . 
+cd ${dagmc_build_dir}/DAGMC
+git clean -dxf .
 
 # Test DAGMC CMake configuration file
 cd ${dagmc_build_dir}/DAGMC/cmake/test_config
 cmake . -DDAGMC_ROOT=${dagmc_install_dir}
+for i in /tmp/*.h5m; do ln -sf src/make_watertight/tests/$i; done
 make all test
 
 cd ${dagmc_build_dir}/bld
@@ -29,6 +57,6 @@ make test
 
 # Delete regression test files
 if [ "${TRAVIS_PULL_REQUEST}" == "false" ]; then
-  rm -f src/make_watertight/tests/*.h5m
-  rm -f src/make_watertight/tests/mw_reg_test_files.tar.gz
+  rm -f /tmp/*.h5m
+  rm -f /tmp/mw_reg_test_files.tar.gz
 fi

--- a/CI/travis/tests.sh
+++ b/CI/travis/tests.sh
@@ -12,22 +12,17 @@ if [ "${TRAVIS_PULL_REQUEST}" == "false" ]; then
   cd -
 fi
 
+# Build DAGMC and test (shared executables)
 cd ${dagmc_build_dir}/DAGMC
 build_static_exe=OFF docker/build_dagmc.sh
-
-cd ${dagmc_build_dir}/bld/src/make_watertight/tests/
-for i in /tmp/*.h5m; do ln -sf $i; done
 cd ${dagmc_build_dir}/bld
-CTEST_OUTPUT_ON_FAILURE=1 make test
+make test
 
 # Build DAGMC and test (static executables)
 cd ${dagmc_build_dir}/DAGMC
 build_static_exe=ON docker/build_dagmc.sh
-
-cd ${dagmc_build_dir}/bld/src/make_watertight/tests/
-for i in /tmp/*.h5m; do ln -sf $i; done
 cd ${dagmc_build_dir}/bld
-CTEST_OUTPUT_ON_FAILURE=1 make test
+make test
 
 # clean out config test directory for next build
 cd ${dagmc_build_dir}/DAGMC
@@ -36,7 +31,6 @@ git clean -dxf .
 # Test DAGMC CMake configuration file
 cd ${dagmc_build_dir}/DAGMC/cmake/test_config
 cmake . -DDAGMC_ROOT=${dagmc_install_dir}
-for i in /tmp/*.h5m; do ln -sf src/make_watertight/tests/$i; done
 make all test
 
 cd ${dagmc_build_dir}/bld

--- a/CI/travis/tests.sh
+++ b/CI/travis/tests.sh
@@ -12,17 +12,22 @@ if [ "${TRAVIS_PULL_REQUEST}" == "false" ]; then
   cd -
 fi
 
-# Build DAGMC and test (shared executables)
-cd ${dagmc_build_dir}/DAGMC
-build_static_exe=OFF CI/travis/build_dagmc.sh
-cd ${dagmc_build_dir}/bld
-make test
+# symlink make_watertight test files if present
+# shared
+cd ${dagmc_build_dir_shared}/bld/src/make_watertight/tests/
+for i in /tmp/*.h5m; do ln -sf $i; done
+# static
+cd ${dagmc_build_dir_static}/bld/src/make_watertight/tests/
+for i in /tmp/*.h5m; do ln -sf $i; done
 
-# Build DAGMC and test (static executables)
-cd ${dagmc_build_dir}/DAGMC
-build_static_exe=ON CI/travis/build_dagmc.sh
-cd ${dagmc_build_dir}/bld
-make test
+
+# Test DAGMC (shared executables)
+cd ${dagmc_build_dir_shared}/bld
+PATH=${dagmc_install_dir_shared}/bin:$PATH make test
+
+# Test DAGMC (static executables)
+cd ${dagmc_build_dir_static}/bld
+PATH=${dagmc_install_dir_static}/bin:PATH make test
 
 # clean out config test directory for next build
 cd ${dagmc_build_dir}/DAGMC
@@ -30,7 +35,7 @@ git clean -dxf .
 
 # Test DAGMC CMake configuration file
 cd ${dagmc_build_dir}/DAGMC/cmake/test_config
-cmake . -DDAGMC_ROOT=${dagmc_install_dir}
+cmake . -DDAGMC_ROOT=${dagmc_install_dir_shared}
 make all test
 
 cd ${dagmc_build_dir}/bld

--- a/CI/travis/tests.sh
+++ b/CI/travis/tests.sh
@@ -4,22 +4,15 @@ set -ex
 
 source ${docker_env}
 
-# If this is not a pull request, get files needed for regression tests
-if [ "${TRAVIS_PULL_REQUEST}" == "false" ]; then
-  cd /tmp
-  wget ${MW_REG_TEST_MODELS_URL} -O mw_reg_test_files.tar.gz -o wget.out
-  tar xzvf mw_reg_test_files.tar.gz
-  cd -
-fi
-
-# symlink make_watertight test files if present
+# symlink make_watertight regression test files if present
 # shared
 cd ${dagmc_build_dir_shared}/bld/src/make_watertight/tests/
 for i in /tmp/*.h5m; do ln -sf $i; done
+ls .
 # static
 cd ${dagmc_build_dir_static}/bld/src/make_watertight/tests/
 for i in /tmp/*.h5m; do ln -sf $i; done
-
+ls .
 
 # Test DAGMC (shared executables)
 cd ${dagmc_build_dir_shared}/bld
@@ -27,7 +20,7 @@ PATH=${dagmc_install_dir_shared}/bin:$PATH make test
 
 # Test DAGMC (static executables)
 cd ${dagmc_build_dir_static}/bld
-PATH=${dagmc_install_dir_static}/bin:PATH make test
+PATH=${dagmc_install_dir_static}/bin:$PATH make test
 
 # clean out config test directory for next build
 cd ${dagmc_build_dir}/DAGMC
@@ -37,19 +30,6 @@ git clean -dxf .
 cd ${dagmc_build_dir}/DAGMC/cmake/test_config
 cmake . -DDAGMC_ROOT=${dagmc_install_dir_shared}
 make all test
-
-cd ${dagmc_build_dir}/bld
-
-# If this is not a pull request, get files needed for regression tests
-if [ "${TRAVIS_PULL_REQUEST}" == "false" ]; then
-  cd src/make_watertight/tests
-  wget ${MW_REG_TEST_MODELS_URL} -O mw_reg_test_files.tar.gz
-  tar xzvf mw_reg_test_files.tar.gz
-  cd ../../..
-fi
-
-# Run the unit tests
-make test
 
 # Delete regression test files
 if [ "${TRAVIS_PULL_REQUEST}" == "false" ]; then

--- a/CI/travis/tests.sh
+++ b/CI/travis/tests.sh
@@ -4,9 +4,6 @@ set -ex
 
 source ${docker_env}
 
-# this command may fail due to lack of Geant4 data
-source ${geant4_install_dir}/bin/geant4.sh || true
-
 # If this is not a pull request, get files needed for regression tests
 if [ "${TRAVIS_PULL_REQUEST}" == "false" ]; then
   cd /tmp

--- a/news/PR-0674.rst
+++ b/news/PR-0674.rst
@@ -1,0 +1,15 @@
+**Added:** None
+
+**Changed:**
+
+  - Enabling testing for the shared object build of DAGMC
+  - Adding RPATH value for our build of Geant4 on CI
+  - Including additional test output on failure in CI
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/src/geant4/CMakeLists.txt
+++ b/src/geant4/CMakeLists.txt
@@ -12,12 +12,6 @@ include_directories(${CMAKE_SOURCE_DIR}/src/dagmc)
 include_directories(${CMAKE_BINARY_DIR}/src/dagmc)
 include_directories(${CMAKE_SOURCE_DIR}/src/pyne)
 
-# GEANT4 libraries require the RPATH (not RUNPATH) to be
-# set properly without setting the LD_LIBRARY_PATH.
-# This flag ensures RPATH will be used over RUNPATH.
-set(CMAKE_SHARED_LINKER_FLAGS "-Wl,--disable-new-dtags")
-
-
 dagmc_install_library(dagsolid)
 
 add_subdirectory(app)

--- a/src/geant4/CMakeLists.txt
+++ b/src/geant4/CMakeLists.txt
@@ -12,6 +12,12 @@ include_directories(${CMAKE_SOURCE_DIR}/src/dagmc)
 include_directories(${CMAKE_BINARY_DIR}/src/dagmc)
 include_directories(${CMAKE_SOURCE_DIR}/src/pyne)
 
+# GEANT4 libraries require the RPATH (not RUNPATH) to be
+# set properly without setting the LD_LIBRARY_PATH.
+# This flag ensures RPATH will be used over RUNPATH.
+set(CMAKE_SHARED_LINKER_FLAGS "-Wl,--disable-new-dtags")
+
+
 dagmc_install_library(dagsolid)
 
 add_subdirectory(app)


### PR DESCRIPTION
## Description
This PR adds shared library testing to our CI. The CI tests will fail at first for reasons described in #673, but once the update to `build_geant4.sh` is applied we should see them succeed. I'll wait to update the docker image until someone has had a look and give me the :+1: to do so.

To enable the shared build testing, I've moved a lot of the actual building of DAGMC into `travis.tests.sh`, so our files 

One other small change I've added is the `CTEST_OUTPUT_ON_FAILURE` flag to provide more information in the CI log if a test does fail.

## Motivation and Context
We should be testing both static and shared builds of DAGMC on CI. We have plenty of spare time and resources on Travis.
