### PR TITLE
Add BUILD_EXE as cmake option

### DIFF
--- a/cmake/DAGMC_macros.cmake
+++ b/cmake/DAGMC_macros.cmake
@@ -297,7 +297,7 @@ endmacro ()
 
 # Install a unit test
 macro (dagmc_install_test test_name ext)
-  if (NOT BUILD_EXEC)
+  if (NOT BUILD_EXE)
       message(STATUS "Skipping unit tests ${test_name} build.")
   else ()
     message(STATUS "Building unit tests: ${test_name}")

--- a/cmake/DAGMC_macros.cmake
+++ b/cmake/DAGMC_macros.cmake
@@ -102,7 +102,7 @@ endif()
   endif ()
   if (NOT BUILD_SHARED_LIBS AND NOT BUILD_STATIC_EXE AND BUILD_EXE)
     SET(BUILD_EXE OFF)
-    message("Turning BUILD_EXE to OFF: SHARED_BUIL_LIBS and BUILD_STATIC_EXE are OFF")
+    message("Turning BUILD_EXE OFF: SHARED_BUILD_LIBS and BUILD_STATIC_EXE are OFF")
   endif ()
 
 endmacro ()

--- a/cmake/DAGMC_macros.cmake
+++ b/cmake/DAGMC_macros.cmake
@@ -66,7 +66,7 @@ macro (dagmc_setup_options)
   option(BUILD_SHARED_LIBS "Build shared libraries" ON)
   option(BUILD_STATIC_LIBS "Build static libraries" ON)
 
-  option(BUILD_EXE i      "Build DAGMC executables"  ON)
+  option(BUILD_EXE        "Build DAGMC executables"  ON)
   option(BUILD_STATIC_EXE "Build static executables" OFF)
   option(BUILD_PIC        "Build with PIC"           OFF)
 

--- a/cmake/DAGMC_macros.cmake
+++ b/cmake/DAGMC_macros.cmake
@@ -53,12 +53,12 @@ macro (dagmc_setup_options)
 
   option(BUILD_FLUKA "Build FluDAG" OFF)
 
-  option(BUILD_UWUW "Build UWUW library and uwuw_preproc" ON)
+  option(BUILD_UWUW  "Build UWUW library and uwuw_preproc" ON)
   option(BUILD_TALLY "Build dagtally library"              ON)
 
   option(BUILD_BUILD_OBB       "Build build_obb tool"       ON)
   option(BUILD_MAKE_WATERTIGHT "Build make_watertight tool" ON)
-  option(BUILD_OVERLAP_CHECK "Build overlap_check tool" ON)
+  option(BUILD_OVERLAP_CHECK   "Build overlap_check tool"   ON)
 
   option(BUILD_TESTS    "Build unit tests" ON)
   option(BUILD_CI_TESTS "Build everything needed to run the CI tests" OFF)
@@ -66,7 +66,7 @@ macro (dagmc_setup_options)
   option(BUILD_SHARED_LIBS "Build shared libraries" ON)
   option(BUILD_STATIC_LIBS "Build static libraries" ON)
 
-  option(BUILD_EXE "Build DAGMC executables" ON)
+  option(BUILD_EXE i      "Build DAGMC executables"  ON)
   option(BUILD_STATIC_EXE "Build static executables" OFF)
   option(BUILD_PIC        "Build with PIC"           OFF)
 

--- a/cmake/DAGMC_macros.cmake
+++ b/cmake/DAGMC_macros.cmake
@@ -243,7 +243,8 @@ macro (dagmc_install_library lib_name)
   if (BUILD_STATIC_LIBS)
     add_library(${lib_name}-static STATIC ${SRC_FILES})
     set_target_properties(${lib_name}-static
-      PROPERTIES OUTPUT_NAME ${lib_name})
+      PROPERTIES OUTPUT_NAME ${lib_name}
+      PUBLIC_HEADER "${PUB_HEADERS}")
     if (BUILD_RPATH)
       set_target_properties(${lib_name}-static
         PROPERTIES INSTALL_RPATH "" INSTALL_RPATH_USE_LINK_PATH FALSE)

--- a/news/PR-0717.rst
+++ b/news/PR-0717.rst
@@ -3,7 +3,7 @@
   without the executable (for static and/or shared libs)
 
 **Changed:** None
-
+- now install dagmc header when building and instaling static libs
 **Deprecated:** None
 
 **Removed:** None

--- a/news/PR-0717.rst
+++ b/news/PR-0717.rst
@@ -1,9 +1,12 @@
 **Added:**
+
 - adding BUILD_EXE option (default ON) alowing to build only the dagmc libs
   without the executable (for static and/or shared libs)
 
 **Changed:** None
+
 - now install dagmc header when building and instaling static libs
+
 **Deprecated:** None
 
 **Removed:** None

--- a/news/PR-0717.rst
+++ b/news/PR-0717.rst
@@ -1,0 +1,13 @@
+**Added:**
+- adding BUILD_EXE option (default ON) alowing to build only the dagmc libs
+  without the executable (for static and/or shared libs)
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None


### PR DESCRIPTION
This should allow to build dagmc libs (shared and.or static) without the exe.
