### PR TITLE
Use multistage docker build action in docker_publish.yml

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -18,14 +18,21 @@ jobs:
           18.04,
           20.04,
           ]
-    name: Ubuntu ${{ matrix.ubuntu_versions }} basics deps
+        compiler : [
+          gcc,
+          clang,
+          ]
+        hdf5_versions : [
+          1.10.4,
+        ]
+        moab_versions : [
+          5.3.0,
+        ]
+    name: Ubuntu ${{ matrix.ubuntu_versions }} + ${{ matrix.compiler }} hdf5 ${{ matrix.hdf5_versions }} + Moab ${{ matrix.moab_versions }}
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-      
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
 
       - name: Log in to the Container registry
         uses: docker/login-action@v1
@@ -34,16 +41,32 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and Export Dockerfile_0_base
-        uses: docker/build-push-action@v2
+      - name: multistage docker build
+        uses: firehed/multistage-docker-build-action@v1
         with:
-          file: CI/Dockerfile
-          target: base
-          push: true
-          context: .
-          build-args: |
-            UBUNTU_VERSION=${{ matrix.ubuntu_versions }}
-          tags: ghcr.io/${{ github.repository_owner }}/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}:ci_testing
+          repository: ghcr.io/${{ github.repository_owner }}/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler}}-ext-hdf5_${{ matrix.hdf5_versions}}-moab_${{ matrix.moab_versions }}:ci_testing
+          stages: base, external_deps, hdf5
+          server-stage: moab
+          quiet: false
+          tag-latest-on-default: false
+          dockerfile: CI/Dockerfile
+          build-args: OWNER=${{ github.repository_owner }},
+            TAG=ci_testing,
+            UBUNTU_VERSION=${{ matrix.ubuntu_versions }},
+            COMPILER=${{ matrix.compiler }},
+            HDF5=${{ matrix.hdf5_versions }},
+            MOAB=${{ matrix.moab_versions }}
+
+      # - name: Build and Export Dockerfile_0_base # replace this with 1 multistage docker build
+      #   uses: docker/build-push-action@v2
+      #   with:
+      #     file: CI/Dockerfile
+      #     target: base
+      #     push: true
+      #     context: .
+      #     build-args: |
+      #       UBUNTU_VERSION=${{ matrix.ubuntu_versions }}
+      #     tags: ghcr.io/${{ github.repository_owner }}/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}:ci_testing
 
   build-housekeeping-img:
     needs: build-base-img
@@ -56,8 +79,6 @@ jobs:
         ubuntu_versions : [18.04,]
 
     steps:
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
 
       - name: Log in to the Container registry
         uses: docker/login-action@v1
@@ -82,121 +103,117 @@ jobs:
           tags: ghcr.io/${{ github.repository_owner }}/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-housekeeping:ci_testing
 
 
-  build-deps-img:
-    needs: build-base-img
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        ubuntu_versions : [
-          18.04,
-          20.04,
-          ]
-        compiler : [
-          gcc,
-          clang,
-          ]
-        hdf5_versions : [
-          1.10.4,
-        ]
+  # build-deps-img:
+  #   needs: build-base-img
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     matrix:
+  #       ubuntu_versions : [
+  #         18.04,
+  #         20.04,
+  #         ]
+  #       compiler : [
+  #         gcc,
+  #         clang,
+  #         ]
+  #       hdf5_versions : [
+  #         1.10.4,
+  #       ]
 
-    name: Ubuntu ${{ matrix.ubuntu_versions }} + ${{ matrix.compiler }} hdf5 ${{ matrix.hdf5_versions }}
-    steps:
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+  #   name: Ubuntu ${{ matrix.ubuntu_versions }} + ${{ matrix.compiler }} hdf5 ${{ matrix.hdf5_versions }}
+  #   steps:
 
-      - name: Log in to the Container registry
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+  #     - name: Log in to the Container registry
+  #       uses: docker/login-action@v1
+  #       with:
+  #         registry: ghcr.io
+  #         username: ${{ github.repository_owner }}
+  #         password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Checkout repository
-        uses: actions/checkout@v3
+  #     - name: Checkout repository
+  #       uses: actions/checkout@v3
 
-      - name: Build and push Dockerfile_1_external_deps
-        uses: docker/build-push-action@v2
-        with:
-          file: CI/Dockerfile
-          target: external_deps
-          context: .
-          push: false
-          build-args: |
-            OWNER=${{ github.repository_owner }}
-            TAG=ci_testing
-            UBUNTU_VERSION=${{ matrix.ubuntu_versions }}
-            COMPILER=${{ matrix.compiler }}
-          tags: ghcr.io/${{ github.repository_owner }}/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler}}-ext:ci_testing
+  #     - name: Build and push Dockerfile_1_external_deps
+  #       uses: docker/build-push-action@v2
+  #       with:
+  #         file: CI/Dockerfile
+  #         target: external_deps
+  #         context: .
+  #         push: false
+  #         build-args: |
+  #           OWNER=${{ github.repository_owner }}
+  #           TAG=ci_testing
+  #           UBUNTU_VERSION=${{ matrix.ubuntu_versions }}
+  #           COMPILER=${{ matrix.compiler }}
+  #         tags: ghcr.io/${{ github.repository_owner }}/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler}}-ext:ci_testing
 
-      - name: Build and export Dockerfile_2_hdf5
-        uses: docker/build-push-action@v2
-        with:
-          file: CI/Dockerfile
-          target: hdf5
-          context: .
-          push: true
-          build-args: |
-            OWNER=${{ github.repository_owner }}
-            TAG=ci_testing
-            UBUNTU_VERSION=${{ matrix.ubuntu_versions }}
-            COMPILER=${{ matrix.compiler }}
-            HDF5=${{ matrix.hdf5_versions }}
-          tags: ghcr.io/${{ github.repository_owner }}/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler}}-ext-hdf5_${{ matrix.hdf5_versions}}:ci_testing
+  #     - name: Build and export Dockerfile_2_hdf5
+  #       uses: docker/build-push-action@v2
+  #       with:
+  #         file: CI/Dockerfile
+  #         target: hdf5
+  #         context: .
+  #         push: true
+  #         build-args: |
+  #           OWNER=${{ github.repository_owner }}
+  #           TAG=ci_testing
+  #           UBUNTU_VERSION=${{ matrix.ubuntu_versions }}
+  #           COMPILER=${{ matrix.compiler }}
+  #           HDF5=${{ matrix.hdf5_versions }}
+  #         tags: ghcr.io/${{ github.repository_owner }}/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler}}-ext-hdf5_${{ matrix.hdf5_versions}}:ci_testing
 
-  build-moab-img:
-    needs: build-deps-img
-    runs-on: ubuntu-latest
-    env:
-      hdf5_versions: 1.10.4
-      hdf5_build_dir: hdf5_build_dir
-    strategy:
-      matrix:
-        ubuntu_versions : [
-          18.04,
-          20.04,
-          ]
-        compiler : [
-          gcc,
-          clang,
-          ]
-        hdf5_versions : [
-          1.10.4,
-        ]
-        moab_versions : [
-          5.3.0,
-        ]
+  # build-moab-img:
+  #   needs: build-deps-img
+  #   runs-on: ubuntu-latest
+  #   env:
+  #     hdf5_versions: 1.10.4
+  #     hdf5_build_dir: hdf5_build_dir
+  #   strategy:
+  #     matrix:
+  #       ubuntu_versions : [
+  #         18.04,
+  #         20.04,
+  #         ]
+  #       compiler : [
+  #         gcc,
+  #         clang,
+  #         ]
+  #       hdf5_versions : [
+  #         1.10.4,
+  #       ]
+  #       moab_versions : [
+  #         5.3.0,
+  #       ]
 
-    name: Ubuntu ${{ matrix.ubuntu_versions }} + ${{ matrix.compiler }} hdf5 ${{ matrix.hdf5_versions }} + Moab ${{ matrix.moab_versions }}
+  #   name: Ubuntu ${{ matrix.ubuntu_versions }} + ${{ matrix.compiler }} hdf5 ${{ matrix.hdf5_versions }} + Moab ${{ matrix.moab_versions }}
 
-    steps:
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+  #   steps:
 
-      - name: Log in to the Container registry
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+  #     - name: Log in to the Container registry
+  #       uses: docker/login-action@v1
+  #       with:
+  #         registry: ghcr.io
+  #         username: ${{ github.repository_owner }}
+  #         password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Checkout repository
-        uses: actions/checkout@v3
+  #     - name: Checkout repository
+  #       uses: actions/checkout@v3
 
-      - name: Build and push Dockerfile_3_moab
-        uses: docker/build-push-action@v2
-        with:
-          file: CI/Dockerfile
-          target: moab
-          context: .
-          push: true
-          build-args: |
-            OWNER=${{ github.repository_owner }}
-            TAG=ci_testing
-            UBUNTU_VERSION=${{ matrix.ubuntu_versions }}
-            COMPILER=${{ matrix.compiler }}
-            HDF5=${{ matrix.hdf5_versions }}
-            MOAB=${{ matrix.moab_versions }}
-          tags: ghcr.io/${{ github.repository_owner }}/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler}}-ext-hdf5_${{ matrix.hdf5_versions}}-moab_${{ matrix.moab_versions }}:ci_testing
+  #     - name: Build and push Dockerfile_3_moab
+  #       uses: docker/build-push-action@v2
+  #       with:
+  #         file: CI/Dockerfile
+  #         target: moab
+  #         context: .
+  #         push: true
+  #         build-args: |
+  #           OWNER=${{ github.repository_owner }}
+  #           TAG=ci_testing
+  #           UBUNTU_VERSION=${{ matrix.ubuntu_versions }}
+  #           COMPILER=${{ matrix.compiler }}
+  #           HDF5=${{ matrix.hdf5_versions }}
+  #           MOAB=${{ matrix.moab_versions }}
+  #         tags: ghcr.io/${{ github.repository_owner }}/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler}}-ext-hdf5_${{ matrix.hdf5_versions}}-moab_${{ matrix.moab_versions }}:ci_testing
 
   housekeeping:
     if: ${{ github.repository_owner != 'svalinn' || github.event_name == 'pull_request' }}
@@ -300,9 +317,6 @@ jobs:
 
     name: Housekeeping':' latest -> stable
     steps:
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-
       - name: Log in to the Container registry
         uses: docker/login-action@v1
         with:
@@ -350,9 +364,6 @@ jobs:
     name: Ubuntu${{ matrix.ubuntu_versions }} + ${{ matrix.compiler }} hdf5 ${{ matrix.hdf5_versions }} + Moab ${{ matrix.moab_versions }}':' latest -> stable
 
     steps:
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-
       - name: Log in to the Container registry
         uses: docker/login-action@v1
         with:

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -44,7 +44,7 @@ jobs:
       - name: multistage docker build
         uses: firehed/multistage-docker-build-action@v1
         with:
-          repository: ghcr.io/${{ github.repository_owner }}/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler}}-ext-hdf5_${{ matrix.hdf5_versions}}-moab_${{ matrix.moab_versions }}:ci_testing
+          repository: ghcr.io/${{ github.repository_owner }}/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler}}-ext-hdf5_${{ matrix.hdf5_versions}}-moab_${{ matrix.moab_versions }}
           stages: base, external_deps, hdf5
           server-stage: moab
           quiet: false

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -248,7 +248,7 @@ jobs:
           /bin/bash "CI/scripts/housekeeping.sh"
       
   test_img:
-    needs: [build-moab-img]
+    needs: [build-base-img]
     runs-on: ubuntu-latest
     env:
       hdf5_versions: 1.10.4

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -50,12 +50,7 @@ jobs:
           quiet: false
           tag-latest-on-default: false
           dockerfile: CI/Dockerfile
-          build-args: OWNER=${{ github.repository_owner }},
-            TAG=ci_testing,
-            UBUNTU_VERSION=${{ matrix.ubuntu_versions }},
-            COMPILER=${{ matrix.compiler }},
-            HDF5=${{ matrix.hdf5_versions }},
-            MOAB=${{ matrix.moab_versions }}
+          build-args: OWNER=${{ github.repository_owner }}, TAG=ci_testing, UBUNTU_VERSION=${{ matrix.ubuntu_versions }}, COMPILER=${{ matrix.compiler }}, HDF5=${{ matrix.hdf5_versions }}, MOAB=${{ matrix.moab_versions }}
 
       # - name: Build and Export Dockerfile_0_base # replace this with 1 multistage docker build
       #   uses: docker/build-push-action@v2

--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -9,6 +9,7 @@ Next version
 
 **Changed:**
 
+   * use multistage docker build action in docker_publish.yml (#875)
    * Improvements/corrections to graveyard capabilities (#855)
    * Using multi stage Dockerfile to reduce the number of Dockerfile (#813)
    * Adding safe folder to allow CI to compile DAGMC (#814)


### PR DESCRIPTION
## Description
I replaced most of the docker build actions with a [multistage build action](https://github.com/marketplace/actions/multi-stage-docker-build) that will build all the stages in one job. This is still a work in progress, and I haven't changed the housekeeping job or updated the image names for the jobs that run tests. 

## Motivation and Context
Using the multistage action was briefly mentioned [here](https://github.com/svalinn/DAGMC/pull/822). 
This PR is a proof of concept to see if the multistage build action can be used in the `docker_publish.yml` workflow and how it should be implemented. Let me know if I should branch off of the PR in the previous link since that one modifies the `Dockerfile` to include the install scripts. 

## Changes
This PR makes `docker_publish.yml` build the images with the multistage docker build action, which is simpler and uses caching of images to avoid building stages that have stayed the same since the last build. 

## Behavior
The current behavior is that there is a job for each stage of the `Dockerfile`, and each job is dependent on the previous job in the workflow. The new behavior is that there is one job that will build all the stages in the `Dockerfile` using the multistage docker build action. 