### PR TITLE
moved to sequential docker building

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -2,36 +2,21 @@ on:
   push:
     paths:
       - 'CI/*'
+      - '.github/workflows/docker_publish.yml'
 
 jobs:
-  build-and-push-image:
+
+  build_and_push_housekeeping:
     runs-on: ubuntu-latest
-
-    env:
-      hdf5_versions: 1.10.4
-      hdf5_build_dir: hdf5_build_dir
-
     strategy:
       matrix:
-       ubuntu_versions : [
+        ubuntu_versions : [
           16.04,
           18.04,
-          ]
-       compiler : [
-          gcc,
-          clang,
-          ]
-       hdf5_versions : [
-         1.10.4,
-       ]
-       moab_versions : [
-         9c96d17,
-         develop,
-         master,
-       ]
-
+        ]
 
     steps:
+
       - name: Checkout repository
         uses: actions/checkout@v2
 
@@ -45,7 +30,42 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push Dockerfile_0_base
+      - name: Build and push housekeeping
+        uses: docker/build-push-action@v2
+        with:
+          file: CI/Dockerfile_1_housekeeping
+          context: .
+          push: true
+          build-args: |
+            UBUNTU_VERSION=${{ matrix.ubuntu_versions }}
+          tags: ghcr.io/shimwell/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-housekeeping
+      
+
+  build_and_push_base:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ubuntu_versions : [
+          16.04,
+          18.04,
+        ]
+
+    steps:
+
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push base
         uses: docker/build-push-action@v2
         with:
           file: CI/Dockerfile_0_base
@@ -53,9 +73,39 @@ jobs:
           push: true
           build-args: |
             UBUNTU_VERSION=${{ matrix.ubuntu_versions }}
-          tags: ghcr.io/svalinn/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}
+          tags: ghcr.io/shimwell/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}
 
-      - name: Build and push Dockerfile_1_external_deps
+
+  build_and_push_external_deps:
+    runs-on: ubuntu-latest
+    needs: build_and_push_base
+    strategy:
+      matrix:
+        ubuntu_versions : [
+          16.04,
+          18.04,
+        ]
+        compiler : [
+          gcc,
+          clang,
+        ]
+
+    steps:
+
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push external_deps
         uses: docker/build-push-action@v2
         with:
           file: CI/Dockerfile_1_external_deps
@@ -64,9 +114,42 @@ jobs:
           build-args: |
             UBUNTU_VERSION=${{ matrix.ubuntu_versions }}
             COMPILER=${{ matrix.compiler }}
-          tags: ghcr.io/svalinn/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler}}-ext
+          tags: ghcr.io/shimwell/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler}}-ext
 
-      - name: Build and push Dockerfile_2_hdf5
+
+  build_and_push_hdf5:
+    runs-on: ubuntu-latest
+    needs: build_and_push_external_deps
+    strategy:
+      matrix:
+        ubuntu_versions : [
+          16.04,
+          18.04,
+        ]
+        compiler : [
+          gcc,
+          clang,
+        ]
+        hdf5_versions : [
+          1.10.4,
+        ]
+
+    steps:
+
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push hdf5
         uses: docker/build-push-action@v2
         with:
           file: CI/Dockerfile_2_hdf5
@@ -76,9 +159,47 @@ jobs:
             UBUNTU_VERSION=${{ matrix.ubuntu_versions }}
             COMPILER=${{ matrix.compiler }}
             HDF5=${{ matrix.hdf5_versions }}
-          tags: ghcr.io/svalinn/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler}}-ext-hdf5_${{ matrix.hdf5_versions}}
+          tags: ghcr.io/shimwell/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler}}-ext-hdf5_${{ matrix.hdf5_versions}}
 
-      - name: Build and push Dockerfile_3_moab
+
+  build_and_push_moab:
+    runs-on: ubuntu-latest
+    needs: build_and_push_hdf5
+    strategy:
+      matrix:
+        ubuntu_versions : [
+          16.04,
+          18.04,
+        ]
+        compiler : [
+          gcc,
+          clang,
+        ]
+        hdf5_versions : [
+          1.10.4,
+        ]
+        moab_versions : [
+          9c96d17,
+          develop,
+          master,
+        ]
+
+    steps:
+
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push moab
         uses: docker/build-push-action@v2
         with:
           file: CI/Dockerfile_3_moab
@@ -89,15 +210,4 @@ jobs:
             COMPILER=${{ matrix.compiler }}
             HDF5=${{ matrix.hdf5_versions }}
             MOAB=${{ matrix.moab_versions }}
-          tags: ghcr.io/svalinn/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler}}-ext-hdf5_${{ matrix.hdf5_versions}}-moab_${{ matrix.moab_versions }}
-
-      - name: Build and push Dockerfile_1_housekeeping
-        uses: docker/build-push-action@v2
-        with:
-          file: CI/Dockerfile_1_housekeeping
-          context: .
-          push: true
-          build-args: |
-            UBUNTU_VERSION=${{ matrix.ubuntu_versions }}
-          tags: ghcr.io/svalinn/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-housekeeping
-      
+          tags: ghcr.io/shimwell/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler}}-ext-hdf5_${{ matrix.hdf5_versions}}-moab_${{ matrix.moab_versions }}

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -38,7 +38,7 @@ jobs:
           push: true
           build-args: |
             UBUNTU_VERSION=${{ matrix.ubuntu_versions }}
-          tags: ghcr.io/shimwell/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-housekeeping
+          tags: ghcr.io/svalinn/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-housekeeping
       
 
   build_and_push_base:
@@ -73,7 +73,7 @@ jobs:
           push: true
           build-args: |
             UBUNTU_VERSION=${{ matrix.ubuntu_versions }}
-          tags: ghcr.io/shimwell/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}
+          tags: ghcr.io/svalinn/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}
 
 
   build_and_push_external_deps:
@@ -114,7 +114,7 @@ jobs:
           build-args: |
             UBUNTU_VERSION=${{ matrix.ubuntu_versions }}
             COMPILER=${{ matrix.compiler }}
-          tags: ghcr.io/shimwell/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler}}-ext
+          tags: ghcr.io/svalinn/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler}}-ext
 
 
   build_and_push_hdf5:
@@ -159,7 +159,7 @@ jobs:
             UBUNTU_VERSION=${{ matrix.ubuntu_versions }}
             COMPILER=${{ matrix.compiler }}
             HDF5=${{ matrix.hdf5_versions }}
-          tags: ghcr.io/shimwell/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler}}-ext-hdf5_${{ matrix.hdf5_versions}}
+          tags: ghcr.io/svalinn/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler}}-ext-hdf5_${{ matrix.hdf5_versions}}
 
 
   build_and_push_moab:
@@ -210,4 +210,4 @@ jobs:
             COMPILER=${{ matrix.compiler }}
             HDF5=${{ matrix.hdf5_versions }}
             MOAB=${{ matrix.moab_versions }}
-          tags: ghcr.io/shimwell/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler}}-ext-hdf5_${{ matrix.hdf5_versions}}-moab_${{ matrix.moab_versions }}
+          tags: ghcr.io/svalinn/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler}}-ext-hdf5_${{ matrix.hdf5_versions}}-moab_${{ matrix.moab_versions }}

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -12,7 +12,6 @@ jobs:
       matrix:
         ubuntu_versions : [
           16.04,
-          18.04,
         ]
 
     steps:

--- a/README.rst
+++ b/README.rst
@@ -4,6 +4,9 @@ DAGMC: Direct Accelerated Geometry Monte Carlo
 ..  image:: https://circleci.com/gh/svalinn/DAGMC.svg?style=shield
     :target: https://circleci.com/gh/svalinn/DAGMC
 
+..  image:: https://github.com/svalinn/DAGMC/actions/workflows/docker_publish.yml/badge.svg?branch=develop
+    :target: https://github.com/svalinn/DAGMC/actions/workflows/docker_publish.yml
+
 Direct Accelerated Geometry Monte Carlo (DAGMC) is a software package that
 allows users to perform Monte Carlo radiation transport directly on CAD models.
 

--- a/news/PR-0748.rst
+++ b/news/PR-0748.rst
@@ -1,0 +1,15 @@
+**Added:** None
+
+  - Improved GitHub Action to build and upload Docker images.
+
+**Changed:**
+
+  - Sequential building of Dockerimages
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None


### PR DESCRIPTION
## Description
This is a minor change to the docker CI image building process. It uses "needs" keyword in the steps for docker images building to ensure the images are getting the most up to date version of the previous image.

This has a nice upgrade path as I think it is compatible with docker layer caching which would speed up the overall process.

Also if we like a badge can be added to the README ?
[![.github/workflows/docker_publish.yml](https://github.com/svalinn/DAGMC/actions/workflows/docker_publish.yml/badge.svg)](https://github.com/svalinn/DAGMC/actions/workflows/docker_publish.yml)

## Motivation and Context
Ensures images build on the latest previous base images
Cleaner presentation of build process with [connections between images identified on the GH actions](https://github.com/svalinn/DAGMC/actions/runs/1011041967)

## Changes
What kind of change does this PR introduce? (Bug fix, feature, documentation update...)
update to current GH action building the dockerfiles

## Behavior
What is the current behavior? What is the new behavior?
Current behavior is one large matrix of builds, new process is sequential matrixes of builds with "needs" keyword 

## News file 
done
