### PR TITLE
move test-on-merge with master/develop to be optional

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -163,7 +163,7 @@ jobs:
           1.10.4,
         ]
         moab_versions : [
-          5.4.0,
+          5.3.0,
           master,
         ]
 

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -164,7 +164,6 @@ jobs:
         ]
         moab_versions : [
           5.3.0,
-          master,
         ]
 
     name: Ubuntu ${{ matrix.ubuntu_versions }} + ${{ matrix.compiler }} hdf5 ${{ matrix.hdf5_versions }} + Moab ${{ matrix.moab_versions }}
@@ -346,7 +345,6 @@ jobs:
         ]
         moab_versions : [
          5.3.0,
-         master,
         ]
 
     name: Ubuntu${{ matrix.ubuntu_versions }} + ${{ matrix.compiler }} hdf5 ${{ matrix.hdf5_versions }} + Moab ${{ matrix.moab_versions }}':' latest -> stable

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -164,7 +164,6 @@ jobs:
         ]
         moab_versions : [
           5.4.0,
-          develop,
           master,
         ]
 
@@ -254,8 +253,6 @@ jobs:
         ]
         moab_versions : [
          5.3.0,
-         develop,
-         master,
         ]
     container: ghcr.io/${{ github.repository_owner }}/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler}}-ext-hdf5_${{ matrix.hdf5_versions}}-moab_${{ matrix.moab_versions }}:ci_testing
 
@@ -349,7 +346,6 @@ jobs:
         ]
         moab_versions : [
          5.3.0,
-         develop,
          master,
         ]
 

--- a/.github/workflows/linux_build_test.yml
+++ b/.github/workflows/linux_build_test.yml
@@ -59,7 +59,7 @@ jobs:
           echo "REPO_SLUG=${GITHUB_REPOSITORY}" >> $GITHUB_ENV
           echo "PULL_REQUEST=$(echo  $GITHUB_REF | cut -d"/" -f3)" >> $GITHUB_ENV
           echo "DOUBLE_DOWN="OFF"" >> $GITHUB_ENV
-          echo "PYTHONPATH="/root/build_dir/moab/bld/pymoab/lib/python3.6/site-packages:$PYTHONPATH"" >> $GITHUB_ENV
+          echo "PYTHONPATH=/root/build_dir/moab/bld/pymoab/lib/python3.8/site-packages:${PYTHONPATH}" >> $GITHUB_ENV
           ln -s $GITHUB_WORKSPACE /root/build_dir/DAGMC
 
       - name: Building DAGMC

--- a/.github/workflows/linux_build_test.yml
+++ b/.github/workflows/linux_build_test.yml
@@ -42,6 +42,59 @@ jobs:
         ]
         moab_versions : [
           5.3.0,
+        ]
+
+    container:
+      image: ghcr.io/svalinn/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler }}-ext-hdf5_${{ matrix.hdf5_versions }}-moab_${{ matrix.moab_versions }}:stable
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Setup
+        run: |
+          echo "MOAB_VERSION=${{ matrix.moab_versions }}" >> $GITHUB_ENV
+          echo "COMPILER=${{ matrix.compiler }}" >> $GITHUB_ENV
+          echo "HDF5_VERSION=${{ matrix.hdf5_versions }}" >> $GITHUB_ENV
+          echo "REPO_SLUG=${GITHUB_REPOSITORY}" >> $GITHUB_ENV
+          echo "PULL_REQUEST=$(echo  $GITHUB_REF | cut -d"/" -f3)" >> $GITHUB_ENV
+          echo "DOUBLE_DOWN="OFF"" >> $GITHUB_ENV
+          echo "PYTHONPATH="/root/build_dir/moab/bld/pymoab/lib/python3.6/site-packages:$PYTHONPATH"" >> $GITHUB_ENV
+          ln -s $GITHUB_WORKSPACE /root/build_dir/DAGMC
+
+      - name: Building DAGMC
+        run: |
+          cd $GITHUB_WORKSPACE
+          CI/scripts/install.sh
+
+      - name: Testing DAGMC
+        run: |
+          cd $GITHUB_WORKSPACE
+          CI/scripts/tests.sh
+
+  BuildTestMasterDev:
+    needs: BuildTest
+    runs-on: ubuntu-latest
+    env:
+      hdf5_versions: ${{ matrix.hdf5_versions }}
+      hdf5_build_dir: hdf5_build_dir
+
+    strategy:
+      matrix:
+        ubuntu_versions : [
+          18.04,
+          20.04,
+          ]
+        compiler : [
+          gcc,
+          clang,
+          ]
+        hdf5_versions : [
+         1.10.4,
+        ]
+        moab_versions : [
           develop,
           master,
         ]
@@ -74,11 +127,13 @@ jobs:
           ln -s $GITHUB_WORKSPACE /root/build_dir/DAGMC
 
       - name: Building DAGMC
+        continue-on-error: true
         run: |
           cd $GITHUB_WORKSPACE
           CI/scripts/install.sh
 
       - name: Testing DAGMC
+        continue-on-error: true
         run: |
           cd $GITHUB_WORKSPACE
           CI/scripts/tests.sh

--- a/.github/workflows/linux_build_test_merge.yml
+++ b/.github/workflows/linux_build_test_merge.yml
@@ -4,8 +4,9 @@ on:
   # allows us to run workflows manually
   workflow_dispatch:
   push:
-    branches:
-      - develop
+# REMOVED for testing
+#    branches:
+#      - develop
     paths-ignore:
       - '.github/workflows/docker_publish.yml'
       - '.github/workflows/housekeeping.yml'

--- a/.github/workflows/linux_build_test_merge.yml
+++ b/.github/workflows/linux_build_test_merge.yml
@@ -1,15 +1,8 @@
-name: Linux Build/Test
+name: Linux Build/Test on Merge
 
 on:
   # allows us to run workflows manually
   workflow_dispatch:
-  pull_request:
-    branches:
-      - develop
-    paths-ignore:
-      - '.github/workflows/docker_publish.yml'
-      - '.github/workflows/housekeeping.yml'
-      - 'CI/**'
   push:
     branches:
       - develop
@@ -19,7 +12,7 @@ on:
       - 'CI/**'
 
 jobs:
-  BuildTest:
+  BuildTestMasterDev:
     runs-on: ubuntu-latest
     env:
       hdf5_versions: ${{ matrix.hdf5_versions }}
@@ -39,7 +32,8 @@ jobs:
          1.10.4,
         ]
         moab_versions : [
-          5.3.0,
+          develop,
+          master,
         ]
 
     container:

--- a/.github/workflows/linux_build_test_merge.yml
+++ b/.github/workflows/linux_build_test_merge.yml
@@ -32,7 +32,6 @@ jobs:
          1.10.4,
         ]
         moab_versions : [
-          develop,
           master,
         ]
 

--- a/.github/workflows/linux_build_test_merge.yml
+++ b/.github/workflows/linux_build_test_merge.yml
@@ -4,9 +4,8 @@ on:
   # allows us to run workflows manually
   workflow_dispatch:
   push:
-# REMOVED for testing
-#    branches:
-#      - develop
+    branches:
+      - develop
     paths-ignore:
       - '.github/workflows/docker_publish.yml'
       - '.github/workflows/housekeeping.yml'

--- a/.github/workflows/linux_build_test_merge.yml
+++ b/.github/workflows/linux_build_test_merge.yml
@@ -52,7 +52,7 @@ jobs:
           echo "REPO_SLUG=${GITHUB_REPOSITORY}" >> $GITHUB_ENV
           echo "PULL_REQUEST=$(echo  $GITHUB_REF | cut -d"/" -f3)" >> $GITHUB_ENV
           echo "DOUBLE_DOWN="OFF"" >> $GITHUB_ENV
-          echo "PYTHONPATH="/root/build_dir/moab/bld/pymoab/lib/python3.6/site-packages:$PYTHONPATH"" >> $GITHUB_ENV
+          echo "PYTHONPATH=/root/build_dir/moab/bld/pymoab/lib/python3.8/site-packages:${PYTHONPATH}" >> $GITHUB_ENV
           ln -s $GITHUB_WORKSPACE /root/build_dir/DAGMC
 
       - name: Building DAGMC

--- a/.github/workflows/mac_build_test.yml
+++ b/.github/workflows/mac_build_test.yml
@@ -6,11 +6,10 @@ on:
   pull_request:
     branches:
       - develop
-      - master
   push:
     branches:
       - develop
-      - master
+
   release:
     types: # This configuration does not affect the page_build event above
       - created

--- a/.github/workflows/windows_build_test.yml
+++ b/.github/workflows/windows_build_test.yml
@@ -6,7 +6,9 @@ on:
   pull_request:
     branches:
       - develop
-      - master
+  push:
+    branches:
+      - develop
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CI/Dockerfile
+++ b/CI/Dockerfile
@@ -92,5 +92,4 @@ ENV MOAB_VERSION ${MOAB}
 RUN if [ "${MOAB_VERSION}" != "master" ] && [ "${MOAB_VERSION}" != "develop" ]; then \
         /root/etc/CI/docker/build_moab.sh; \
     fi;
-
-RUN python -c "import pymoab"
+    

--- a/CI/Dockerfile
+++ b/CI/Dockerfile
@@ -80,7 +80,7 @@ RUN /root/etc/CI/docker/build_hdf5.sh
 
 FROM hdf5 AS moab
 
-ENV PYTHONPATH=/root/build_dir/moab/bld/pymoab/lib/python3.6/site-packages
+ENV PYTHONPATH=/root/build_dir/moab/bld/pymoab/lib/python3.8/site-packages
 
 # Set MOAB env variable
 ENV moab_build_dir=${build_dir}/moab

--- a/README.rst
+++ b/README.rst
@@ -35,9 +35,6 @@ materials and other geometry-related information.
 
 For more information, please visit the `DAGMC website <DAGMC_>`_.
 
-..  image:: https://github.com/svalinn/DAGMC/actions/workflows/linux_build_test_merge.yml/badge.svg?branch=develop
-    :target: https://github.com/svalinn/DAGMC/actions/workflows/linux_build_test_merge.yml
-
 Quick links:
 
 * `Install guide <https://svalinn.github.io/DAGMC/install/index.html>`_
@@ -45,8 +42,10 @@ Quick links:
 * `Contributors guide <https://svalinn.github.io/DAGMC/contribute/index.html>`_
 * `Release instructions <release.rst>`_
 
-Preview CI for MOAB `master` and `develop`
-------------------------------------------
+*Preview CI for MOAB `master` and `develop`*
+
+..  image:: https://github.com/svalinn/DAGMC/actions/workflows/linux_build_test_merge.yml/badge.svg?branch=develop
+    :target: https://github.com/svalinn/DAGMC/actions/workflows/linux_build_test_merge.yml
 
 ..  _DAGMC: https://svalinn.github.io/DAGMC
 ..  _Cubit: https://coreform.com/products/coreform-cubit/

--- a/README.rst
+++ b/README.rst
@@ -16,10 +16,6 @@ DAGMC: Direct Accelerated Geometry Monte Carlo
 ..  image:: https://anaconda.org/conda-forge/dagmc/badges/version.svg
     :target: https://anaconda.org/conda-forge/dagmc
 
-\[Preview for MOAB `master` and `develop`:\] 
-
-..  image:: https://github.com/svalinn/DAGMC/actions/workflows/linux_build_test_merge.yml/badge.svg?branch=develop
-    :target: https://github.com/svalinn/DAGMC/actions/workflows/linux_build_test_merge.yml
 
 Direct Accelerated Geometry Monte Carlo (DAGMC) is a software package that
 allows users to perform Monte Carlo radiation transport directly on CAD models.
@@ -39,12 +35,18 @@ materials and other geometry-related information.
 
 For more information, please visit the `DAGMC website <DAGMC_>`_.
 
+..  image:: https://github.com/svalinn/DAGMC/actions/workflows/linux_build_test_merge.yml/badge.svg?branch=develop
+    :target: https://github.com/svalinn/DAGMC/actions/workflows/linux_build_test_merge.yml
+
 Quick links:
 
 * `Install guide <https://svalinn.github.io/DAGMC/install/index.html>`_
 * `Users guide <https://svalinn.github.io/DAGMC/usersguide/index.html>`_
 * `Contributors guide <https://svalinn.github.io/DAGMC/contribute/index.html>`_
-*  `Release instructions <release.rst>`_
+* `Release instructions <release.rst>`_
+
+Preview CI for MOAB `master` and `develop`
+------------------------------------------
 
 ..  _DAGMC: https://svalinn.github.io/DAGMC
 ..  _Cubit: https://coreform.com/products/coreform-cubit/

--- a/README.rst
+++ b/README.rst
@@ -16,6 +16,11 @@ DAGMC: Direct Accelerated Geometry Monte Carlo
 ..  image:: https://anaconda.org/conda-forge/dagmc/badges/version.svg
     :target: https://anaconda.org/conda-forge/dagmc
 
+[Preview for MOAB `master` and `develop`: 
+..  image:: https://github.com/svalinn/DAGMC/actions/workflows/linux_build_test_merge.yml/badge.svg?branch=develop
+    :target: https://github.com/svalinn/DAGMC/actions/workflows/linux_build_test_merge.yml
+    ]
+
 Direct Accelerated Geometry Monte Carlo (DAGMC) is a software package that
 allows users to perform Monte Carlo radiation transport directly on CAD models.
 

--- a/README.rst
+++ b/README.rst
@@ -15,10 +15,11 @@ DAGMC: Direct Accelerated Geometry Monte Carlo
 
 ..  image:: https://anaconda.org/conda-forge/dagmc/badges/version.svg
     :target: https://anaconda.org/conda-forge/dagmc
-\[Preview for MOAB `master` and `develop`: 
+
+\[Preview for MOAB `master` and `develop`:\] 
+
 ..  image:: https://github.com/svalinn/DAGMC/actions/workflows/linux_build_test_merge.yml/badge.svg?branch=develop
     :target: https://github.com/svalinn/DAGMC/actions/workflows/linux_build_test_merge.yml
-    \]
 
 Direct Accelerated Geometry Monte Carlo (DAGMC) is a software package that
 allows users to perform Monte Carlo radiation transport directly on CAD models.

--- a/README.rst
+++ b/README.rst
@@ -15,11 +15,10 @@ DAGMC: Direct Accelerated Geometry Monte Carlo
 
 ..  image:: https://anaconda.org/conda-forge/dagmc/badges/version.svg
     :target: https://anaconda.org/conda-forge/dagmc
-
-[Preview for MOAB `master` and `develop`: 
+\[Preview for MOAB `master` and `develop`: 
 ..  image:: https://github.com/svalinn/DAGMC/actions/workflows/linux_build_test_merge.yml/badge.svg?branch=develop
     :target: https://github.com/svalinn/DAGMC/actions/workflows/linux_build_test_merge.yml
-    ]
+    \]
 
 Direct Accelerated Geometry Monte Carlo (DAGMC) is a software package that
 allows users to perform Monte Carlo radiation transport directly on CAD models.

--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -18,6 +18,7 @@ Next version
    * Minor typo fixes in documentation (#851)
    * Removed unused Circle CI yml (#859)
    * Added configuration options to CMake configuration file (#86)
+   * Change test-on-merge against MOAB master/develop to be optional (#??)
 
 **Fixed:**
    * Patch to compile with Geant4 10.6     

--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -17,8 +17,8 @@ Next version
    * Update Pyne submodule (#848)
    * Minor typo fixes in documentation (#851)
    * Removed unused Circle CI yml (#859)
-   * Added configuration options to CMake configuration file (#86)
-   * Change test-on-merge against MOAB master/develop to be optional (#??)
+   * Added configuration options to CMake configuration file (#867)
+   * Change test-on-merge against MOAB master/develop to be optional (#870)
 
 **Fixed:**
    * Patch to compile with Geant4 10.6     


### PR DESCRIPTION
## Description
Change tests against MOAB `master` and `develop` to be optional.

## Motivation and Context
We current only test on MOAB 5.3.0 during review of a PR, but then test on MOAB `master` and `develop` upon merge.  Those tests against `master` & `develop` are meant to be advisory and not indicative of the state of the project. 

## Changes
Change github action behavior.
