### PR TITLE
Change name of var for make file parallelization

### DIFF
--- a/CI/circleci/build_dagmc.sh
+++ b/CI/circleci/build_dagmc.sh
@@ -47,7 +47,7 @@ function build_dagmc() {
                -DCMAKE_INSTALL_PREFIX=${install_dir} \
                -DDOUBLE_DOWN=${double_down} \
                -Ddd_ROOT=${double_down_install_dir}
-  make -j${jobs}
+  make -j${ci_jobs}
   make install
 }
 

--- a/CI/circleci/build_double_down.sh
+++ b/CI/circleci/build_double_down.sh
@@ -13,6 +13,6 @@ ln -snf double-down src
 cd ${double_down_build_dir}/bld
 cmake ${double_down_build_dir}/src -DCMAKE_INSTALL_PREFIX=${double_down_install_dir} \
       -DMOAB_DIR=${moab_install_dir} -DEMBREE_DIR=$HOME/EMBREE/
-make -j${jobs}
+make -j${ci_jobs}
 make install
 cd

--- a/CI/docker/build_geant4.sh
+++ b/CI/docker/build_geant4.sh
@@ -27,7 +27,7 @@ cmake ../geant4.${geant4_version} -DBUILD_STATIC_LIBS=ON \
              -DCMAKE_CXX_COMPILER=${CXX} \
              -DCMAKE_INSTALL_RPATH=${geant4_install_dir}/lib \
              -DCMAKE_INSTALL_PREFIX=${geant4_install_dir}
-make -j${jobs}
+make -j${ci_jobs}
 make install
 cd
 rm -rf ${geant4_build_dir}

--- a/CI/docker/build_geant4.sh
+++ b/CI/docker/build_geant4.sh
@@ -3,24 +3,26 @@
 set -ex
 
 # Geant version and corresponding SHASUM
-export geant4_version=10.05
-export geant4_shasum=4b05b4f7d50945459f8dbe287333b9efb772bd23d50920630d5454ec570b782d
+export geant4_version=10.5.1
+export geant4_basename=geant4-v${geant4_version}
+export geant4_tarball=${geant4_basename}.tar.gz
+export geant4_shasum=2397eb859dc4de095ff66059d8bda9f060fdc42e10469dd7890946293eeb0e39
 
 source ${docker_env}
 
 rm -rf ${geant4_build_dir}/bld ${geant4_install_dir}
 mkdir -p ${geant4_build_dir}/bld
 cd ${geant4_build_dir}
-wget https://gitlab.cern.ch/geant4/geant4/-/archive/v10.5.1/geant4-v10.5.1.tar.gz --no-check-certificate
-tar_chashum=$(sha256sum ${geant4_version}.tar.gz | cut -d' ' -f1)
+wget https://gitlab.cern.ch/geant4/geant4/-/archive/v${geant4_version}/${geant4_tarball} --no-check-certificate
+tar_chashum=$(sha256sum ${geant4_tarball} | cut -d' ' -f1)
 if [ $geant4_shasum != $tar_chashum ]; then
     echo "Bad shasum for Geant4 tar!"
     exit 1
 fi
 
-tar -xzf geant4.${geant4_version}.tar.gz
+tar -xzf ${geant4_tarball}
 cd bld
-cmake ../geant4.${geant4_version} -DBUILD_STATIC_LIBS=ON \
+cmake ../${geant4_basename} -DBUILD_STATIC_LIBS=ON \
              -DGEANT4_USE_SYSTEM_EXPAT=OFF \
              -DCMAKE_BUILD_TYPE=Release \
              -DCMAKE_C_COMPILER=${CC} \

--- a/CI/docker/build_geant4.sh
+++ b/CI/docker/build_geant4.sh
@@ -11,7 +11,7 @@ source ${docker_env}
 rm -rf ${geant4_build_dir}/bld ${geant4_install_dir}
 mkdir -p ${geant4_build_dir}/bld
 cd ${geant4_build_dir}
-wget https://geant4.cern.ch/support/source/geant4.${geant4_version}.tar.gz --no-check-certificate
+wget https://gitlab.cern.ch/geant4/geant4/-/archive/v10.5.1/geant4-v10.5.1.tar.gz --no-check-certificate
 tar_chashum=$(sha256sum ${geant4_version}.tar.gz | cut -d' ' -f1)
 if [ $geant4_shasum != $tar_chashum ]; then
     echo "Bad shasum for Geant4 tar!"

--- a/CI/docker/build_hdf5.sh
+++ b/CI/docker/build_hdf5.sh
@@ -29,7 +29,7 @@ cd bld
 ../hdf5-${HDF5_VERSION}/configure --enable-shared \
                  --prefix=${hdf5_install_dir} \
                  CC=${CC} CXX=${CXX}
-make -j${jobs}
+make -j${ci_jobs}
 make install
 cd
 rm -rf ${hdf5_build_dir}

--- a/CI/docker/build_moab.sh
+++ b/CI/docker/build_moab.sh
@@ -26,7 +26,7 @@ cd ../bld
                  --with-hdf5=${hdf5_install_dir} \
                  --prefix=${moab_install_dir} \
                  CC=${CC} CXX=${CXX}
-make -j${jobs}
+make -j${ci_jobs}
 make install
 cd
 rm -rf ${moab_build_dir}

--- a/CI/env.sh
+++ b/CI/env.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export jobs=`grep -c processor /proc/cpuinfo`
+export ci_jobs=`grep -c processor /proc/cpuinfo`
 
 export CTEST_OUTPUT_ON_FAILURE=1
 
@@ -20,7 +20,7 @@ export  FC=`which gfortran`
 if [ "$COMPILER" == "gcc" ]; then
   export  CC=`which gcc`
   export CXX=`which g++`
-  export jobs="4"
+  export ci_jobs="4"
 elif [ "$COMPILER" == "clang" ]; then
   export  CC=`which clang`
   export CXX=`which clang++`

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,6 @@ if(GIT_FOUND AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")
   option(GIT_SUBMODULE "Check submodules during build" ON)
   if(GIT_SUBMODULE)
     message(STATUS "Submodule update")
-    set(ENV{jobs} "")
     execute_process(COMMAND ${GIT_EXECUTABLE} "submodule" "update" "--init" "--recursive"
                     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
                     RESULT_VARIABLE GIT_SUBMOD_RESULT)

--- a/news/PR-0735.rst
+++ b/news/PR-0735.rst
@@ -2,11 +2,14 @@
 
 **Changed:** None
 
+- updated location & checksum of GEANT4 tarball
+ 
 **Deprecated:** None
 
 **Removed:** None
 
 **Fixed:** 
+
 - Renamed `jobs` variable CI build system to avoid undocumented conflict with `git submodule`
 
 **Security:** None

--- a/news/PR-0735.rst
+++ b/news/PR-0735.rst
@@ -1,0 +1,12 @@
+**Added:** None
+
+**Changed:** None
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** 
+- Renamed `jobs` variable CI build system to avoid undocumented conflict with `git submodule`
+
+**Security:** None


### PR DESCRIPTION
## Description
Change the name of the variable used in CI to manage `make` parallelization from `jobs` to `ci_jobs`.

## Motivation and Context
The variable `jobs` is used in undocumented/poorly documented ways by the `git submodule` command.  We have used a variable with that name in our CI scripts to pass the number of processors to `make -j` for build parallelization.  Changing the name of this variable should allow `git submodule` to work as expected. (as introduced in #734)

Reference: https://github.com/git/git/blame/3a0b884caba2752da0af626fb2de7d597c844e8b/git-submodule.sh
In the last 3-5 years, `git submodule` started using this env variable to expose parallelism to the user.  E.g. Line 547 was added to this file about 3 years ago. Line 50 was added in the above about 12 months ago, indicating a similar problem identified within the git project.  Presumably, newer versions of `git` would not see this problem, just as older versions of `git` did not.


## Changes
This is best described as a bug fix.

## Behavior
Prior to this change, calls to `git submodule` would fail with an unknown pathspec with the same value as the `jobs` variable.

After this change, calls to `git submodule` should work correctly.