### PR TITLE
Add eigen3 to docker image

### DIFF
--- a/CI/Dockerfile
+++ b/CI/Dockerfile
@@ -8,7 +8,7 @@ SHELL ["/bin/bash", "-c"]
 ARG UBUNTU_VERSION=18.04
 RUN apt-get -y update; \
     apt-get -y install autoconf clang cmake g++ gcc gfortran git libblas-dev \
-                       libhdf5-dev liblapack-dev libpython2.7-dev libtool \
+                       libhdf5-dev liblapack-dev libpython2.7-dev libtool libeigen3-dev\
                        python-numpy python-pip python-setuptools wget; \
     if [ "${UBUNTU_VERSION}" = "18.04" ]; then \
         pip install sphinx; \

--- a/CI/docker/build_moab.sh
+++ b/CI/docker/build_moab.sh
@@ -21,6 +21,7 @@ cd ../bld
                  --enable-shared \
                  --enable-optimize \
                  --disable-debug \
+                 --disable-blaslapack \
                  --with-hdf5=${hdf5_install_dir} \
                  --prefix=${moab_install_dir} \
                  CC=${CC} CXX=${CXX} FC=${FC}

--- a/CI/docker/build_moab.sh
+++ b/CI/docker/build_moab.sh
@@ -22,6 +22,7 @@ cd ../bld
                  --enable-optimize \
                  --disable-debug \
                  --disable-blaslapack \
+                 --enableeigen \
                  --with-hdf5=${hdf5_install_dir} \
                  --prefix=${moab_install_dir} \
                  CC=${CC} CXX=${CXX} FC=${FC}

--- a/news/PR-0683.rst
+++ b/news/PR-0683.rst
@@ -1,0 +1,12 @@
+**Added:** None
+
+**Changed:** 
+* Added `libeigen3-dev` package to be installed by `apt`
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/news/PR-0683.rst
+++ b/news/PR-0683.rst
@@ -1,7 +1,8 @@
 **Added:** None
+* Added `libeigen3-dev` package to be installed by `apt`
 
 **Changed:** 
-* Added `libeigen3-dev` package to be installed by `apt`
+* build settings for MOAB remove BLAS/LAPACK and add Eigen3
 
 **Deprecated:** None
 


### PR DESCRIPTION
## Description
Adds the Eigen3 package to the docker image using `apt` without removing anything (yet).


## Motivation and Context
This is the first step in testing for a transition from Lapack dependence to Eigen3 dependence.  Eigen3 is a pure C++ header only dependence, so it requires fewer steps to make it available on any given system.

Once the transition is complete, and there is no longer any Lapack dependence in the source code, another PR will remove lapack & blas from the list of installed packages for this docker image.

## Changes
Dockerfile update

## Behavior
The only change in behavior is the presence of an additional package.

