### PR TITLE
add compatibility flag required to build PyNE against hdf5@1.12+

### DIFF
--- a/news/PR-0728.rst
+++ b/news/PR-0728.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:**
+- adding special build flag to enable old hdf5 interface for PyNE when compiling
+  against hdf5@1.12+
+
+**Security:** None

--- a/src/pyne/CMakeLists.txt
+++ b/src/pyne/CMakeLists.txt
@@ -12,4 +12,8 @@ if (CMAKE_Fortran_COMPILER_ID STREQUAL "Intel")
   set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O0 -g")
 endif ()
 
+if(NOT (${HDF5_VERSION} VERSION_LESS 1.12.0))
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DH5Oget_info_by_idx_vers=1 -DH5O_info_t_vers=1 -DH5Oget_info_by_name_vers=1")
+ endif()
+
 dagmc_install_library(pyne_dagmc)


### PR DESCRIPTION
deprecation in hdf5 1.12 change the interfaces.
this allows to use the old interface with `hdf5 1.12+` on which PyNE relies.
see pyne/pyne#1220 for more details