### PR TITLE
Update to PyNE v0.7.5

### DIFF
--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -30,6 +30,7 @@ Next version
    * Location of double-down header files. (#745)
    * Location of Dockerimages from Dockerhub to GHCR. (#746)
    * update MOAB version (#740, #760, #768, #771)
+   * updated PyNE to version 0.7.5 (#770)
 
 
 **Deprecated:** 


### PR DESCRIPTION
This updates the SHA for the PyNE submodule to v0.7.5
