### PR TITLE
Graveyard updates

### DIFF
--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -9,6 +9,7 @@ Next version
 
 **Changed:**
 
+   * Improvements/corrections to graveyard capabilities (#855)
    * Using multi stage Dockerfile to reduce the number of Dockerfile (#813)
    * Adding safe folder to allow CI to compile DAGMC (#814)
    * Correction to CMake variable name in OpenMC install instructions (#817)

--- a/src/dagmc/DagMC.cpp
+++ b/src/dagmc/DagMC.cpp
@@ -555,8 +555,10 @@ ErrorCode DagMC::create_graveyard(bool overwrite) {
   MB_CHK_SET_ERR(rval, "Failed to update the geometry sets");
 
   // delete the implicit complement tree (but not the surface trees)
-  rval = remove_bvh(implicit_complement, true);
-  MB_CHK_SET_ERR(rval, "Failed to delete the implicit complement tree");
+  if (has_acceleration_datastructures()) {
+    rval = remove_bvh(implicit_complement, true);
+    MB_CHK_SET_ERR(rval, "Failed to delete the implicit complement tree");
+  }
 
   // create BVH for both the new implicit complement and the new graveyard
   // volume

--- a/src/dagmc/DagMC.cpp
+++ b/src/dagmc/DagMC.cpp
@@ -261,7 +261,6 @@ ErrorCode DagMC::get_graveyard_group(EntityHandle& graveyard_group) {
 }
 
 ErrorCode DagMC::remove_graveyard() {
-
   if (!has_graveyard()) return MB_SUCCESS;
 
   ErrorCode rval;
@@ -412,7 +411,8 @@ ErrorCode DagMC::create_graveyard(bool overwrite) {
       // get the bounding box of the volume
       moab::EntityHandle surf = this->entity_by_index(2, i + 1);
       moab::Range vertices;
-      rval = this->moab_instance()->get_entities_by_type(surf, moab::MBVERTEX, vertices);
+      rval = this->moab_instance()->get_entities_by_type(surf, moab::MBVERTEX,
+                                                         vertices);
       MB_CHK_SET_ERR(rval, "Failed to get surface vertices");
       double coords[3];
       for (auto vertex : vertices) {
@@ -422,8 +422,8 @@ ErrorCode DagMC::create_graveyard(bool overwrite) {
         box.update(coords);
       }
     }
-  // if there acceleration data structures exist, use those for
-  // a faster bounding box build
+    // if there acceleration data structures exist, use those for
+    // a faster bounding box build
   } else {
     for (int i = 0; i < num_entities(3); i++) {
       // get the bounding box of the volume
@@ -500,7 +500,8 @@ ErrorCode DagMC::create_graveyard(bool overwrite) {
     rval = setup_impl_compl();
     MB_CHK_SET_ERR(rval, "Failed to create the implicit complement.");
     rval = geom_tool()->get_implicit_complement(implicit_complement);
-    MB_CHK_SET_ERR(rval, "Failed to get implicit complement right after creation");
+    MB_CHK_SET_ERR(rval,
+                   "Failed to get implicit complement right after creation");
   }
 
   EntityHandle inner_surface;
@@ -543,7 +544,8 @@ ErrorCode DagMC::create_graveyard(bool overwrite) {
                  "Failed to create the graveyard parent-child relationship");
 
   // set the surface senses (all triangles have outward normals so this should
-  // be FORWARD wrt the graveyard volume and REVERSE wrt the implicit complement)
+  // be FORWARD wrt the graveyard volume and REVERSE wrt the implicit
+  // complement)
   EntityHandle outer_senses[2] = {volume_set, implicit_complement};
   rval = MBI->tag_set_data(sense_tag(), &outer_surface, 1, outer_senses);
   MB_CHK_SET_ERR(rval, "Failed to set graveyard surface senses");
@@ -568,9 +570,9 @@ ErrorCode DagMC::create_graveyard(bool overwrite) {
         "Failed to build accel. data structure for the new graveyard volume");
     // re-build the BVH for the implicit complement
     rval = build_bvh(implicit_complement);
-    MB_CHK_SET_ERR(
-        rval,
-        "Failed to build accel. data structure for the new implicit complement");
+    MB_CHK_SET_ERR(rval,
+                   "Failed to build accel. data structure for the new implicit "
+                   "complement");
   }
 
   // re-initialize indices

--- a/src/dagmc/DagMC.cpp
+++ b/src/dagmc/DagMC.cpp
@@ -397,7 +397,7 @@ ErrorCode DagMC::create_graveyard(bool overwrite) {
 
   // if a graveyard already exists and we aren't overwriting it,
   // report an error
-  if (has_graveyard() && !overwrite) {
+  if (has_graveyard()) {
     MB_CHK_SET_ERR(MB_FAILURE, "Graveyard already exists");
   }
 
@@ -554,15 +554,13 @@ ErrorCode DagMC::create_graveyard(bool overwrite) {
   rval = geom_tool()->find_geomsets();
   MB_CHK_SET_ERR(rval, "Failed to update the geometry sets");
 
-  // delete the implicit complement tree (but not the surface trees)
-  if (has_acceleration_datastructures()) {
-    rval = remove_bvh(implicit_complement, true);
-    MB_CHK_SET_ERR(rval, "Failed to delete the implicit complement tree");
-  }
-
   // create BVH for both the new implicit complement and the new graveyard
   // volume
   if (has_acceleration_datastructures()) {
+    // delete the implicit complement tree (but not the surface trees)
+    rval = remove_bvh(implicit_complement, true);
+    MB_CHK_SET_ERR(rval, "Failed to delete the implicit complement tree");
+
     // build the BVH for the new graveyard volume
     rval = build_bvh(volume_set);
     MB_CHK_SET_ERR(

--- a/src/dagmc/DagMC.cpp
+++ b/src/dagmc/DagMC.cpp
@@ -493,7 +493,7 @@ ErrorCode DagMC::create_graveyard(bool overwrite) {
   if (rval != MB_ENTITY_NOT_FOUND && rval != MB_SUCCESS) {
     MB_CHK_SET_ERR(rval, "Could not get the implicit complement");
   }
-  // create the implicit complement if it coesn't exist at this point
+  // create the implicit complement if it doesn't exist at this point
   // the code below that inserts the graveyard into the implicit complement can
   // be run without changing the model at this point
   if (!implicit_complement) {

--- a/src/dagmc/DagMC.cpp
+++ b/src/dagmc/DagMC.cpp
@@ -261,6 +261,9 @@ ErrorCode DagMC::get_graveyard_group(EntityHandle& graveyard_group) {
 }
 
 ErrorCode DagMC::remove_graveyard() {
+
+  if (!has_graveyard()) return MB_SUCCESS;
+
   ErrorCode rval;
 
   EntityHandle graveyard_group;
@@ -388,7 +391,7 @@ ErrorCode DagMC::create_graveyard(bool overwrite) {
   ErrorCode rval;
 
   // remove existing graveyard if overwrite is true
-  if (has_graveyard() && overwrite) {
+  if (overwrite) {
     remove_graveyard();
   }
 
@@ -494,7 +497,8 @@ ErrorCode DagMC::create_graveyard(bool overwrite) {
   // the code below that inserts the graveyard into the implicit complement can
   // be run without changing the model at this point
   if (!implicit_complement) {
-    setup_impl_compl();
+    rval = setup_impl_compl();
+    MB_CHK_SET_ERR(rval, "Failed to create the implicit complement.");
     rval = geom_tool()->get_implicit_complement(implicit_complement);
     MB_CHK_SET_ERR(rval, "Failed to get implicit complement right after creation");
   }

--- a/src/dagmc/tests/dagmc_graveyard_test.cpp
+++ b/src/dagmc/tests/dagmc_graveyard_test.cpp
@@ -335,7 +335,8 @@ TEST_F(DagmcGraveyardTest, dagmc_graveyard_test_trelis_file_no_bvh) {
 
   EXPECT_FALSE(DAG->has_graveyard());
 
-  rval = DAG->create_graveyard();
+  // create graveyard with overwrite on when graveyard isn't present
+  rval = DAG->create_graveyard(true);
   EXPECT_EQ(MB_SUCCESS, rval);
 
   // the implicit complement will be created here too

--- a/src/dagmc/tests/dagmc_graveyard_test.cpp
+++ b/src/dagmc/tests/dagmc_graveyard_test.cpp
@@ -253,3 +253,159 @@ TEST_F(DagmcGraveyardTest, dagmc_graveyard_test_trelis_file) {
   EXPECT_EQ(model_sets.size(), ending_sets.size());
   EXPECT_EQ(0, subtract(model_sets, ending_sets).size());
 }
+
+TEST_F(DagmcGraveyardTest, dagmc_graveyard_test_trelis_file_no_bvh) {
+  // create DAGMC instance
+  std::unique_ptr<DagMC> DAG(new DagMC());
+  // load the trelis test file
+  ErrorCode rval = DAG->load_file(trelis_file.c_str());
+  EXPECT_EQ(MB_SUCCESS, rval);
+
+  ////////////////////////////////////////////////
+  // BVH creation would normally occur here.    //
+  // It is intentionally skipped for this test. //
+  ////////////////////////////////////////////////
+
+  rval = DAG->setup_indices();
+  EXPECT_EQ(MB_SUCCESS, rval);
+
+  // collect starting sets to make sure we end up with the same thing at the end
+  Range starting_vertices;
+  rval = DAG->moab_instance()->get_entities_by_type(0, MBVERTEX,
+                                                    starting_vertices);
+  EXPECT_EQ(MB_SUCCESS, rval);
+
+  Range starting_triangles;
+  rval =
+      DAG->moab_instance()->get_entities_by_type(0, MBTRI, starting_triangles);
+  EXPECT_EQ(MB_SUCCESS, rval);
+
+  Range starting_sets;
+  rval =
+      DAG->moab_instance()->get_entities_by_type(0, MBENTITYSET, starting_sets);
+  EXPECT_EQ(MB_SUCCESS, rval);
+
+  // a graveyard is already present in this model
+  EXPECT_TRUE(DAG->has_graveyard());
+
+  int n_groups = DAG->num_entities(4);
+  int n_vols = DAG->num_entities(3);
+  int n_surfs = DAG->num_entities(2);
+  // the DagMC class only tracks relevant geometry sets (surfaces and volumes)
+  int n_curves = DAG->geom_tool()->num_ents_of_dim(1);
+  int n_geom_verts = DAG->geom_tool()->num_ents_of_dim(0);
+
+  // remove original graveyard
+  rval = DAG->remove_graveyard();
+  EXPECT_EQ(MB_SUCCESS, rval);
+
+  // geometric sets removed:
+  // (geometric vertices - 16, curves - 24, surfaces - 12, volumes - 1, groups -
+  // 1)
+  EXPECT_EQ(16, n_geom_verts - DAG->geom_tool()->num_ents_of_dim(0));
+  EXPECT_EQ(24, n_curves - DAG->geom_tool()->num_ents_of_dim(1));
+  EXPECT_EQ(12, n_surfs - DAG->num_entities(2));
+  EXPECT_EQ(1, n_vols - DAG->num_entities(3));
+  EXPECT_EQ(1, n_groups - DAG->num_entities(4));
+
+  DAG->moab_instance()->write_file("test.h5m");
+  // set of vertices, triangles, and sets without the original graveyard volume
+  Range model_vertices;
+  rval =
+      DAG->moab_instance()->get_entities_by_type(0, MBVERTEX, model_vertices);
+  EXPECT_EQ(MB_SUCCESS, rval);
+
+  Range model_triangles;
+  rval = DAG->moab_instance()->get_entities_by_type(0, MBTRI, model_triangles);
+  EXPECT_EQ(MB_SUCCESS, rval);
+
+  Range model_sets;
+  rval = DAG->moab_instance()->get_entities_by_type(0, MBENTITYSET, model_sets);
+  EXPECT_EQ(MB_SUCCESS, rval);
+
+  // make sure the right number of mesh elements were removed
+  // sixteen vertices removed (corners of two cuboid volumes)
+  EXPECT_EQ(starting_vertices.size() - 16, model_vertices.size());
+  // twenty-four triangles removed (two per face for two cuboid volumes)
+  EXPECT_EQ(starting_triangles.size() - 24, model_triangles.size());
+
+  // update number of surfaces and volumes before creating the graveyard
+  n_vols = DAG->num_entities(3);
+  n_surfs = DAG->num_entities(2);
+
+  EXPECT_FALSE(DAG->has_graveyard());
+
+  rval = DAG->create_graveyard();
+  EXPECT_EQ(MB_SUCCESS, rval);
+
+  // the implicit complement will be created here too
+  // so there will be two more volumes than before
+  EXPECT_EQ(n_vols + 2, DAG->num_entities(3));
+  EXPECT_EQ(n_surfs + 2, DAG->num_entities(2));
+
+  EXPECT_TRUE(DAG->has_graveyard());
+
+  rval = DAG->remove_graveyard();
+  EXPECT_EQ(MB_SUCCESS, rval);
+
+  // here we've removed the graveyard, but the implicit complement remains
+  // so there will be one fewer volumes than the last check
+  EXPECT_EQ(n_vols + 1, DAG->num_entities(3));
+  EXPECT_EQ(n_surfs, DAG->num_entities(2));
+
+  EXPECT_FALSE(DAG->has_graveyard());
+
+  rval = DAG->create_graveyard();
+  EXPECT_EQ(MB_SUCCESS, rval);
+
+  EXPECT_TRUE(DAG->has_graveyard());
+
+  // test overwrite capability
+  bool overwrite_graveyard = true;
+  rval = DAG->create_graveyard(true);
+  EXPECT_EQ(MB_SUCCESS, rval);
+
+  EXPECT_EQ(n_vols + +2, DAG->num_entities(3));
+  EXPECT_EQ(n_surfs + 2, DAG->num_entities(2));
+
+  // this should fail, graveyard already exists
+  // and overwrite isn't specified
+  rval = DAG->create_graveyard();
+  EXPECT_EQ(MB_FAILURE, rval);
+
+  rval = DAG->remove_graveyard();
+  EXPECT_EQ(MB_SUCCESS, rval);
+
+  EXPECT_FALSE(DAG->has_graveyard());
+
+  // checks to make sure we didn't accumulate any new data on the mesh
+  Range ending_vertices;
+  rval =
+      DAG->moab_instance()->get_entities_by_type(0, MBVERTEX, ending_vertices);
+  EXPECT_EQ(MB_SUCCESS, rval);
+
+  Range ending_triangles;
+  rval = DAG->moab_instance()->get_entities_by_type(0, MBTRI, ending_triangles);
+  EXPECT_EQ(MB_SUCCESS, rval);
+
+  Range ending_sets;
+  rval =
+      DAG->moab_instance()->get_entities_by_type(0, MBENTITYSET, ending_sets);
+  EXPECT_EQ(MB_SUCCESS, rval);
+
+  EXPECT_EQ(model_vertices.size(), ending_vertices.size());
+  EXPECT_EQ(0, subtract(model_vertices, ending_vertices).size());
+
+  EXPECT_EQ(model_triangles.size(), ending_triangles.size());
+  EXPECT_EQ(0, subtract(model_triangles, ending_triangles).size());
+
+  // here we've added the implict complement before setting the model sets
+  // so there should be one extra set and it will be equal to the implicit
+  // complement set
+  EXPECT_EQ(model_sets.size() + 1, ending_sets.size());
+  EXPECT_EQ(1, subtract(ending_sets, model_sets).size());
+  EntityHandle implicit_complement;
+  rval = DAG->geom_tool()->get_implicit_complement(implicit_complement);
+  EXPECT_EQ(MB_SUCCESS, rval);
+  EXPECT_EQ(implicit_complement, subtract(ending_sets, model_sets)[0]);
+}


### PR DESCRIPTION
## Description
These changes update some behavior of the `DagMC::create/remove_graveyard` function. 

### `create_graveyard`
  - `create_graveyard` can now create a graveyard without acceleration data structures using the vertices of the model to create a bounding box as a basis for the graveyard volume.
  - `create_graveyard` will create an implicit complement if none exists so the graveyard volume can be inserted into the model topology correctly.
  - `create_graveyard` will only (re)construct acceleration data structures for the new graveyard volume and the implicit complement if  these data structures were present when the method was initially called.

### `remove_graveyard`

There's a bug when calling `create_graveyard` with `overwrite == true` when a graveyard is not present. Previously, this would fail when trying to remove a graveyard that isn't present. This adds a check at the beginning of `remove_graveyard` to simply return `MB_SUCCESS` if no graveyard is present.

