### PR TITLE
Updating README badges.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,14 @@
 DAGMC: Direct Accelerated Geometry Monte Carlo
 ==============================================
 
-..  image:: https://github.com/svalinn/DAGMC/actions/workflows/build_test.yml/badge.svg?branch=develop
-    :target: https://github.com/svalinn/DAGMC/actions/workflows/build_test.yml
+..  image:: https://github.com/svalinn/DAGMC/actions/workflows/linux_build_test.yml/badge.svg?branch=develop
+    :target: https://github.com/svalinn/DAGMC/actions/workflows/linux_build_test.yml
+
+..  image:: https://github.com/svalinn/DAGMC/actions/workflows/mac_build_test.yml/badge.svg?branch=develop
+    :target: https://github.com/svalinn/DAGMC/actions/workflows/mac_build_test.yml
+
+..  image:: https://github.com/svalinn/DAGMC/actions/workflows/windows_build_test.yml/badge.svg?branch=develop
+    :target: https://github.com/svalinn/DAGMC/actions/workflows/windows_build_test.yml
 
 ..  image:: https://github.com/svalinn/DAGMC/actions/workflows/docker_publish.yml/badge.svg?branch=develop
     :target: https://github.com/svalinn/DAGMC/actions/workflows/docker_publish.yml

--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -38,6 +38,7 @@ Next version
    * improve path pattern to trigger docker build workflow (#772)
    * limit the extend of housekeeping workflows to pull_request (#774)
    * upgrade g-test to 1.8.0 (#778)
+   * updated CI badges (#784)
 
 
 **Deprecated:**


### PR DESCRIPTION
## Description

This PR updates the GHA badges in the README now that we have separate Linux, Mac, and Windows action files for CI.

## Motivation and Context
Current CI badge is broken.