### PR TITLE
Direct bounding box calls to relevant methods when using Double-Down

### DIFF
--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -54,6 +54,7 @@ Next version
 
     * adding special build flag to enable old hdf5 interface for PyNE when compiling against hdf5@1.12+ (#728)
     * Renamed `jobs` variable CI build system to avoid undocumented conflict with `git submodule` (#735)
+    * Return correct bounding boxes when configured with Double-Down. (#779)
 
 
 **Security:**

--- a/src/dagmc/DagMC.cpp
+++ b/src/dagmc/DagMC.cpp
@@ -369,7 +369,7 @@ ErrorCode DagMC::next_vol(EntityHandle surface, EntityHandle old_volume,
   return rval;
 }
 
-/* SECTION III */
+/* SECTION III: Indexing & Cross-referencing */
 
 EntityHandle DagMC::entity_by_id(int dimension, int id) {
   return GTT->entity_by_id(dimension, id);
@@ -445,7 +445,7 @@ ErrorCode DagMC::build_indices(Range& surfs, Range& vols) {
   return MB_SUCCESS;
 }
 
-/* SECTION IV */
+/* SECTION IV: : Handling DagMC settings */
 
 double DagMC::overlap_thickness() {
   return ray_tracer->get_overlap_thickness();
@@ -797,6 +797,33 @@ Tag DagMC::get_tag(const char* name, int size, TagType store, DataType type,
     std::cerr << "Couldn't find nor create tag named " << name << std::endl;
 
   return retval;
+}
+
+/* SECTION VI: Other */
+
+ErrorCode DagMC::getobb(EntityHandle volume, double minPt[3],
+                               double maxPt[3]) {
+  #ifdef DOUBLE_DOWN
+    ErrorCode rval = ray_tracer->get_bbox(volume, minPt, maxPt);
+  #else
+    ErrorCode rval = GTT->get_bounding_coords(volume, minPt, maxPt);
+  #endif
+  MB_CHK_SET_ERR(rval, "Failed to get obb for volume");
+  return MB_SUCCESS;
+}
+
+ErrorCode DagMC::getobb(EntityHandle volume,
+                        double center[3],
+                        double axis1[3],
+                        double axis2[3],
+                        double axis3[3]) {
+  #ifdef DOUBLE_DOWN
+    ErrorCode rval = ray_tracer->get_obb(volume, center, axis1, axis2, axis3);
+  #else
+    ErrorCode rval = GTT->get_obb(volume, center, axis1, axis2, axis3);
+  #endif
+  MB_CHK_SET_ERR(rval, "Failed to get obb for volume");
+  return MB_SUCCESS;
 }
 
 }  // namespace moab

--- a/src/dagmc/DagMC.cpp
+++ b/src/dagmc/DagMC.cpp
@@ -801,27 +801,23 @@ Tag DagMC::get_tag(const char* name, int size, TagType store, DataType type,
 
 /* SECTION VI: Other */
 
-ErrorCode DagMC::getobb(EntityHandle volume, double minPt[3],
-                               double maxPt[3]) {
-  #ifdef DOUBLE_DOWN
-    ErrorCode rval = ray_tracer->get_bbox(volume, minPt, maxPt);
-  #else
-    ErrorCode rval = GTT->get_bounding_coords(volume, minPt, maxPt);
-  #endif
+ErrorCode DagMC::getobb(EntityHandle volume, double minPt[3], double maxPt[3]) {
+#ifdef DOUBLE_DOWN
+  ErrorCode rval = ray_tracer->get_bbox(volume, minPt, maxPt);
+#else
+  ErrorCode rval = GTT->get_bounding_coords(volume, minPt, maxPt);
+#endif
   MB_CHK_SET_ERR(rval, "Failed to get obb for volume");
   return MB_SUCCESS;
 }
 
-ErrorCode DagMC::getobb(EntityHandle volume,
-                        double center[3],
-                        double axis1[3],
-                        double axis2[3],
-                        double axis3[3]) {
-  #ifdef DOUBLE_DOWN
-    ErrorCode rval = ray_tracer->get_obb(volume, center, axis1, axis2, axis3);
-  #else
-    ErrorCode rval = GTT->get_obb(volume, center, axis1, axis2, axis3);
-  #endif
+ErrorCode DagMC::getobb(EntityHandle volume, double center[3], double axis1[3],
+                        double axis2[3], double axis3[3]) {
+#ifdef DOUBLE_DOWN
+  ErrorCode rval = ray_tracer->get_obb(volume, center, axis1, axis2, axis3);
+#else
+  ErrorCode rval = GTT->get_obb(volume, center, axis1, axis2, axis3);
+#endif
   MB_CHK_SET_ERR(rval, "Failed to get obb for volume");
   return MB_SUCCESS;
 }

--- a/src/dagmc/DagMC.cpp
+++ b/src/dagmc/DagMC.cpp
@@ -445,7 +445,7 @@ ErrorCode DagMC::build_indices(Range& surfs, Range& vols) {
   return MB_SUCCESS;
 }
 
-/* SECTION IV: : Handling DagMC settings */
+/* SECTION IV: Handling DagMC settings */
 
 double DagMC::overlap_thickness() {
   return ray_tracer->get_overlap_thickness();

--- a/src/dagmc/DagMC.hpp
+++ b/src/dagmc/DagMC.hpp
@@ -490,21 +490,6 @@ inline unsigned int DagMC::num_entities(int dimension) {
   return entHandles[dimension].size() - 1;
 }
 
-inline ErrorCode DagMC::getobb(EntityHandle volume, double minPt[3],
-                               double maxPt[3]) {
-  ErrorCode rval = GTT->get_bounding_coords(volume, minPt, maxPt);
-  MB_CHK_SET_ERR(rval, "Failed to get obb for volume");
-  return MB_SUCCESS;
-}
-
-inline ErrorCode DagMC::getobb(EntityHandle volume, double center[3],
-                               double axis1[3], double axis2[3],
-                               double axis3[3]) {
-  ErrorCode rval = GTT->get_obb(volume, center, axis1, axis2, axis3);
-  MB_CHK_SET_ERR(rval, "Failed to get obb for volume");
-  return MB_SUCCESS;
-}
-
 inline ErrorCode DagMC::get_root(EntityHandle vol_or_surf, EntityHandle& root) {
   ErrorCode rval = GTT->get_root(vol_or_surf, root);
   MB_CHK_SET_ERR(rval, "Failed to get obb root set of volume or surface");

--- a/src/dagmc/tests/dagmc_simple_test.cpp
+++ b/src/dagmc/tests/dagmc_simple_test.cpp
@@ -250,3 +250,19 @@ TEST_F(DagmcSimpleTest, dagmc_test_boundary) {
   // check ray leaving volume
   EXPECT_EQ(expect_result, result);
 }
+
+TEST_F(DagmcSimpleTest, dagmc_test_get_obb) {
+  int vol_idx = 1;
+  EntityHandle vol_h = DAG->entity_by_index(3, vol_idx);
+
+  double llc[3], urc[3];
+  ErrorCode rval = DAG->getobb(vol_h, llc, urc);
+  EXPECT_EQ(rval, MB_SUCCESS);
+
+  // hardcoded value for 'test_geom.h5m'
+  double geom_extent = 5.0;
+  for (int i = 0; i < 3; i++) {
+    EXPECT_LE(llc[i], -geom_extent);
+    EXPECT_GE(urc[i], geom_extent);
+  }
+}


### PR DESCRIPTION
@Shimwell noted that bounding boxes coming out of DAGMC when using Double-Down aren't correct. I thought I had included wrappers for the relevant methods in DAGMC, but it appears that slipped through the cracks. This updates our `getobb` calls to the correct methods on the `ray_tracer` object in Double-Down. Unfortunately, this means a couple more `#ifdef`'s for now as that method relies on the `RayTracingInterface` in Double-Down rather than the `GeomTopoTool`.