### PR TITLE
Updating objects in some of the fluka_funcs functions.

### DIFF
--- a/news/PR-0713.rst
+++ b/news/PR-0713.rst
@@ -1,0 +1,14 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+
+  - pyne::MaterialLibrary calls in fluka_funcs.
+  - Tally::particle_name to Tally::particle_names update in fluka_funcs as well.
+
+**Security:** None

--- a/src/fluka/fluka_funcs.cpp
+++ b/src/fluka/fluka_funcs.cpp
@@ -985,7 +985,16 @@ void fludag_all_tallies(std::ostringstream& mstr, std::map<std::string, pyne::Ta
   std::list<std::string> tally_parts;
   std::string tally_id;
   for (it = tally_map.begin() ; it != tally_map.end() ; ++it) {
-    tally_id = (it->second).tally_type + "/" + (it->second).particle_names[0];
+
+    std::string particle_name = (it->second).particle_names.at(0);
+
+    if ((it->second).particle_names.size() > 1) {
+      std::cerr << "Warning: Multiple particles specified on a tally. "
+                   "Only the first particle (" << particle_name <<
+                   ") will be used." << std::endl;
+    }
+
+    tally_id = (it->second).tally_type + "/" + particle_name;
     if (std::count(tally_parts.begin(), tally_parts.end(), tally_id) == 0) {
       tally_parts.insert(tally_parts.end(), tally_id);
     }
@@ -1007,7 +1016,7 @@ void fludag_all_tallies(std::ostringstream& mstr, std::map<std::string, pyne::Ta
     ss << ".";
     tally.entity_name = ss.str();
 
-    std::string tally_id = tally.tally_type + "/" + tally.particle_names[0];
+    std::string tally_id = tally.tally_type + "/" + tally.particle_names.at(0);
 
     std::list<std::string>::iterator iter = std::find(tally_parts.begin(), tally_parts.end(), tally_id);
 

--- a/src/fluka/fluka_funcs.cpp
+++ b/src/fluka/fluka_funcs.cpp
@@ -988,8 +988,8 @@ void fludag_all_tallies(std::ostringstream& mstr, std::map<std::string, pyne::Ta
 
     if ((it->second).particle_names.size() > 1) {
       std::cerr << "Warning: Multiple particles specified on a tally. "
-                   "Only the first particle (" << particle_name <<
-                   ") will be used." << std::endl;
+                "Only the first particle (" << particle_name <<
+                ") will be used." << std::endl;
     }
 
     tally_id = (it->second).tally_type + "/" + particle_name;

--- a/src/fluka/fluka_funcs.cpp
+++ b/src/fluka/fluka_funcs.cpp
@@ -815,8 +815,7 @@ void fludag_write(std::string matfile, std::string lfname) {
 
   // ASSIGNMA Cards
   std::ostringstream assignma_str;
-  pyne::mat_map mat_lib = workflow_data.material_library.get_mat_library();
-  fludagwrite_assignma(assignma_str, mat_lib);
+  fludagwrite_assignma(assignma_str, workflow_data.material_library);
 
   // get the importances
   std::ostringstream importance_str;
@@ -834,8 +833,7 @@ void fludag_write(std::string matfile, std::string lfname) {
   if (workflow_data.material_library.size() != 0) {
     // write COMPOUND CARDS
     std::ostringstream material_str;
-    pyne::mat_map mat_lib = workflow_data.material_library.get_mat_library();
-    fludag_all_materials(material_str, mat_lib);
+    fludag_all_materials(material_str, workflow_data.material_library);
     lcadfile << material_str.str();
     lcadfile << header << std::endl;
   }
@@ -924,8 +922,8 @@ void fludagwrite_importances(std::ostringstream& ostr) {
 //---------------------------------------------------------------------------//
 // Put the ASSIGNMAt statements in the output ostringstream
 void fludagwrite_assignma(std::ostringstream& ostr,
-                          const pyne::mat_map& pyne_map) {
-  pyne::mat_map::const_iterator it;
+                          const pyne::MaterialLibrary& pyne_map) {
+  pyne::MaterialLibrary::const_iterator it;
   for (it = pyne_map.begin(); it != pyne_map.end(); it++) {
     std::cout << it->first << std::endl;
   }
@@ -955,7 +953,7 @@ void fludagwrite_assignma(std::ostringstream& ostr,
       // otherwise we assume uwuw
       // if you arent graveyard or vacuum you must be in the uwuw library
       if (mat_prop.find("Graveyard") == std::string::npos && mat_prop.find("Vacuum") == std::string::npos) {
-        pyne::Material material = *(pyne_map.at(mat_prop));
+        pyne::Material material = pyne_map.get_material(mat_prop);
         mat_name = material.metadata["fluka_name"].asString();
         std::cout << mat_name << std::endl;
       } else if (mat_prop.find("Graveyard") != std::string::npos) {
@@ -1038,7 +1036,7 @@ void fludag_all_tallies(std::ostringstream& mstr, std::map<std::string, pyne::Ta
 //---------------------------------------------------------------------------//
 // Get material cards for all materials in the problem, both elemental and compounds
 void fludag_all_materials(std::ostringstream& mstr,
-                          const pyne::mat_map& pyne_map) {
+                          const pyne::MaterialLibrary& pyne_map) {
   std::set<int> exception_set = make_exception_set();
 
   std::map<int, std::string> map_nucid_fname;
@@ -1046,7 +1044,7 @@ void fludag_all_materials(std::ostringstream& mstr,
   pyne::Material unique = pyne::Material();
 
   // loop over all materials, summing
-  pyne::mat_map::const_iterator nuc;
+  pyne::MaterialLibrary::const_iterator nuc;
   for (nuc = pyne_map.begin(); nuc != pyne_map.end(); ++nuc) {
     unique = unique + *(nuc->second);
   }

--- a/src/fluka/fluka_funcs.cpp
+++ b/src/fluka/fluka_funcs.cpp
@@ -1044,9 +1044,9 @@ void fludag_all_materials(std::ostringstream& mstr,
   pyne::Material unique = pyne::Material();
 
   // loop over all materials, summing
-  pyne::MaterialLibrary::const_iterator nuc;
-  for (nuc = pyne_map.begin(); nuc != pyne_map.end(); ++nuc) {
-    unique = unique + *(nuc->second);
+  pyne::MaterialLibrary::const_iterator mat;
+  for (mat = pyne_map.begin(); mat != pyne_map.end(); ++mat) {
+    unique = unique + *(mat->second);
   }
   // now collapse elements
   unique = unique.collapse_elements(exception_set);
@@ -1054,14 +1054,14 @@ void fludag_all_materials(std::ostringstream& mstr,
   // remove those that are no longer needed due to
   // compound card inclusions
   // now write out material card & compound card for each compound
-  for (nuc = pyne_map.begin() ; nuc != pyne_map.end(); ++nuc) {
-    pyne::Material compound = (nuc->second)->collapse_elements(exception_set);
+  for (mat = pyne_map.begin() ; mat != pyne_map.end(); ++mat) {
+    pyne::Material compound = (mat->second)->collapse_elements(exception_set);
     // if only one element in comp, then we can remove the one that exists
     // in the unique material
     if (compound.comp.size() == 1) {
-      pyne::comp_iter nuc = compound.comp.begin();
+      pyne::comp_iter mat = compound.comp.begin();
       std::set<int> nuc2del;
-      nuc2del.insert(nuc->first);
+      nuc2del.insert(mat->first);
       // remove the nuclide from the unique list
       unique = unique.del_mat(nuc2del);
     }
@@ -1090,8 +1090,8 @@ void fludag_all_materials(std::ostringstream& mstr,
 
   // now write out material card & compound card for each compound
   std::string compound_string;
-  for (nuc = pyne_map.begin() ; nuc != pyne_map.end(); ++nuc) {
-    pyne::Material compound = (nuc->second)->collapse_elements(exception_set);
+  for (mat = pyne_map.begin() ; mat != pyne_map.end(); ++mat) {
+    pyne::Material compound = (mat->second)->collapse_elements(exception_set);
     compound_string = compound.fluka(i);
     if (compound_string.length() != 0) {
       i++;

--- a/src/fluka/fluka_funcs.h
+++ b/src/fluka/fluka_funcs.h
@@ -502,7 +502,7 @@ void fludagwrite_importances(std::ostringstream& ostr);
  * \param[in] map_name ???
  */
 void fludagwrite_assignma(std::ostringstream& ostr,
-                          std::map<std::string, pyne::Material> pyne_map);
+                          const pyne::mat_map& pyne_map);
 /**
  * \brief writes all the material compisitions from the map of materials to output stream
  *
@@ -511,7 +511,7 @@ void fludagwrite_assignma(std::ostringstream& ostr,
  *
  */
 void fludag_all_materials(std::ostringstream& mstr,
-                          std::map<std::string, pyne::Material> pyne_list);
+                          const pyne::mat_map& pyne_list);
 
 /**
  * \brief Writes all the PyNE tally objects out that are contained in the tally map

--- a/src/fluka/fluka_funcs.h
+++ b/src/fluka/fluka_funcs.h
@@ -502,7 +502,7 @@ void fludagwrite_importances(std::ostringstream& ostr);
  * \param[in] map_name ???
  */
 void fludagwrite_assignma(std::ostringstream& ostr,
-                          const pyne::mat_map& pyne_map);
+                          const pyne::MaterialLibrary& pyne_map);
 /**
  * \brief writes all the material compisitions from the map of materials to output stream
  *
@@ -511,7 +511,7 @@ void fludagwrite_assignma(std::ostringstream& ostr,
  *
  */
 void fludag_all_materials(std::ostringstream& mstr,
-                          const pyne::mat_map& pyne_list);
+                          const pyne::MaterialLibrary& pyne_map);
 
 /**
  * \brief Writes all the PyNE tally objects out that are contained in the tally map


### PR DESCRIPTION
I took a crack at updating the calls for the PyNE material library in the `fluka_funcs.*` files that were failing to compile, as reported by @ljacobson64  in #712.

The issues with the update from `Tally::particle_name` to `Tally::particle_names` in PyNE is more subtle. What I have in there is likely insufficient. Should those FLUKA routines create multiple tallies if multiple particle names exist? Should that routine fail? Any guidance here is appreciated @bam241 @makeclean @gonuke.