### PR TITLE
adding guard to run housekeeping on PR only

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -14,6 +14,7 @@ on:
 
 jobs:
   Housekeeping:
+    if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/svalinn/dagmc-ci-ubuntu-18.04-housekeeping:stable
@@ -35,7 +36,6 @@ jobs:
 
 
   BuildTest:
-    needs: Housekeeping
     runs-on: ubuntu-latest
 
     env:

--- a/news/PR-0763.rst
+++ b/news/PR-0763.rst
@@ -1,0 +1,12 @@
+**Added:** None
+
+**Changed:** 
+    - Housekeeping scripts only run during PR
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None


### PR DESCRIPTION
Housekeeping should run on PR only 
(our detection script will not work on merge/push)