### PR TITLE
Enable double-down in CI for pull requests.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,7 @@ workflows:
               only: develop
       - build_and_test:
           context: dockerhub
-          name: "Double Down"
+          name: "Double-Down"
           img: "18.04"
           compiler: "gcc"
           hdf5: "1.10.4"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,6 +86,18 @@ workflows:
             branches:
               ignore: develop
 
+      - build_and_test:
+          context: dockerhub
+          name: "Double Down"
+          img: "18.04"
+          compiler: "gcc"
+          hdf5: "1.10.4"
+          moab: "master"
+          double_down: "ON"
+          filters:
+            branches:
+              ignore: develop
+
   merge:  # Run only on develop change -> when merging a PullRequest
     jobs:
       - build_and_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ workflows:
 
       - build_and_test:
           context: dockerhub
-          name: "Double Down"
+          name: "Double-Down"
           img: "18.04"
           compiler: "gcc"
           hdf5: "1.10.4"

--- a/news/PR-0738.rst
+++ b/news/PR-0738.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:**
+
+  - Added a job to CI for running tests with the DOUBLE_DOWN option enabled.
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None


### PR DESCRIPTION
Seeing as this option is being increasingly used outside of DAGMC, I'd like to add it to CI run with pull requests to make sure things aren't breaking as development continues.