### PR TITLE
Add newer (v2.18) git to CI images

### DIFF
--- a/CI/Dockerfile_0_base
+++ b/CI/Dockerfile_0_base
@@ -25,9 +25,9 @@ RUN apt-get -y update; \
                        libpython3-dev \
                        wget \
                        software-properties-common;
-    add-apt-repository ppa:git-core/ppa
-    apt-get update
-    apt-get install -y git
+    add-apt-repository ppa:git-core/ppa; \
+    apt-get update; \
+    apt-get install -y git; \
     update-alternatives --install /usr/bin/python python /usr/bin/python3 10; \
     update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 10; \
     pip install cython;

--- a/CI/Dockerfile_0_base
+++ b/CI/Dockerfile_0_base
@@ -24,7 +24,7 @@ RUN apt-get -y update; \
                        python3-dev \
                        libpython3-dev \
                        wget \
-                       software-properties-common;
+                       software-properties-common; \
     add-apt-repository ppa:git-core/ppa; \
     apt-get update; \
     apt-get install -y git; \

--- a/CI/Dockerfile_0_base
+++ b/CI/Dockerfile_0_base
@@ -12,7 +12,6 @@ RUN apt-get -y update; \
                        g++ \
                        gcc \
                        gfortran \
-                       git \
                        libblas-dev \
                        libhdf5-dev \
                        liblapack-dev \
@@ -24,7 +23,11 @@ RUN apt-get -y update; \
                        python3-setuptools \
                        python3-dev \
                        libpython3-dev \
-                       wget; \
+                       wget \
+                       software-properties-common;
+    add-apt-repository ppa:git-core/ppa
+    apt-get update
+    apt-get install -y git
     update-alternatives --install /usr/bin/python python /usr/bin/python3 10; \
     update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 10; \
     pip install cython;

--- a/news/PR-0753.rst
+++ b/news/PR-0753.rst
@@ -1,0 +1,12 @@
+**Added:** None
+
+**Changed:** 
+ - install newer version of git in CI images
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None


### PR DESCRIPTION
## Description
Install newer git during creation of CI images.

## Motivation and Context
Continuous integration relies on having a full peer of the git repo.  This was standard during CI on CircleCI, but the Github Action to fetch the repo requires a newer version of git (v2.18+) to accomplish this.

## Changes
This changes the packages installed when making the base CI images.
