### PR TITLE
Making density specification optional in the metadata manager.

### DIFF
--- a/news/PR-0688.rst
+++ b/news/PR-0688.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:**
+
+Behavior of the dagmcMetaData class to ignore missing density assignments for more flexible integration with certain codes.
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/src/dagmc/dagmcmetadata.cpp
+++ b/src/dagmc/dagmcmetadata.cpp
@@ -7,9 +7,12 @@ const char graveyard_str[] = "Graveyard";
 const char vacuum_str[] = "Vacuum";
 
 // constructor for metadata class
-dagmcMetaData::dagmcMetaData(moab::DagMC* dag_ptr, bool verbosity) {
+dagmcMetaData::dagmcMetaData(moab::DagMC* dag_ptr,
+                             bool verbosity,
+                             bool ensure_density_present) {
   DAG = dag_ptr; // dagmc pointer
   verbose = verbosity;
+  ensure_density = ensure_density_present;
   // these are the keywords that dagmc will understand
   // from groups if you need to process more
   // they should be added here
@@ -184,7 +187,8 @@ void dagmcMetaData::parse_material_data() {
 
     // check to see if the simplified naming scheme is used, by try to convert the
     // material property to an int
-    if (try_to_make_int(material_props[0]) && density_props[0].empty() && !(DAG->is_implicit_complement(eh))) {
+    if (ensure_density && try_to_make_int(material_props[0]) &&
+        density_props[0].empty() && !(DAG->is_implicit_complement(eh))) {
       std::cerr << "Using the simplified naming scheme without a density" << std::endl;
       std::cerr << "property is forbidden, please rename the group mat:" << material_props[0] << std::endl;
       exit(EXIT_FAILURE);

--- a/src/dagmc/dagmcmetadata.cpp
+++ b/src/dagmc/dagmcmetadata.cpp
@@ -9,10 +9,10 @@ const char vacuum_str[] = "Vacuum";
 // constructor for metadata class
 dagmcMetaData::dagmcMetaData(moab::DagMC* dag_ptr,
                              bool verbosity,
-                             bool ensure_density_present) {
+                             bool require_density_present) {
   DAG = dag_ptr; // dagmc pointer
   verbose = verbosity;
-  ensure_density = ensure_density_present;
+  require_density = require_density_present;
   // these are the keywords that dagmc will understand
   // from groups if you need to process more
   // they should be added here
@@ -187,7 +187,7 @@ void dagmcMetaData::parse_material_data() {
 
     // check to see if the simplified naming scheme is used, by try to convert the
     // material property to an int
-    if (ensure_density && try_to_make_int(material_props[0]) &&
+    if (require_density && try_to_make_int(material_props[0]) &&
         density_props[0].empty() && !(DAG->is_implicit_complement(eh))) {
       std::cerr << "Using the simplified naming scheme without a density" << std::endl;
       std::cerr << "property is forbidden, please rename the group mat:" << material_props[0] << std::endl;

--- a/src/dagmc/dagmcmetadata.hpp
+++ b/src/dagmc/dagmcmetadata.hpp
@@ -8,7 +8,7 @@ class dagmcMetaData {
  public:
   dagmcMetaData(moab::DagMC* DAGptr,
                 bool verbosity = false,
-                bool ensure_density_present = true);
+                bool require_density_present = true);
   ~dagmcMetaData();
 
   // load the dagmc properties into maps
@@ -85,7 +85,7 @@ class dagmcMetaData {
  private:
   moab::DagMC* DAG; // Pointer to DAGMC instance
   bool verbose;
-  bool ensure_density;
+  bool require_density;
   std::vector< std::string > metadata_keywords;
   std::map< std::string, std::string > keyword_synonyms;
 };

--- a/src/dagmc/dagmcmetadata.hpp
+++ b/src/dagmc/dagmcmetadata.hpp
@@ -6,7 +6,9 @@
 
 class dagmcMetaData {
  public:
-  dagmcMetaData(moab::DagMC* DAGptr, bool verbosity = false);
+  dagmcMetaData(moab::DagMC* DAGptr,
+                bool verbosity = false,
+                bool ensure_density_present = true);
   ~dagmcMetaData();
 
   // load the dagmc properties into maps
@@ -83,6 +85,7 @@ class dagmcMetaData {
  private:
   moab::DagMC* DAG; // Pointer to DAGMC instance
   bool verbose;
+  bool ensure_density;
   std::vector< std::string > metadata_keywords;
   std::map< std::string, std::string > keyword_synonyms;
 };


### PR DESCRIPTION
## Description

This provides an option to allow the `dagmcMetaData` class to read material assignments without requiring that a density specification is present with the default being the original behavior of the class.

## Motivation and Context

My take on this is that this requirement was originally adopted for DAG-MCNP, where cell material assignments include specification of the density in that region. In other codes the density is supplied as part of the material definition (e.g. OpenMC) so having a density present in the DAGMC assignments creates something of a contradiction between the specified DAGMC density and the density specified as part of the native material definitions.

This change provides the option to omit or ignore the density specification on the DAGMC model material assignments, but still use the `dagmcMetaData` class to parsing of the model metadata rather than rely on other methods (like using the somewhat outdated metadata options that are part of the `DagMC`  class itself).