### PR TITLE
Adding console output methods to some classes

### DIFF
--- a/.github/workflows/linux_build_test.yml
+++ b/.github/workflows/linux_build_test.yml
@@ -48,6 +48,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          set-safe-directory: '*'
 
       - name: Setup
         run: |

--- a/.github/workflows/linux_build_test.yml
+++ b/.github/workflows/linux_build_test.yml
@@ -48,8 +48,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-        with:
-          submodules: recursive
 
       - name: Setup
         run: |

--- a/.github/workflows/linux_build_test_merge.yml
+++ b/.github/workflows/linux_build_test_merge.yml
@@ -41,8 +41,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-        with:
-          submodules: recursive
 
       - name: Setup
         run: |

--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -22,8 +22,8 @@ Next version
    * Change test-on-merge against MOAB master/develop to be optional (#870)
 
 **Fixed:**
-   * Patch to compile with Geant4 10.6     
-
+   * Patch to compile with Geant4 10.6
+   * Enhance console logging capabilities (#872)
 
 v3.2.2
 ====================
@@ -48,7 +48,7 @@ v3.2.1
 **Removed:**
 
 **Fixed:**
-      
+
 **Security:**
 
 **Maintenance:**

--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -20,10 +20,10 @@ Next version
    * Removed unused Circle CI yml (#859)
    * Added configuration options to CMake configuration file (#867)
    * Change test-on-merge against MOAB master/develop to be optional (#870)
+   * Enhance console logging capabilities (#872)
 
 **Fixed:**
    * Patch to compile with Geant4 10.6
-   * Enhance console logging capabilities (#872)
 
 v3.2.2
 ====================

--- a/src/dagmc/DagMC.hpp
+++ b/src/dagmc/DagMC.hpp
@@ -75,11 +75,10 @@ class DagMC {
   DagMC(std::shared_ptr<Interface> mb_impl = nullptr,
         double overlap_tolerance = 0., double numerical_precision = .001);
   // Deprecated Constructor
-  [
-      [deprecated("Replaced by DagMC(std::shared_ptr<Interface> mb_impl, ... "
-                  ")")]] DagMC(Interface* mb_impl,
-                               double overlap_tolerance = 0.,
-                               double numerical_precision = .001);
+  [[deprecated(
+      "Replaced by DagMC(std::shared_ptr<Interface> mb_impl, ... "
+      ")")]] DagMC(Interface* mb_impl, double overlap_tolerance = 0.,
+                   double numerical_precision = .001);
   // Destructor
   ~DagMC();
 

--- a/src/dagmc/DagMC.hpp
+++ b/src/dagmc/DagMC.hpp
@@ -466,6 +466,56 @@ class DagMC {
     return MBI_shared_ptr;
   }
 
+  // Verbosity levels
+  // -1 : "override" the current verbosity setting and write message
+  //  0 : No output
+  //  1 : All output
+  int set_verbosity(int val) {
+    int verbosity_max = 0;
+    int verbosity_min = 1;
+    if (val < verbosity_min || val > verbosity_max)
+      warning("Invalid verbosity value " + std::to_string(val) +
+              " will be set to nearest valid value.");
+    val = std::min(std::max(verbosity_min, val), verbosity_max);
+    return verbosity = val;
+  }
+
+  int get_verbosity(int val) { return verbosity; }
+
+  /** console output mechanism
+   *  @param msg Message to be written to the console
+   *  @param lvl Message will not be written if the verbosity level
+   *             is higher than the class instance's current verbosity setting.
+   *             Use of -1 ensures the message will always be written.
+   *  @param newline Whether or not to apend a newline to the message.
+   */
+  void message(const std::string& msg, int lvl = 1, bool newline = true) const {
+    // do not write message if level is higher than
+    // verbosity setting
+    if (lvl > verbosity) return;
+    // otherwise, display message
+    if (newline)
+      std::cout << msg << "\n";
+    else
+      std::cout << msg;
+  }
+
+  /** write a warning message to the console
+   *  @param msg Message to be written to the console
+   *  @param newline Whether or not to apend a newline to the message.
+   */
+  void warning(const std::string& msg, bool newline = true) const {
+    message("WARNING: " + msg, -1, newline);
+  }
+
+  /** write an error message to the console
+   *  @param msg Message to be written to the console
+   *  @param newline Whether or not to apend a newline to the message.
+   */
+  void err_msg(const std::string& msg, bool newline = true) const {
+    message("ERROR: " + msg, -1, newline);
+  }
+
  private:
   /* PRIVATE MEMBER DATA */
 
@@ -485,6 +535,9 @@ class DagMC {
 #endif
 
   std::unique_ptr<RayTracer> ray_tracer;
+
+  /** verbosity setting for DAGMC operations */
+  int verbosity{1};
 
  public:
   Tag nameTag, facetingTolTag;

--- a/src/dagmc/DagMC.hpp
+++ b/src/dagmc/DagMC.hpp
@@ -471,8 +471,8 @@ class DagMC {
   //  0 : No output
   //  1 : All output
   int set_verbosity(int val) {
-    int verbosity_max = 0;
-    int verbosity_min = 1;
+    int verbosity_min = 0;
+    int verbosity_max = 1;
     if (val < verbosity_min || val > verbosity_max)
       warning("Invalid verbosity value " + std::to_string(val) +
               " will be set to nearest valid value.");
@@ -480,7 +480,7 @@ class DagMC {
     return verbosity = val;
   }
 
-  int get_verbosity(int val) { return verbosity; }
+  int get_verbosity() const { return verbosity; }
 
   /** console output mechanism
    *  @param msg Message to be written to the console

--- a/src/dagmc/dagmcmetadata.cpp
+++ b/src/dagmc/dagmcmetadata.cpp
@@ -289,9 +289,8 @@ void dagmcMetaData::parse_importance_data() {
            << std::endl;
         ss << "Assigned for particle type " << pair.first << std::endl;
         ss << "Only one importance value per volume per particle type "
-              "is allowed"
-           << std::endl;
-        message(ss.str(), -1, false);
+              "is allowed";
+        message(ss.str(), -1);
         exit(EXIT_FAILURE);
       }
     }
@@ -370,8 +369,7 @@ void dagmcMetaData::parse_boundary_data() {
       for (int j = 0; j < boundary_assignment.size(); j++) {
         ss << boundary_assignment[j] << std::endl;
       }
-      ss << "Please check your boundary condition assignments " << surfid
-         << std::endl;
+      ss << "Please check your boundary condition assignments " << surfid;
       err_msg(ss.str());
       exit(EXIT_FAILURE);
     }

--- a/src/dagmc/dagmcmetadata.cpp
+++ b/src/dagmc/dagmcmetadata.cpp
@@ -2,8 +2,8 @@
 
 #include <algorithm>
 #include <iostream>
-#include <sstream>
 #include <set>
+#include <sstream>
 
 #include "util.hpp"
 
@@ -285,10 +285,12 @@ void dagmcMetaData::parse_importance_data() {
         importance_map[eh][pair.first] = imp;
       } else {
         std::stringstream ss;
-        ss << "Volume with ID " << volid << " has more than one importance " << std::endl;
+        ss << "Volume with ID " << volid << " has more than one importance "
+           << std::endl;
         ss << "Assigned for particle type " << pair.first << std::endl;
         ss << "Only one importance value per volume per particle type "
-                     "is allowed" << std::endl;
+              "is allowed"
+           << std::endl;
         message(ss.str(), -1, false);
         exit(EXIT_FAILURE);
       }
@@ -363,14 +365,13 @@ void dagmcMetaData::parse_boundary_data() {
     if (boundary_assignment.size() != 1) {
       std::stringstream ss;
       ss << "More than one boundary conditions specified for " << surfid
-                << std::endl;
-      ss << surfid << " has the following density assignments"
-                << std::endl;
+         << std::endl;
+      ss << surfid << " has the following density assignments" << std::endl;
       for (int j = 0; j < boundary_assignment.size(); j++) {
         ss << boundary_assignment[j] << std::endl;
       }
       ss << "Please check your boundary condition assignments " << surfid
-                << std::endl;
+         << std::endl;
       err_msg(ss.str());
       exit(EXIT_FAILURE);
     }
@@ -623,8 +624,9 @@ std::pair<std::string, std::string> dagmcMetaData::split_string(
     int str_length = property_string.length() - found_delimiter;
     second = property_string.substr(found_delimiter + 1, str_length);
   } else {
-    warning("Didn't find any delimiter.\n "
-            "Returning empty strings");
+    warning(
+        "Didn't find any delimiter.\n "
+        "Returning empty strings");
   }
 
   return {first, second};

--- a/src/dagmc/dagmcmetadata.hpp
+++ b/src/dagmc/dagmcmetadata.hpp
@@ -1,8 +1,8 @@
 #ifndef SRC_DAGMC_DAGMCMETADATA_HPP_
 #define SRC_DAGMC_DAGMCMETADATA_HPP_
 #include <iostream>
-#include <sstream>
 #include <set>
+#include <sstream>
 
 #include "DagMC.hpp"
 
@@ -117,14 +117,14 @@ class dagmcMetaData {
   int set_verbosity(int val) {
     int verbosity_max = 0;
     int verbosity_min = 1;
-    if (val < verbosity_min || val > verbosity_max) warning("Invalid verbosity value " + std::to_string(val) + " will be set to nearest valid value.");
+    if (val < verbosity_min || val > verbosity_max)
+      warning("Invalid verbosity value " + std::to_string(val) +
+              " will be set to nearest valid value.");
     val = std::min(std::max(verbosity_min, val), verbosity_max);
     return verbosity = val;
   }
 
-  int get_verbosity(int val) {
-    return verbosity;
-  }
+  int get_verbosity(int val) { return verbosity; }
 
   /** console output mechanism
    *  @param msg Message to be written to the console
@@ -132,9 +132,8 @@ class dagmcMetaData {
    *             is higher than the class instance's current verbosity setting.
    *             Use of -1 ensures the message will always be written.
    *  @param newline Whether or not to apend a newline to the message.
-  */
-  void message(const std::string& msg, int lvl = 1, bool newline = true) const
-  {
+   */
+  void message(const std::string& msg, int lvl = 1, bool newline = true) const {
     // do not write message if level is higher than
     // verbosity setting
     if (lvl > verbosity) return;
@@ -148,25 +147,23 @@ class dagmcMetaData {
   /** write a warning message to the console
    *  @param msg Message to be written to the console
    *  @param newline Whether or not to apend a newline to the message.
-  */
-  void warning(const std::string& msg, bool newline = true) const
-  {
+   */
+  void warning(const std::string& msg, bool newline = true) const {
     message("WARNING: " + msg, -1, newline);
   }
 
   /** write an error message to the console
    *  @param msg Message to be written to the console
    *  @param newline Whether or not to apend a newline to the message.
-  */
-  void err_msg(const std::string& msg, bool newline = true) const
-  {
+   */
+  void err_msg(const std::string& msg, bool newline = true) const {
     message("ERROR: " + msg, -1, newline);
   }
 
   // private member variables
  private:
   moab::DagMC* DAG;  // Pointer to DAGMC instance
-  int verbosity {1};      // Provide additional output while setting up and parsing
+  int verbosity{1};  // Provide additional output while setting up and parsing
                      // properties
   bool require_density;  // Require that all volumes have a specified density
                          // value

--- a/src/dagmc/dagmcmetadata.hpp
+++ b/src/dagmc/dagmcmetadata.hpp
@@ -1,6 +1,7 @@
 #ifndef SRC_DAGMC_DAGMCMETADATA_HPP_
 #define SRC_DAGMC_DAGMCMETADATA_HPP_
 #include <iostream>
+#include <sstream>
 #include <set>
 
 #include "DagMC.hpp"
@@ -109,10 +110,63 @@ class dagmcMetaData {
   // map of importance data
   std::map<moab::EntityHandle, std::map<std::string, double>> importance_map;
 
+  // Verbosity levels
+  // -1 : "override" the current verbosity setting and write message
+  //  0 : No output
+  //  1 : All output
+  int set_verbosity(int val) {
+    int verbosity_max = 0;
+    int verbosity_min = 1;
+    if (val < verbosity_min || val > verbosity_max) warning("Invalid verbosity value " + std::to_string(val) + " will be set to nearest valid value.");
+    val = std::min(std::max(verbosity_min, val), verbosity_max);
+    return verbosity = val;
+  }
+
+  int get_verbosity(int val) {
+    return verbosity;
+  }
+
+  /** console output mechanism
+   *  @param msg Message to be written to the console
+   *  @param lvl Message will not be written if the verbosity level
+   *             is higher than the class instance's current verbosity setting.
+   *             Use of -1 ensures the message will always be written.
+   *  @param newline Whether or not to apend a newline to the message.
+  */
+  void message(const std::string& msg, int lvl = 1, bool newline = true) const
+  {
+    // do not write message if level is higher than
+    // verbosity setting
+    if (lvl > verbosity) return;
+    // otherwise, display message
+    if (newline)
+      std::cout << msg << "\n";
+    else
+      std::cout << msg;
+  }
+
+  /** write a warning message to the console
+   *  @param msg Message to be written to the console
+   *  @param newline Whether or not to apend a newline to the message.
+  */
+  void warning(const std::string& msg, bool newline = true) const
+  {
+    message("WARNING: " + msg, -1, newline);
+  }
+
+  /** write an error message to the console
+   *  @param msg Message to be written to the console
+   *  @param newline Whether or not to apend a newline to the message.
+  */
+  void err_msg(const std::string& msg, bool newline = true) const
+  {
+    message("ERROR: " + msg, -1, newline);
+  }
+
   // private member variables
  private:
   moab::DagMC* DAG;  // Pointer to DAGMC instance
-  bool verbose;      // Provide additional output while setting up and parsing
+  int verbosity {1};      // Provide additional output while setting up and parsing
                      // properties
   bool require_density;  // Require that all volumes have a specified density
                          // value


### PR DESCRIPTION
This is a step toward improved console logging in some of our classes. As described in #856, DAGMC and other classes in MOAB always write some output, which can conflict with output in downstream applications and cause confusion.

`message`, `warning`, and `err_msg` methods have been added to the `dagmcMetaData` and `DagMC` classes. Warnings and errors will always be written to screen. The `message` method allows a verbosity level to be associated with the message. The message will either be written to screen or not depending on the verbosity level set on the class instance. I've specified two levels of verbosity for now, but I'm open to a more fine grain set of verbosity levels down the line.

There's some duplicated code here, which could be improved. I'll look into abstracting these capabilieis into an object that both of the affected classes can inherit from perhaps. 

Another thing I don't love about this is that a `std::stringstream` object needs to be created for messages where conversion of non-char/string types occurs via the streaming operator. There are other libraries like `fmt` that handle this more gracefully, but I'll leave that for an improvement in the future.

