### PR TITLE
Use cmake variable for Eigen3 location and include that dir

### DIFF
--- a/news/PR-0694.rst
+++ b/news/PR-0694.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** 
+
+* fixed use of Eigen3 include directories
+
+**Security:** None

--- a/src/tally/CMakeLists.txt
+++ b/src/tally/CMakeLists.txt
@@ -1,6 +1,7 @@
 message("")
 
 find_package(Eigen3 REQUIRED NO_MODULE)
+include_directories(${EIGEN3_INCLUDE_DIRS})
 
 file(GLOB SRC_FILES "*.cpp")
 file(GLOB PUB_HEADERS "*.hpp")

--- a/src/tally/KDEKernel.cpp
+++ b/src/tally/KDEKernel.cpp
@@ -3,8 +3,6 @@
 #include <cassert>
 #include <iostream>
 
-#include <eigen3/Eigen/Dense>
-
 #include "KDEKernel.hpp"
 #include "PolynomialKernel.hpp"
 

--- a/src/tally/KDEKernel.hpp
+++ b/src/tally/KDEKernel.hpp
@@ -6,7 +6,7 @@
 #include <string>
 #include <vector>
 
-#include <eigen3/Eigen/Dense>
+#include <Eigen/Dense>
 
 #include "Quadrature.hpp"
 


### PR DESCRIPTION
The original code over-specified the location of Eigen3 because it did not use the include dir found by CMake. This worked on a default install, but not on a custom install. This version should work in both cases.

Also remove the extra include in the `cpp` file.