### PR TITLE
Force python3 for the atomicgen.py script as well

### DIFF
--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -13,7 +13,7 @@ Next version
    * Including installation of a CMake version file for use with `find_package` in client codes. (#722)
    * CMake option to checkout PyNE submodule automatically (#734, #787)
    * GitHub Action to build and upload Docker images. (#746, #748, #754, #757, #758, #759, #765, #767)
-   * Enforcing usage of Python3 for PyNE amalgamation. (#773)
+   * Enforcing usage of Python3 for PyNE amalgamation. (#773,#791)
    * Adding workflow_dispatch option to docker_publish workflow (#776)
    * DagMC methods for creation and removal of the graveyard volume (#714)
    * CI build and test now support MacOS (shared build, no pymoab, no Double Down) (#780)

--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -13,7 +13,7 @@ Next version
    * Including installation of a CMake version file for use with `find_package` in client codes. (#722)
    * CMake option to checkout PyNE submodule automatically (#734, #787)
    * GitHub Action to build and upload Docker images. (#746, #748, #754, #757, #758, #759, #765, #767)
-   * Enforcing usage of Python3 for PyNE amalgamation. (#773,#791)
+   * Enforcing usage of Python3 for PyNE amalgamation. (#773,#792)
    * Adding workflow_dispatch option to docker_publish workflow (#776)
    * DagMC methods for creation and removal of the graveyard volume (#714)
    * CI build and test now support MacOS (shared build, no pymoab, no Double Down) (#780)

--- a/src/pyne/amalgamate_pyne.sh
+++ b/src/pyne/amalgamate_pyne.sh
@@ -9,7 +9,7 @@ set -e
 # Update amalgamated pyne
 
 cd $1/pyne/src
-python atomicgen.py
+python3 atomicgen.py
 cd ..
 python3 amalgamate.py -f license.txt src/utils.* src/extra_types.h src/h5wrap.h \
     src/state_map.cpp src/nucname.* src/rxname.* src/particle.* src/data.* \


### PR DESCRIPTION
Please follow these guidelines when making a Pull Request.
This template was adapted from [here](https://github.com/stevemao/github-issue-templates/blob/master/questions-answers/PULL_REQUEST_TEMPLATE.md) and [here](https://github.com/stevemao/github-issue-templates/blob/master/conversational/PULL_REQUEST_TEMPLATE.md).

## Description
Different conventions for calling python were used in this amalgamation. 

## Motivation and Context
If e.g. only python3 is installed on a machine the build script will fail.

## Changes
Bug fix

## Behavior
Current behavior is to call default python then 2 lines later call python3 explicitly. New behavior is to always use python3 explicitly.
