### PR TITLE
targeting 9c96d17 MOAB commit instead of version 5.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ workflows:
               img: [ "16.04", "18.04"]
               compiler: ["clang", "gcc"]
               hdf5: ["1.10.4"]
-              moab: ["5.1.0"]
+              moab: ["9c96d17"]
           requires:
             - house_keeping
           filters:
@@ -95,7 +95,7 @@ workflows:
               img: [ "16.04", "18.04"]
               compiler: ["clang", "gcc"]
               hdf5: ["1.10.4"]
-              moab: ["5.1.0", "develop", "master"]
+              moab: ["9c96d17", "develop", "master"]
           filters:
             branches:
               only: develop

--- a/CI/Dockerfile_3_moab
+++ b/CI/Dockerfile_3_moab
@@ -7,8 +7,8 @@ FROM svalinn/dagmc-ci-ubuntu-${UBUNTU_VERSION}-${COMPILER}-ext-hdf5_${HDF5}
 ENV moab_build_dir=${build_dir}/moab
 ENV moab_install_dir=${install_dir}/moab
 
-# MOAB Verions: 5.1.0
-ARG MOAB=5.1.0
+# MOAB Commit: 9c96d17 (Merged commit of @pshriwise thread fix)
+ARG MOAB=9c96d17
 ENV MOAB_VERSION ${MOAB}
 RUN if [ "${MOAB_VERSION}" != "master" ] && [ "${MOAB_VERSION}" != "develop" ]; then \
         /root/etc/CI/docker/build_moab.sh; \

--- a/CI/docker/build_moab.sh
+++ b/CI/docker/build_moab.sh
@@ -8,7 +8,7 @@ if [ ${MOAB_VERSION} == "master" ] || [ ${MOAB_VERSION} == "develop" ]; then
   branch=${MOAB_VERSION}
 else
 #  branch=Version${MOAB_VERSION}
-  commit=${MOAB_VERSION}
+  branch=${MOAB_VERSION}
 fi
 
 rm -rf ${moab_build_dir}/bld ${moab_install_dir}

--- a/CI/docker/build_moab.sh
+++ b/CI/docker/build_moab.sh
@@ -7,7 +7,8 @@ source ${docker_env}
 if [ ${MOAB_VERSION} == "master" ] || [ ${MOAB_VERSION} == "develop" ]; then
   branch=${MOAB_VERSION}
 else
-  branch=Version${MOAB_VERSION}
+#  branch=Version${MOAB_VERSION}
+  commit=${MOAB_VERSION}
 fi
 
 rm -rf ${moab_build_dir}/bld ${moab_install_dir}

--- a/CI/docker/build_moab.sh
+++ b/CI/docker/build_moab.sh
@@ -14,7 +14,9 @@ fi
 rm -rf ${moab_build_dir}/bld ${moab_install_dir}
 mkdir -p ${moab_build_dir}/bld
 cd ${moab_build_dir}
-git clone --depth 1 https://bitbucket.org/fathomteam/moab -b ${branch}
+#git clone --depth 1 https://bitbucket.org/fathomteam/moab -b ${branch}
+git clone https://bitbucket.org/fathomteam/moab 
+git checkout ${branch}
 cd moab
 autoreconf -fi
 cd ../bld

--- a/CI/docker/build_moab.sh
+++ b/CI/docker/build_moab.sh
@@ -16,8 +16,8 @@ mkdir -p ${moab_build_dir}/bld
 cd ${moab_build_dir}
 #git clone --depth 1 https://bitbucket.org/fathomteam/moab -b ${branch}
 git clone https://bitbucket.org/fathomteam/moab 
-git checkout ${branch}
 cd moab
+git checkout ${branch}
 autoreconf -fi
 cd ../bld
 ../moab/configure --enable-pymoab \

--- a/CI/update_docker.sh
+++ b/CI/update_docker.sh
@@ -18,7 +18,7 @@ done
 ubuntu_versions="16.04 18.04"
 compilers="gcc clang"
 hdf5_versions="1.10.4"
-moab_versions="5.1.0 develop master"
+moab_versions="9c96d17 develop master"
 for ubuntu_version in ${ubuntu_versions}; do
   image_name="svalinn/dagmc-ci-ubuntu-${ubuntu_version}"
   docker build -t ${image_name} --build-arg UBUNTU_VERSION=${ubuntu_version} \

--- a/news/PR-0740.rst
+++ b/news/PR-0740.rst
@@ -1,0 +1,12 @@
+**Added:** None
+
+**Changed:** 
+- docker stack now checks out commit 9c96d17 (Merged commit of @pshriwise thread fix)
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None


### PR DESCRIPTION
This is a temporary MOAB update in CI to allow our CI to pass.


this will be change at the next MOAB release


I am building the docker stack right now, I'll push them on request