### PR TITLE
Fix for setting precision and overlap tolerance.

### DIFF
--- a/news/PR-0708.rst
+++ b/news/PR-0708.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:**
+
+ - replaced calls for overlap tolerance and numerical precision in DagMC constructor
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/src/dagmc/DagMC.cpp
+++ b/src/dagmc/DagMC.cpp
@@ -70,6 +70,8 @@ DagMC::DagMC(std::shared_ptr<moab::Interface> mb_impl, double overlap_tolerance,
 #else
   ray_tracer = std::unique_ptr<RayTracer>(new RayTracer(GTT.get()));
 #endif
+  this->set_overlap_thickness(overlap_tolerance);
+  this->set_numerical_precision(p_numerical_precision);
 
   // This is the correct place to uniquely define default values for the dagmc settings
   defaultFacetingTolerance = .001;
@@ -88,8 +90,8 @@ DagMC::DagMC(Interface* mb_impl, double overlap_tolerance, double p_numerical_pr
 #else
   ray_tracer = std::unique_ptr<RayTracer>(new RayTracer(GTT.get()));
 #endif
-  ray_tracer->set_overlap_thickness(overlap_tolerance);
-  ray_tracer->set_numerical_precision(p_numerical_precision);
+  this->set_overlap_thickness(overlap_tolerance);
+  this->set_numerical_precision(p_numerical_precision);
 
   // This is the correct place to uniquely define default values for the dagmc settings
   defaultFacetingTolerance = .001;


### PR DESCRIPTION
@bam241 noticed that a couple of calls went missing for setting the numerical precision and overlap tolerance in #693. This beings those calls back in one of the `DagMC` constructors and makes those calls on the DagMC object itself rather than on the ray tracer.