### PR TITLE
One should use direct path whenever possible

### DIFF
--- a/news/PR-0703.rst
+++ b/news/PR-0703.rst
@@ -1,0 +1,12 @@
+**Added:** None
+
+**Changed:** 
+- switching from relative path to direct one.
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/src/fluka/CMakeLists.txt
+++ b/src/fluka/CMakeLists.txt
@@ -11,6 +11,7 @@ set(LINK_LIBS_EXTERN_NAMES)
 include_directories(${CMAKE_SOURCE_DIR}/src/pyne)
 include_directories(${CMAKE_SOURCE_DIR}/src/dagmc)
 include_directories(${CMAKE_BINARY_DIR}/src/dagmc)
+include_directories(${CMAKE_SOURCE_DIR}/src/uwuw)
 
 dagmc_install_library(fludag)
 

--- a/src/fluka/fluka_funcs.h
+++ b/src/fluka/fluka_funcs.h
@@ -12,8 +12,8 @@
 #include "moab/Interface.hpp"
 #include "moab/CartVect.hpp"
 #include "DagMC.hpp"
-#include "../pyne/pyne.h"
-#include "../uwuw/uwuw.hpp"
+#include "pyne.h"
+#include "uwuw.hpp"
 
 // defines for the flkstk common block structure
 #define STACK_SIZE 40001 // because the fortran array goes from [0:40000]

--- a/src/geant4/app/include/DagSolidMaterial.hh
+++ b/src/geant4/app/include/DagSolidMaterial.hh
@@ -1,7 +1,7 @@
 #include <map>
 #include "G4SystemOfUnits.hh"
 #include "G4Material.hh"
-#include "../pyne/pyne.h"
+#include "pyne.h"
 
 #ifndef uwuw_hpp
 #define uwuw_hpp 1

--- a/src/geant4/app/include/DagSolidTally.hh
+++ b/src/geant4/app/include/DagSolidTally.hh
@@ -1,5 +1,5 @@
 #include <map>
-#include "../pyne/pyne.h"
+#include "pyne.h"
 
 /*
  * General note about UWUW-DagSolid tallies, the pure PyNE form is not currently

--- a/src/geant4/app/src/ExN01DetectorConstruction.cc
+++ b/src/geant4/app/src/ExN01DetectorConstruction.cc
@@ -38,7 +38,7 @@
 #include "DagSolidMaterial.hh"
 #include "DagSolidTally.hh"
 
-#include "../pyne/pyne.h"
+#include "pyne.h"
 
 moab::DagMC* dagmc = new moab::DagMC(); // create dag instance
 dagmcMetaData* DMD;

--- a/src/geant4/app/src/ExN01EventAction.cc
+++ b/src/geant4/app/src/ExN01EventAction.cc
@@ -11,7 +11,7 @@
 #include "G4HCofThisEvent.hh"
 #include "G4UnitsTable.hh"
 
-#include "../pyne/pyne.h"
+#include "pyne.h"
 #include "ExN01DetectorConstruction.hh"
 
 #include "Randomize.hh"

--- a/src/mcnp/CMakeLists.txt
+++ b/src/mcnp/CMakeLists.txt
@@ -11,6 +11,7 @@ include_directories(${CMAKE_SOURCE_DIR}/src/dagmc)
 include_directories(${CMAKE_BINARY_DIR}/src/dagmc)
 include_directories(${CMAKE_SOURCE_DIR}/src/tally)
 include_directories(${CMAKE_SOURCE_DIR}/src/pyne)
+include_directories(${CMAKE_SOURCE_DIR}/src/uwuw)
 
 message(STATUS "Building object library: mcnp_funcs")
 add_library(mcnp_funcs OBJECT mcnp_funcs.cpp)

--- a/src/mcnp/mcnp_funcs.h
+++ b/src/mcnp/mcnp_funcs.h
@@ -10,8 +10,8 @@
 #include <fstream>
 #include <sstream>
 
-#include "../uwuw/uwuw.hpp"
-#include "../pyne/pyne.h"
+#include "uwuw.hpp"
+#include "pyne.h"
 #include <unistd.h>
 
 #ifdef __cplusplus

--- a/src/uwuw/app/uwuw_preproc.hpp
+++ b/src/uwuw/app/uwuw_preproc.hpp
@@ -3,7 +3,7 @@
 #include <map>
 
 #include "uwuw.hpp"
-#include "../pyne/pyne.h"
+#include "pyne.h"
 #include "DagMC.hpp"
 
 class uwuw_preprocessor {

--- a/src/uwuw/tests/uwuw_unit_tests.cpp
+++ b/src/uwuw/tests/uwuw_unit_tests.cpp
@@ -9,7 +9,7 @@
 #include <stdio.h>
 
 #include "uwuw.hpp"
-#include "../pyne/pyne.h"
+#include "pyne.h"
 
 UWUW* workflow_data;
 

--- a/src/uwuw/tests/uwuw_unit_tests_tally.cpp
+++ b/src/uwuw/tests/uwuw_unit_tests_tally.cpp
@@ -1,7 +1,7 @@
 //  DagSolid_test.cpp
 #include <gtest/gtest.h>
 #include "uwuw.hpp"
-#include "../pyne/pyne.h"
+#include "pyne.h"
 
 #define TEST_FILE "mat_lib.h5"
 

--- a/src/uwuw/uwuw_preprocessor.hpp
+++ b/src/uwuw/uwuw_preprocessor.hpp
@@ -4,7 +4,7 @@
 #include <map>
 
 #include "uwuw.hpp"
-#include "../pyne/pyne.h"
+#include "pyne.h"
 #include "DagMC.hpp"
 #include "name_concatenator.hpp"
 


### PR DESCRIPTION
Changing `DAGMC` relative path to direct path, allowing external inclusion and usage of the different header files