### PR TITLE
More robust invocation of bash

### DIFF
--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -11,7 +11,7 @@ Next version
 
    * adding BUILD_EXE option (default ON) allowing to build only the dagmc libs without the executable (for static and/or shared libs) (#717)
    * Including installation of a CMake version file for use with `find_package` in client codes. (#722)
-   * CMake option to checkout PyNE submodule automatically (#734)
+   * CMake option to checkout PyNE submodule automatically (#734, #787)
    * GitHub Action to build and upload Docker images. (#746, #748, #754, #757, #758, #759, #765, #767)
    * Enforcing usage of Python3 for PyNE amalgamation. (#773)
    * Adding workflow_dispatch option to docker_publish workflow (#776)

--- a/src/pyne/amalgamate_pyne.sh
+++ b/src/pyne/amalgamate_pyne.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # take 2 arguments:
 # $1 location of the pyne source folder


### PR DESCRIPTION
## Description
Use system method to find correct bash

## Motivation and Context
The bash shell executable exists in different places on different systems. Rather than hard coding the path, use an accepted approach to resolve its location (albeit with a different hard coded path).  Should resolve #783 

## Changes
This fixes a bug first identified in #783 

## Behavior
On some Linux distributions, the current behavior is that the PyNE amalgamation script does not run under CMake because bash is not found.