### PR TITLE
Updates to type alias for `RayTracer` and double-down namespace.

### DIFF
--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -20,6 +20,7 @@ Next version
 
 **Changed:**
 
+   * RayTracer type alias and double-down includes. (#786)
    * reformat all files using clang-format (#679)
    * change housekeeping to test format against clang-format (#679)
    * now install dagmc header when building and installing static libs (#717)

--- a/src/dagmc/DagMC.cpp
+++ b/src/dagmc/DagMC.cpp
@@ -16,6 +16,10 @@
 #include <sstream>
 #include <string>
 
+#ifdef DOUBLE_DOWN
+#include "double_down/RTI.hpp"
+#endif
+
 #include "util.hpp"
 #ifndef M_PI /* windows */
 #define M_PI 3.14159265358979323846

--- a/src/dagmc/DagMC.cpp
+++ b/src/dagmc/DagMC.cpp
@@ -21,11 +21,6 @@
 #define M_PI 3.14159265358979323846
 #endif
 
-#ifdef DOUBLE_DOWN
-#include "double_down/MOABRay.h"
-#include "double_down/RTI.hpp"
-#endif
-
 #define MB_OBB_TREE_TAG_NAME "OBB_TREE"
 #define FACETING_TOL_TAG_NAME "FACETING_TOL"
 static const int null_delimiter_length = 1;

--- a/src/dagmc/DagMC.hpp
+++ b/src/dagmc/DagMC.hpp
@@ -21,10 +21,6 @@
 #include "moab/Interface.hpp"
 #include "moab/Range.hpp"
 
-#ifdef DOUBLE_DOWN
-#include "double_down/RTI.hpp"
-#endif
-
 class RefEntity;
 
 struct DagmcVolData {
@@ -32,6 +28,10 @@ struct DagmcVolData {
   double density, importance;
   std::string comp_name;
 };
+
+namespace double_down {
+class RayTracingInterface;
+}
 
 namespace moab {
 

--- a/src/dagmc/DagMC.hpp
+++ b/src/dagmc/DagMC.hpp
@@ -21,6 +21,10 @@
 #include "moab/Interface.hpp"
 #include "moab/Range.hpp"
 
+#ifdef DOUBLE_DOWN
+#include "double_down/RTI.hpp"
+#endif
+
 class RefEntity;
 
 struct DagmcVolData {
@@ -28,8 +32,6 @@ struct DagmcVolData {
   double density, importance;
   std::string comp_name;
 };
-
-class RayTracingInterface;
 
 namespace moab {
 
@@ -477,7 +479,7 @@ class DagMC {
   std::shared_ptr<GeomTopoTool> GTT;
   // type alias for ray tracing engine
 #ifdef DOUBLE_DOWN
-  using RayTracer = RayTracingInterface;
+  using RayTracer = double_down::RayTracingInterface;
 #else
   using RayTracer = GeomQueryTool;
 #endif


### PR DESCRIPTION

I added a namespace to double-down in https://github.com/pshriwise/double-down/pull/29 to protect from clashes of commonly-used class names (`Vec3f`, etc.) and constants with other packages. These are breaking changes with DAGMC that are resolved in this PR. I figured it would be good to get this relatively small issue taken care of before our next DAGMC release. 

To ease potential concerns about any continued patterns along these lines, I'm about to do an initial release of double-down. No further breaking changes should happen before that, meaning that DAGMC can rely on specific versions of dd for testing going forward.

## Description
Movement of double-down includes from `DagMC.cpp` to `DagMC.hpp`.

## Motivation and Context
To maintain compatibility with the latest version of double-down.
