### PR TITLE
added conda package badge to readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,9 @@ DAGMC: Direct Accelerated Geometry Monte Carlo
 ..  image:: https://github.com/svalinn/DAGMC/actions/workflows/docker_publish.yml/badge.svg?branch=develop
     :target: https://github.com/svalinn/DAGMC/actions/workflows/docker_publish.yml
 
+..  image:: https://anaconda.org/conda-forge/dagmc/badges/version.svg
+    :target: https://anaconda.org/conda-forge/dagmc
+
 Direct Accelerated Geometry Monte Carlo (DAGMC) is a software package that
 allows users to perform Monte Carlo radiation transport directly on CAD models.
 

--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -9,6 +9,26 @@ Next version
 
 **Added:**
 
+   * Added link to latest Conda package in GitHub README.md
+
+**Changed:**
+
+**Deprecated:**
+
+**Removed:**
+
+**Fixed:**
+
+**Security:**
+
+**Maintenance:**
+
+
+v3.2.1
+====================
+
+**Added:**
+
    * adding BUILD_EXE option (default ON) allowing to build only the dagmc libs without the executable (for static and/or shared libs) (#717)
    * Including installation of a CMake version file for use with `find_package` in client codes. (#722)
    * CMake option to checkout PyNE submodule automatically (#734, #787)


### PR DESCRIPTION

## Description
Added a conda badge to the readme [![conda-pacakge](https://anaconda.org/conda-forge/dagmc/badges/version.svg)](https://anaconda.org/conda-forge/dagmc)


## Motivation and Context
Greater awareness of this install option

## Changes
documentation

## Behavior
What is the current behavior? What is the new behavior?
Not everyone visiting the repo knows about the conda package -> people have an improved chance of knowing about the package


## Changelog file
Are we moving away from this change log in favor of the auto generated release info?