### PR TITLE
Remove superfluous headers from DAGMC headers

### DIFF
--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -47,9 +47,6 @@ v3.2.2
    * Removing build of static libs as a default option (#802)
    * Adding PYTHONPATH to linux CI images and creating pymoab installation directories (#802)
 
-v3.2.1
-====================
-
 **Added:**
 
    * Added link to latest Conda package in GitHub README.md (#801)

--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -35,6 +35,8 @@ Next version
    * Tweak conda environment for Windows build to avoid conflicting gtest headers (#888)
    * Restrict cython version for MOAB (#893)
    * Various documentation updates (#869)
+   * cleaned up headers to include fewer upstream headers (#800)
+
 
 v3.2.2
 ====================
@@ -61,6 +63,19 @@ v3.2.1
 **Fixed:**
 
 **Security:**
+
+**Maintenance:**
+
+
+**Added:**
+
+**Changed:**
+
+**Deprecated:**
+
+**Removed:**
+
+**Fixed:**
 
 **Maintenance:**
 

--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -52,33 +52,7 @@ v3.2.1
 
 **Added:**
 
-   * Added link to latest Conda package in GitHub README.md
-
-**Changed:**
-
-**Deprecated:**
-
-**Removed:**
-
-**Fixed:**
-
-**Security:**
-
-**Maintenance:**
-
-
-**Added:**
-
-**Changed:**
-
-**Deprecated:**
-
-**Removed:**
-
-**Fixed:**
-
-**Maintenance:**
-
+   * Added link to latest Conda package in GitHub README.md (#801)
 
 v3.2.1
 ====================

--- a/src/dagmc/DagMC.cpp
+++ b/src/dagmc/DagMC.cpp
@@ -16,6 +16,14 @@
 #include <sstream>
 #include <string>
 
+
+#include "moab/CartVect.hpp"
+#include "moab/FileOptions.hpp"
+#include "moab/GeomTopoTool.hpp"
+#include "moab/GeomQueryTool.hpp"
+#include "moab/GeomUtil.hpp"
+#include "moab/Range.hpp"
+
 #ifdef DOUBLE_DOWN
 #include "double_down/RTI.hpp"
 #endif

--- a/src/dagmc/DagMC.hpp
+++ b/src/dagmc/DagMC.hpp
@@ -11,18 +11,7 @@
 #include <vector>
 
 #include "DagMCVersion.hpp"
-#include "MBTagConventions.hpp"
-#include "logger.hpp"
-#include "moab/CartVect.hpp"
-#include "moab/Core.hpp"
-#include "moab/FileOptions.hpp"
-#include "moab/GeomQueryTool.hpp"
-#include "moab/GeomTopoTool.hpp"
-#include "moab/GeomUtil.hpp"
 #include "moab/Interface.hpp"
-#include "moab/Range.hpp"
-
-class RefEntity;
 
 struct DagmcVolData {
   int mat_id;

--- a/src/dagmc/DagMC.hpp
+++ b/src/dagmc/DagMC.hpp
@@ -34,6 +34,7 @@ static const std::string GRAVEYARD_NAME = "mat:graveyard";
 
 class CartVect;
 class GeomQueryTool;
+class GeomQueryTool::RayHistory;
 
 /**\brief
  *


### PR DESCRIPTION
## Description
Move headers from DAGMC's headers to the implementation files.  Upstream headers only need to be included in header files if details of the classes that those upstream headers define are accessed within the header.  If only the existence of those classes is necessary, then forward declaration of the classes is sufficient.

## Motivation and Context
Since DAGMC's headers may be included by downstream codes, it is good practice to avoid "polluting" our headers with other headers that may, unkown to us, further include other headers and so on.  This 

Fixes #799 

## Changes
Fix of an annoying but non-pathologial bug