### PR TITLE
Correcting CMake variable name in OpenMC installation instructions

### DIFF
--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -10,6 +10,7 @@ Next version
 **Changed:**
 
    * Using multi stage Dockerfile to reduce the number of Dockerfile (#813)
+   * Correction to CMake variable name in OpenMC install instructions (#817)
 
 
 v3.2.2

--- a/doc/install/openmc.rst
+++ b/doc/install/openmc.rst
@@ -26,7 +26,7 @@ From the build directory, run::
 
     $ cmake ../src -DMOAB_DIR=$HOME/dagmc_bld/MOAB \
                    -DBUILD_TALLY=ON \
-                   -DCMAKE_INSTALL_PATH=$INSTALL_PATH
+                   -DCMAKE_INSTALL_PREFIX=$INSTALL_PATH
 
 If the CMake configuration proceeded successfully, you are now ready to install
 DAGMC.


### PR DESCRIPTION
Quick fix for a CMake variable name in the OpenMC installation instructions here. 