### PR TITLE
Updating remote URL for documentation Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ GH_SOURCE_BRANCH  = develop
 # Repository branch that contains the rendered HTML
 GH_PUBLISH_BRANCH = gh-pages
 # Repository that contains the rendered HTML
-GH_UPSTREAM_URL   = https://github.com/svalinn/DAGMC
+GH_UPSTREAM_URL   = git@github.com:svalinn/DAGMC
 # Directory that contains the rendered HTML
 BUILDDIR          = gh-build
 # Sphinx executable

--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -11,6 +11,7 @@ Next version
 
    * Using multi stage Dockerfile to reduce the number of Dockerfile (#813)
    * Correction to CMake variable name in OpenMC install instructions (#817)
+   * Updating documentation publishing URL (#823)
 
 
 v3.2.2


### PR DESCRIPTION
As of August 13, 2021 github requires that pushes use some kind of token authentication ([relevant announcement](https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/)).

This PR updates the expected URL in the documentation publishing Makefile to use the token-based URL for the expected remote.