### PR TITLE
Only require fortran compiler if building MCNP5/6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(DAGMC)
 cmake_minimum_required(VERSION 3.1)
-enable_language(Fortran)
+enable_language(CXX)
 
 # Set DAGMC version
 set(DAGMC_MAJOR_VERSION 3)
@@ -15,6 +15,11 @@ include(DAGMC_macros)
 dagmc_setup_build()
 
 dagmc_setup_options()
+
+if(BUILD_MCNP5 OR BUILD_MCNP6)
+  enable_language(Fortran)
+endif()
+
 
 find_package(MOAB REQUIRED)
 find_package(OpenMP)

--- a/news/PR-701.rst
+++ b/news/PR-701.rst
@@ -1,0 +1,12 @@
+**Added:** None
+
+**Changed:**
+  - No longer require Fortran compiler unless building MCNP5/6
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None


### PR DESCRIPTION
## Description
As of #686 we no longer have a strict dependency on a Fortran compiler unless we're building MCNP executables.

## Motivation and Context
For codes requiring only the C++ based libraries we build. These changes reduce our dependency list.