### PR TITLE
Update CI images to rely on MOAB 5.3.0

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -156,7 +156,7 @@ jobs:
           1.10.4,
         ]
         moab_versions : [
-          9c96d17,
+          5.3.0,
           develop,
           master,
         ]
@@ -243,7 +243,7 @@ jobs:
          1.10.4,
         ]
         moab_versions : [
-         9c96d17,
+         5.3.0,
          develop,
          master,
         ]
@@ -327,7 +327,7 @@ jobs:
          1.10.4,
         ]
         moab_versions : [
-         9c96d17,
+         5.3.0,
          develop,
          master,
         ]

--- a/CI/Dockerfile_3_moab
+++ b/CI/Dockerfile_3_moab
@@ -8,8 +8,7 @@ FROM ghcr.io/${OWNER}/dagmc-ci-ubuntu-${UBUNTU_VERSION}-${COMPILER}-ext-hdf5_${H
 ENV moab_build_dir=${build_dir}/moab
 ENV moab_install_dir=${install_dir}/moab
 
-# MOAB Commit: 9c96d17 (Merged commit of @pshriwise thread fix)
-ARG MOAB=9c96d17
+ARG MOAB=5.3.0
 ENV MOAB_VERSION ${MOAB}
 RUN if [ "${MOAB_VERSION}" != "master" ] && [ "${MOAB_VERSION}" != "develop" ]; then \
         /root/etc/CI/docker/build_moab.sh; \

--- a/CI/update_docker.sh
+++ b/CI/update_docker.sh
@@ -18,7 +18,7 @@ done
 ubuntu_versions="16.04 18.04"
 compilers="gcc clang"
 hdf5_versions="1.10.4"
-moab_versions="9c96d17 develop master"
+moab_versions="5.3.0 develop master"
 for ubuntu_version in ${ubuntu_versions}; do
   image_name="svalinn/dagmc-ci-ubuntu-${ubuntu_version}"
   docker build -t ${image_name} --build-arg UBUNTU_VERSION=${ubuntu_version} \

--- a/news/PR-0760.rst
+++ b/news/PR-0760.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:** 
+
+  * changed CI image to rely on MOAB V5.3.0
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None


### PR DESCRIPTION
## Description
We temporarily relied on a specific commit of the MOAB repo to move our testing forward while waiting for a new release.  The new release has occurred (v5.3.0) and this updates CI images to rely on that instead.

## Motivation and Context
This is changing a temporary situation to a permanent one.
