### PR TITLE
Ensure PYTHONPATH and pymoab install directory are present for Linux CI builds

### DIFF
--- a/.github/workflows/linux_build_test.yml
+++ b/.github/workflows/linux_build_test.yml
@@ -10,7 +10,7 @@ on:
       - '.github/workflows/docker_publish.yml'
       - '.github/workflows/housekeeping.yml'
       - 'CI/**'
-      - 'news/**' 
+      - 'news/**'
   push:
     branches:
       - develop
@@ -51,11 +51,11 @@ jobs:
           - isPR: true
             moab_versions: develop
           - isPR: true
-            moab_versions: master           
+            moab_versions: master
 
     container:
       image: ghcr.io/svalinn/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler }}-ext-hdf5_${{ matrix.hdf5_versions }}-moab_${{ matrix.moab_versions }}:stable
-    
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -70,8 +70,9 @@ jobs:
           echo "REPO_SLUG=${GITHUB_REPOSITORY}" >> $GITHUB_ENV
           echo "PULL_REQUEST=$(echo  $GITHUB_REF | cut -d"/" -f3)" >> $GITHUB_ENV
           echo "DOUBLE_DOWN="OFF"" >> $GITHUB_ENV
+          echo "PYTHONPATH="/root/build_dir/moab/bld/pymoab/lib/python3.6/site-packages:$PYTHONPATH"" >> $GITHUB_ENV
           ln -s $GITHUB_WORKSPACE /root/build_dir/DAGMC
-         
+
       - name: Building DAGMC
         run: |
           cd $GITHUB_WORKSPACE

--- a/CI/docker/build_moab.sh
+++ b/CI/docker/build_moab.sh
@@ -34,6 +34,8 @@ cmake ../moab -DENABLE_HDF5=ON -DHDF5_ROOT=${hdf5_install_dir} \
               -DCMAKE_CXX_COMPILER=${CXX} \
               -DBUILD_SHARED_LIBS=ON \
               -DCMAKE_INSTALL_RPATH=${hdf5_install_dir}/lib:${moab_install_dir}/lib
+# ensure that the installation directory for python packages exist
+for d in $(echo $PYTHONPATH | tr : '\n'); do mkdir -p $d; done
 make -j${ci_jobs}
 make install
 cd

--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -11,7 +11,7 @@ Next version
 
    * Placing installed CMake configuration files in project directory (#802)
    * Removing build of static libs as a default option (#802)
-
+   * Adding PYTHONPATH to linux CI images and creating pymoab installation directories (#802)
 
 v3.2.1
 ====================


### PR DESCRIPTION
## Description
This adds the installation directory of PyMOAB to the `PYTHONPATH` env var in the linux builds used in CI. It also ensures that the installation directory is present by explicitly creating that directory before building MOAB. 

I recognize that this is a band-aid, but the root problem is almost certainly upstream in MOAB and that will take time to remedy.

## Motivation and Context
CI is broken.

## Changelog file
~I don't think this change really warrants an entry in the changelog, but I will add one if requested.~

EDIT: Nevermind I guess we _require_ a changelog check.
