### PR TITLE
switch to cmake and use version variable

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -6,6 +6,7 @@ on:
       - 'CI/*'
       - '.github/workflows/docker_publish.yml'
 
+      
 jobs:
   build-base-img:
     runs-on: ubuntu-latest

--- a/CI/docker/build_moab.sh
+++ b/CI/docker/build_moab.sh
@@ -7,28 +7,33 @@ source ${docker_env}
 if [ ${MOAB_VERSION} == "master" ] || [ ${MOAB_VERSION} == "develop" ]; then
   branch=${MOAB_VERSION}
 else
-#  branch=Version${MOAB_VERSION}
   branch=${MOAB_VERSION}
 fi
 
 rm -rf ${moab_build_dir}/bld ${moab_install_dir}
 mkdir -p ${moab_build_dir}/bld
 cd ${moab_build_dir}
-#git clone --depth 1 https://bitbucket.org/fathomteam/moab -b ${branch}
-git clone https://bitbucket.org/fathomteam/moab 
-cd moab
-git checkout ${branch}
-autoreconf -fi
-cd ../bld
-../moab/configure --enable-pymoab \
-                 --enable-shared \
-                 --enable-optimize \
-                 --disable-debug \
-                 --disable-fortran \
-                 --disable-blaslapack \
-                 --with-hdf5=${hdf5_install_dir} \
-                 --prefix=${moab_install_dir} \
-                 CC=${CC} CXX=${CXX}
+git clone --depth 1 https://bitbucket.org/fathomteam/moab -b ${branch}
+cd bld
+cmake ../moab -DENABLE_HDF5=ON -DHDF5_ROOT=${hdf5_install_dir} \
+              -DENABLE_BLASLAPACK=OFF \
+              -DENABLE_FORTRAN=OFF \
+              -DCMAKE_INSTALL_PREFIX=${moab_install_dir} \
+              -DCMAKE_C_COMPILER=${CC} \
+              -DCMAKE_CXX_COMPILER=${CXX} \
+              -DBUILD_SHARED_LIBS=OFF
+make -j${ci_jobs}
+make install
+rm -rf *
+cmake ../moab -DENABLE_HDF5=ON -DHDF5_ROOT=${hdf5_install_dir} \
+              -DENABLE_PYMOAB=ON \
+              -DENABLE_BLASLAPACK=OFF \
+              -DENABLE_FORTRAN=OFF \
+              -DCMAKE_INSTALL_PREFIX=${moab_install_dir} \
+              -DCMAKE_C_COMPILER=${CC} \
+              -DCMAKE_CXX_COMPILER=${CXX} \
+              -DBUILD_SHARED_LIBS=ON \
+              -DCMAKE_INSTALL_RPATH=${hdf5_install_dir}/lib:${moab_install_dir}/lib
 make -j${ci_jobs}
 make install
 cd

--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -29,7 +29,7 @@ Next version
    * website now points to github for plugin download (#744)
    * Location of double-down header files. (#745)
    * Location of Dockerimages from Dockerhub to GHCR. (#746)
-   * update MOAB version (#740, #760, #768)
+   * update MOAB version (#740, #760, #768, #771)
 
 
 **Deprecated:** 
@@ -53,6 +53,7 @@ Next version
 **Maintenance:**
 
    * move CI to github actions (#752, #753, #761, #763, #766)
+   * move CI docker build of MOAB to CMake (#771)
 
 v3.2.0
 ====================


### PR DESCRIPTION
This replaces #687 to move to CMake.

This also reverts some changes to get a smaller/faster clone of MOAB for a specific branch/tag instead of a sha.