### PR TITLE
Fix for overlap check test

### DIFF
--- a/news/PR-0743.rst
+++ b/news/PR-0743.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:**
+
+  - Threadsafe fix for the overlap check test.
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/src/overlap_check/overlap.cpp
+++ b/src/overlap_check/overlap.cpp
@@ -31,6 +31,7 @@ ErrorCode check_location_for_overlap(std::shared_ptr<GeomQueryTool>& GQT,
   }
 
   if (vols_found.size() > 1) {
+    #pragma omp critical
     overlap_map[vols_found] = loc;
   }
 
@@ -51,6 +52,7 @@ ErrorCode check_location_for_overlap(std::shared_ptr<GeomQueryTool>& GQT,
   }
 
   if (vols_found.size() > 1) {
+    #pragma omp critical
     overlap_map[vols_found] = loc;
   }
 

--- a/src/overlap_check/overlap.cpp
+++ b/src/overlap_check/overlap.cpp
@@ -31,7 +31,7 @@ ErrorCode check_location_for_overlap(std::shared_ptr<GeomQueryTool>& GQT,
   }
 
   if (vols_found.size() > 1) {
-    #pragma omp critical
+#pragma omp critical
     overlap_map[vols_found] = loc;
   }
 
@@ -52,7 +52,7 @@ ErrorCode check_location_for_overlap(std::shared_ptr<GeomQueryTool>& GQT,
   }
 
   if (vols_found.size() > 1) {
-    #pragma omp critical
+#pragma omp critical
     overlap_map[vols_found] = loc;
   }
 


### PR DESCRIPTION
## Description
Threadsafe fix for the overlap check test. The `overlap_map` shared variable was being modified in an unprotected block and could potentially be modified by multiple threads at once.