### PR TITLE
Checkout PyNE submodule as part of CMake

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
         type: string
     docker:
       - image: svalinn/dagmc-ci-ubuntu-18.04-housekeeping:latest
-        auth: 
+        auth:
           username: $DOCKERHUB_USER
           password: $DOCKERHUB_PASS
     working_directory: /root/build_dir/DAGMC
@@ -36,16 +36,12 @@ jobs:
         default: "OFF"
     docker:
       - image: svalinn/dagmc-ci-ubuntu-<< parameters.img >>-<< parameters.compiler >>-ext-hdf5_<< parameters.hdf5 >>-moab_<< parameters.moab >>:latest
-        auth: 
+        auth:
           username: $DOCKERHUB_USER
           password: $DOCKERHUB_PASS
     working_directory: /root/build_dir/DAGMC
     steps:
       - checkout
-      - run:
-          name: "Pull Submodules"
-          command: |
-            git submodule update --init 
       - run:
           name: Setup environment
           command: |
@@ -66,7 +62,7 @@ workflows:
   version: 2
   pull_request: # Run only for PullRequest
     jobs:
-      
+
       - house_keeping:
           context: dockerhub
           matrix:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ set(DAGMC_VERSION ${DAGMC_MAJOR_VERSION}.${DAGMC_MINOR_VERSION}.${DAGMC_PATCH_VE
 
 # Set git SHA1 hash as a compile definition
 find_package(Git)
-if(GIT_FOUND)
+if(GIT_FOUND AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")
   execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse HEAD
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     RESULT_VARIABLE DAGMC_GIT_SHA_SUCCESS
@@ -22,6 +22,24 @@ if(GIT_FOUND)
     message(WARNING "Could not determine the commit SHA for DAGMC.")
     set(DAGMC_GIT_SHA "")
   endif()
+
+  option(GIT_SUBMODULE "Check submodules during build" ON)
+  if(GIT_SUBMODULE)
+    message(STATUS "Submodule update")
+    execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive
+                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                    RESULT_VARIABLE GIT_SUBMOD_RESULT)
+    if(NOT GIT_SUBMOD_RESULT EQUAL 0)
+      message(FATAL_ERROR "git submodule update --init failed with \
+        ${GIT_SUBMOD_RESULT}, please checkout submodules")
+    endif()
+  endif()
+endif()
+
+# Check to see if submodules exist (by checking one)
+if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/src/pyne/README.md")
+  message(FATAL_ERROR "The git submodules were not downloaded! GIT_SUBMODULE was \
+    turned off or failed. Please update submodules and try again.")
 endif()
 
 # Make the scripts in the "cmake" directory available to CMake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ if(GIT_FOUND AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")
   option(GIT_SUBMODULE "Check submodules during build" ON)
   if(GIT_SUBMODULE)
     message(STATUS "Submodule update")
+    set(ENV{jobs} "")
     execute_process(COMMAND ${GIT_EXECUTABLE} "submodule" "update" "--init" "--recursive"
                     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
                     RESULT_VARIABLE GIT_SUBMOD_RESULT)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ if(GIT_FOUND AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")
                     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
                     RESULT_VARIABLE GIT_SUBMOD_RESULT)
     if(NOT GIT_SUBMOD_RESULT EQUAL 0)
-      message(FATAL_ERROR "git submodule update --init failed with \
+      message(FATAL_ERROR "git submodule update --init --recursive failed with \
         ${GIT_SUBMOD_RESULT}, please checkout submodules")
     endif()
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ if(GIT_FOUND AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")
   option(GIT_SUBMODULE "Check submodules during build" ON)
   if(GIT_SUBMODULE)
     message(STATUS "Submodule update")
-    execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive
+    execute_process(COMMAND ${GIT_EXECUTABLE} "submodule" "update" "--init" "--recursive"
                     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
                     RESULT_VARIABLE GIT_SUBMOD_RESULT)
     if(NOT GIT_SUBMOD_RESULT EQUAL 0)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ if(GIT_FOUND AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")
 endif()
 
 # Check to see if submodules exist (by checking one)
-if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/src/pyne/README.md")
+if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/src/pyne/pyne/readme.rst")
   message(FATAL_ERROR "The git submodules were not downloaded! GIT_SUBMODULE was \
     turned off or failed. Please update submodules and try again.")
 endif()

--- a/news/PR-0734.rst
+++ b/news/PR-0734.rst
@@ -1,0 +1,13 @@
+**Added:**
+
+  - CMake option to checkout PyNE submodule automatically
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None


### PR DESCRIPTION
## Description
Adds an option (default ON) to checkout the PyNE submodule as part of the CMake configuration step.

## Motivation and Context
The addition of this submodule in DAGMC makes updates of PyNE in DAGMC more elegant, but it also requires an extra manual step in DAGMC installation (`git submodule update --init`). There are many build scripts/CI scripts out there that don't include this step and will break as a result.

## Changes
This PR incorporates the submodule initialization and update into the CMake step, meaning that no external build scripts will need to change due to the use of PyNE as a submodule. 

## Behavior
As mentioned above, a section has been added to `CMakeLists.txt` that will checkout the PyNE submodule automatically. If `git` is found on the system, the option `GIT_SUBMODULE` is added with a default value of `ON`. This option can be turned off for development with new versions of PyNE in DAGMC (another benefit of using the submodule as opposed to the previous approach). If `git` is not available, then this option will not appear in the CMake configuration and we will expect that the PyNE submodule is already present in the DAGMC source.