### PR TITLE
Adding safe folder to allow CI to compile DAGMC

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -218,7 +218,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
-          set-safe-directory: "/__w/DAGMC/DAGMC"
+          set-safe-directory: ${GITHUB_WORKSPACE}
 
 
       - name: Setup
@@ -266,7 +266,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
-          set-safe-directory: "/__w/DAGMC/DAGMC"
+          set-safe-directory: ${GITHUB_WORKSPACE}
 
       - name: Setup
         run: |

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -218,6 +218,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
+          set-safe-directory: 'DAGMC/DAGMC'
+
 
       - name: Setup
         run: |

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -163,7 +163,7 @@ jobs:
           1.10.4,
         ]
         moab_versions : [
-          5.3.1,
+          5.4.0,
           develop,
           master,
         ]

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -218,11 +218,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
-          set-safe-directory: ${GITHUB_WORKSPACE}
-
 
       - name: Setup
         run: |
+          git config --global --add safe.directory ${GITHUB_WORKSPACE}
           mkdir /root/build_dir/
           echo "REPO_SLUG=${GITHUB_REPOSITORY}" >> $GITHUB_ENV
           echo "PULL_REQUEST=$(echo  $GITHUB_REF | cut -d"/" -f3)" >> $GITHUB_ENV
@@ -266,10 +265,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
-          set-safe-directory: ${GITHUB_WORKSPACE}
 
       - name: Setup
         run: |
+          git config --global --add safe.directory ${GITHUB_WORKSPACE}
           echo "MOAB_VERSION=${{ matrix.moab_versions }}" >> $GITHUB_ENV
           echo "COMPILER=${{ matrix.compiler }}" >> $GITHUB_ENV
           echo "HDF5_VERSION=${{ matrix.hdf5_versions }}" >> $GITHUB_ENV

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -218,7 +218,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
-          set-safe-directory: '/__w/DAGMC/DAGMC'
+          set-safe-directory: "/__w/DAGMC/DAGMC"
 
 
       - name: Setup
@@ -266,6 +266,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
+          set-safe-directory: "/__w/DAGMC/DAGMC"
 
       - name: Setup
         run: |

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -67,7 +67,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build and push Dockerfile_1_housekeeping
         uses: docker/build-push-action@v2
@@ -112,7 +112,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build and push Dockerfile_1_external_deps
         uses: docker/build-push-action@v2
@@ -182,7 +182,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build and push Dockerfile_3_moab
         uses: docker/build-push-action@v2
@@ -215,7 +215,7 @@ jobs:
     name: Running Housekeeping scrips
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: recursive
 
@@ -261,7 +261,7 @@ jobs:
     name: Installing and Testing DAGMC
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: recursive
 

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -8,7 +8,7 @@ on:
       - 'CI/?ocker**'
       - '.github/workflows/docker_publish.yml'
 
-      
+
 jobs:
   build-base-img:
     runs-on: ubuntu-latest
@@ -163,7 +163,7 @@ jobs:
           1.10.4,
         ]
         moab_versions : [
-          5.3.0,
+          5.3.1,
           develop,
           master,
         ]

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -218,7 +218,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
-          set-safe-directory: 'DAGMC/DAGMC'
+          set-safe-directory: '/__w/DAGMC/DAGMC'
 
 
       - name: Setup

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -269,6 +269,7 @@ jobs:
       - name: Setup
         run: |
           git config --global --add safe.directory ${GITHUB_WORKSPACE}
+          git config --global --add safe.directory /github/home
           echo "MOAB_VERSION=${{ matrix.moab_versions }}" >> $GITHUB_ENV
           echo "COMPILER=${{ matrix.compiler }}" >> $GITHUB_ENV
           echo "HDF5_VERSION=${{ matrix.hdf5_versions }}" >> $GITHUB_ENV

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -269,7 +269,10 @@ jobs:
       - name: Setup
         run: |
           git config --global --add safe.directory ${GITHUB_WORKSPACE}
-          git config --global --add safe.directory /github/home
+          git config --global --add safe.directory /github/home/
+          git config --global --add safe.directory /github/home/.cache
+          git config --global --add safe.directory /github/home/.cache/pip
+          git config --global --add safe.directory /github/home/.cache/pip/http
           echo "MOAB_VERSION=${{ matrix.moab_versions }}" >> $GITHUB_ENV
           echo "COMPILER=${{ matrix.compiler }}" >> $GITHUB_ENV
           echo "HDF5_VERSION=${{ matrix.hdf5_versions }}" >> $GITHUB_ENV

--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -14,7 +14,7 @@ jobs:
       image: ghcr.io/svalinn/dagmc-ci-ubuntu-18.04-housekeeping:stable
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup environment 
         run: |

--- a/.github/workflows/linux_build_test.yml
+++ b/.github/workflows/linux_build_test.yml
@@ -58,7 +58,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: recursive
 

--- a/.github/workflows/mac_build_test.yml
+++ b/.github/workflows/mac_build_test.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: macos-10.15
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Initial setup
         shell: bash -l {0}

--- a/.github/workflows/windows_build_test.yml
+++ b/.github/workflows/windows_build_test.yml
@@ -63,7 +63,7 @@ jobs:
           cmake --build . --config Release
           cmake --install . --config Release
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: build DAGMC
         shell: bash -l {0}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/pyne/pyne"]
 	path = src/pyne/pyne
-	url = https://github.com/pyne/pyne
+	url = https://github.com/pyne/pyne.git

--- a/CI/Dockerfile
+++ b/CI/Dockerfile
@@ -93,3 +93,4 @@ RUN if [ "${MOAB_VERSION}" != "master" ] && [ "${MOAB_VERSION}" != "develop" ]; 
         /root/etc/CI/docker/build_moab.sh; \
     fi;
 
+RUN python -c "import pymoab"

--- a/CI/Dockerfile
+++ b/CI/Dockerfile
@@ -80,6 +80,8 @@ RUN /root/etc/CI/docker/build_hdf5.sh
 
 FROM hdf5 AS moab
 
+ENV PYTHONPATH=/root/build_dir/moab/bld/pymoab/lib/python3.6/site-packages
+
 # Set MOAB env variable
 ENV moab_build_dir=${build_dir}/moab
 ENV moab_install_dir=${install_dir}/moab

--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -10,6 +10,7 @@ Next version
 **Changed:**
 
    * Using multi stage Dockerfile to reduce the number of Dockerfile (#813)
+   * Adding safe folder to allow CI to compile DAGMC (#814)
 
 
 v3.2.2


### PR DESCRIPTION
## Description
Attempt to fix the CI that builds and publishes the docker images

## Motivation and Context
Why is this change required? What problem does it solve?
The latest action to publish the docker image failed with this error message 
```
CMake Warning at CMakeLists.txt:27 (message):
-- Submodule update
  Could not determine the commit SHA for DAGMC.
fatal: unsafe repository ('/__w/DAGMC/DAGMC' is owned by someone else)
To add an exception for this directory, call:
	git config --global --add safe.directory /__w/DAGMC/DAGMC
CMake Error at CMakeLists.txt:38 (message):
  git submodule update --init --recursive failed with 128, please checkout
  submodules
-- Configuring incomplete, errors occurred!
See also "/root/build_dir/DAGMC-static/bld/CMakeFiles/CMakeOutput.log".
```
https://github.com/svalinn/DAGMC/actions/runs/2637740871

This PR adds the folder to the safe directory folders


## Changes
bug fix

## Behavior
What is the current behavior? What is the new behavior?
broken CI - hopefully a fixed CI (I can't be sure as file owership issues in the CI can't be fully reproduced)
