### PR TITLE
Simple logger

### DIFF
--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -26,4 +26,5 @@ jobs:
       - name: Housekeeping
         run: |
           cd $GITHUB_WORKSPACE
+          git config --global --add safe.directory /__w/DAGMC/DAGMC
           CI/scripts/housekeeping.sh

--- a/.github/workflows/linux_build_test.yml
+++ b/.github/workflows/linux_build_test.yml
@@ -65,6 +65,7 @@ jobs:
       - name: Building DAGMC
         run: |
           cd $GITHUB_WORKSPACE
+          git config --global --add safe.directory /__w/DAGMC/DAGMC
           CI/scripts/install.sh
 
       - name: Testing DAGMC

--- a/CI/scripts/housekeeping.sh
+++ b/CI/scripts/housekeeping.sh
@@ -23,6 +23,7 @@ if [ -z "${clang_diffs}" ]; then
 else
   echo "ERROR: Style guide checker failed. Please run clang-format."
   echo "clang_diffs: ${clang_diffs}"
+  git diff
   exit 1
 fi
 

--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -20,6 +20,7 @@ Next version
    * Removed unused Circle CI yml (#859)
    * Added configuration options to CMake configuration file (#867)
    * Change test-on-merge against MOAB master/develop to be optional (#870)
+   * Introduced logger to better manage console output (#876)
 
 **Fixed:**
    * Patch to compile with Geant4 10.6     

--- a/src/dagmc/DagMC.cpp
+++ b/src/dagmc/DagMC.cpp
@@ -50,7 +50,7 @@ const std::map<std::string, std::string> DagMC::no_synonyms;
 DagMC::DagMC(std::shared_ptr<moab::Interface> mb_impl, double overlap_tolerance,
              double p_numerical_precision, int verbosity) : logger(verbosity) {
 #ifdef DOUBLE_DOWN
-  logger.message("Using the DOUBLE-DOWN interface to Embree.", 1);
+  logger.message("Using the DOUBLE-DOWN interface to Embree.");
 #endif
 
   moab_instance_created = false;
@@ -119,7 +119,7 @@ ErrorCode DagMC::load_file(const char* cfile) {
   std::string filename(cfile);
   std::stringstream ss;
   ss << "Loading file " << cfile;
-  logger.message(ss.str(), 1);
+  logger.message(ss.str());
   // load options
   char options[120] = {0};
   std::string file_ext = "";  // file extension
@@ -194,7 +194,7 @@ ErrorCode DagMC::setup_obbs() {
 
   // If we havent got an OBB Tree, build one.
   if (!GTT->have_obb_tree()) {
-    logger.message("Building acceleration data structures...",1);
+    logger.message("Building acceleration data structures...");
 #ifdef DOUBLE_DOWN
     rval = ray_tracer->init();
 #else
@@ -762,13 +762,13 @@ ErrorCode DagMC::finish_loading() {
   }
 
   // initialize ray_tracer
-  logger.message("Initializing the GeomQueryTool...", 1);
+  logger.message("Initializing the GeomQueryTool...");
   rval = GTT->find_geomsets();
   MB_CHK_SET_ERR(rval, "Failed to find the geometry sets");
 
   std::stringstream ss;
   ss << "Using faceting tolerance: " << facetingTolerance;
-  logger.message(ss.str(), 1);
+  logger.message(ss.str());
 
   return MB_SUCCESS;
 }
@@ -881,7 +881,7 @@ ErrorCode DagMC::build_indices(Range& surfs, Range& vols) {
   ErrorCode rval = MB_SUCCESS;
 
   if (surfs.size() == 0 || vols.size() == 0) {
-    logger.message("Volumes or Surfaces not found", 1);
+    logger.message("Volumes or Surfaces not found");
     return MB_ENTITY_NOT_FOUND;
   }
   setOffset = std::min(*surfs.begin(), *vols.begin());

--- a/src/dagmc/DagMC.cpp
+++ b/src/dagmc/DagMC.cpp
@@ -1295,11 +1295,12 @@ Tag DagMC::get_tag(const char* name, int size, TagType store, DataType type,
   if (!create_if_missing) flags |= MB_TAG_EXCL;
   ErrorCode result =
       MBI->tag_get_handle(name, size, type, retval, flags, def_value);
-  if (create_if_missing && MB_SUCCESS != result)
+  if (create_if_missing && MB_SUCCESS != result) {
     std::stringstream ss;
     ss << "Couldn't find nor create tag named " << name;
     logger.error(ss.str());
-
+  }
+  
   return retval;
 }
 

--- a/src/dagmc/DagMC.cpp
+++ b/src/dagmc/DagMC.cpp
@@ -48,7 +48,8 @@ const std::map<std::string, std::string> DagMC::no_synonyms;
 
 // DagMC Constructor
 DagMC::DagMC(std::shared_ptr<moab::Interface> mb_impl, double overlap_tolerance,
-             double p_numerical_precision, int verbosity) : logger(verbosity) {
+             double p_numerical_precision, int verbosity)
+    : logger(verbosity) {
 #ifdef DOUBLE_DOWN
   logger.message("Using the DOUBLE-DOWN interface to Embree.");
 #endif
@@ -76,8 +77,8 @@ DagMC::DagMC(std::shared_ptr<moab::Interface> mb_impl, double overlap_tolerance,
 }
 
 DagMC::DagMC(Interface* mb_impl, double overlap_tolerance,
-             double p_numerical_precision, int verbosity) : 
-             logger(verbosity) {
+             double p_numerical_precision, int verbosity)
+    : logger(verbosity) {
   moab_instance_created = false;
   // set the internal moab pointer
   MBI = mb_impl;
@@ -1300,7 +1301,7 @@ Tag DagMC::get_tag(const char* name, int size, TagType store, DataType type,
     ss << "Couldn't find nor create tag named " << name;
     logger.error(ss.str());
   }
-  
+
   return retval;
 }
 

--- a/src/dagmc/DagMC.hpp
+++ b/src/dagmc/DagMC.hpp
@@ -77,10 +77,12 @@ class DagMC {
         double overlap_tolerance = 0., double numerical_precision = .001,
         int verbosity = 1);
   // Deprecated Constructor
-  [[deprecated(
-      "Replaced by DagMC(std::shared_ptr<Interface> mb_impl, ... "
-      ")")]] DagMC(Interface* mb_impl, double overlap_tolerance = 0.,
-                   double numerical_precision = .001, int verbosity = 1);
+  [
+      [deprecated("Replaced by DagMC(std::shared_ptr<Interface> mb_impl, ... "
+                  ")")]] DagMC(Interface* mb_impl, 
+                               double overlap_tolerance = 0.,
+                               double numerical_precision = .001, 
+                               int verbosity = 1);
   // Destructor
   ~DagMC();
 

--- a/src/dagmc/DagMC.hpp
+++ b/src/dagmc/DagMC.hpp
@@ -12,6 +12,7 @@
 
 #include "DagMCVersion.hpp"
 #include "MBTagConventions.hpp"
+#include "logger.hpp"
 #include "moab/CartVect.hpp"
 #include "moab/Core.hpp"
 #include "moab/FileOptions.hpp"
@@ -20,8 +21,6 @@
 #include "moab/GeomUtil.hpp"
 #include "moab/Interface.hpp"
 #include "moab/Range.hpp"
-
-#include "logger.hpp"
 
 class RefEntity;
 
@@ -75,15 +74,13 @@ class DagMC {
  public:
   // Constructor
   DagMC(std::shared_ptr<Interface> mb_impl = nullptr,
-        double overlap_tolerance = 0., double numerical_precision = .001, 
+        double overlap_tolerance = 0., double numerical_precision = .001,
         int verbosity = 1);
   // Deprecated Constructor
-  [
-      [deprecated("Replaced by DagMC(std::shared_ptr<Interface> mb_impl, ... "
-                  ")")]] DagMC(Interface* mb_impl,
-                               double overlap_tolerance = 0.,
-                               double numerical_precision = .001,
-                               int verbosity = 1);
+  [[deprecated(
+      "Replaced by DagMC(std::shared_ptr<Interface> mb_impl, ... "
+      ")")]] DagMC(Interface* mb_impl, double overlap_tolerance = 0.,
+                   double numerical_precision = .001, int verbosity = 1);
   // Destructor
   ~DagMC();
 

--- a/src/dagmc/DagMC.hpp
+++ b/src/dagmc/DagMC.hpp
@@ -79,9 +79,9 @@ class DagMC {
   // Deprecated Constructor
   [
       [deprecated("Replaced by DagMC(std::shared_ptr<Interface> mb_impl, ... "
-                  ")")]] DagMC(Interface* mb_impl, 
+                  ")")]] DagMC(Interface* mb_impl,
                                double overlap_tolerance = 0.,
-                               double numerical_precision = .001, 
+                               double numerical_precision = .001,
                                int verbosity = 1);
   // Destructor
   ~DagMC();

--- a/src/dagmc/DagMC.hpp
+++ b/src/dagmc/DagMC.hpp
@@ -21,6 +21,8 @@
 #include "moab/Interface.hpp"
 #include "moab/Range.hpp"
 
+#include "logger.hpp"
+
 class RefEntity;
 
 struct DagmcVolData {
@@ -73,13 +75,15 @@ class DagMC {
  public:
   // Constructor
   DagMC(std::shared_ptr<Interface> mb_impl = nullptr,
-        double overlap_tolerance = 0., double numerical_precision = .001);
+        double overlap_tolerance = 0., double numerical_precision = .001, 
+        int verbosity = 1);
   // Deprecated Constructor
   [
       [deprecated("Replaced by DagMC(std::shared_ptr<Interface> mb_impl, ... "
                   ")")]] DagMC(Interface* mb_impl,
                                double overlap_tolerance = 0.,
-                               double numerical_precision = .001);
+                               double numerical_precision = .001,
+                               int verbosity = 1);
   // Destructor
   ~DagMC();
 
@@ -514,6 +518,9 @@ class DagMC {
   std::vector<double> disList;
   std::vector<int> dirList;
   std::vector<EntityHandle> surList, facList;
+
+  /** logger **/
+  DagMC_Logger logger;
 
   // axis-aligned box used to track geometry bounds
   // (internal use only)

--- a/src/dagmc/dagmcmetadata.cpp
+++ b/src/dagmc/dagmcmetadata.cpp
@@ -631,7 +631,7 @@ std::pair<std::string, std::string> dagmcMetaData::split_string(
     int str_length = property_string.length() - found_delimiter;
     second = property_string.substr(found_delimiter + 1, str_length);
   } else {
-    logger.meesage("Didn't find any delimiter");
+    logger.message("Didn't find any delimiter");
     logger.message("Returning empty strings");
   }
 

--- a/src/dagmc/dagmcmetadata.cpp
+++ b/src/dagmc/dagmcmetadata.cpp
@@ -143,11 +143,10 @@ void dagmcMetaData::parse_material_data() {
         // failure, a volume can only have a single material associated with it
         std::stringstream ss;
         ss << "More than one material for volume with id " << cellid
-            << std::endl;
+           << std::endl;
         ss << "that does not the the _comp tag associated with it."
-            << std::endl;
-        ss << cellid
-            << " has the following material assignments:" << std::endl;
+           << std::endl;
+        ss << cellid << " has the following material assignments:" << std::endl;
         for (int j = 0; j < material_props.size(); j++) {
           ss << material_props[j] << std::endl;
         }
@@ -162,7 +161,7 @@ void dagmcMetaData::parse_material_data() {
       if (material_props[0] == "" && !(DAG->is_implicit_complement(eh))) {
         std::stringstream ss;
         ss << "No material property found for volume with ID " << cellid
-                  << std::endl;
+           << std::endl;
         ss << "Every volume must have exactly one mat: property";
         logger.error(ss.str());
         exit(EXIT_FAILURE);
@@ -172,10 +171,8 @@ void dagmcMetaData::parse_material_data() {
     // this is never ok for a volume to have more than one property for density
     if (density_props.size() > 1) {
       std::stringstream ss;
-      ss << "More than one density specified for " << cellid
-                << std::endl;
-      ss << cellid << " has the following density assignments"
-                << std::endl;
+      ss << "More than one density specified for " << cellid << std::endl;
+      ss << cellid << " has the following density assignments" << std::endl;
       for (int j = 0; j < density_props.size(); j++) {
         ss << density_props[j] << std::endl;
       }
@@ -202,10 +199,9 @@ void dagmcMetaData::parse_material_data() {
     if (require_density && try_to_make_int(material_props[0]) &&
         density_props[0].empty() && !(DAG->is_implicit_complement(eh))) {
       std::stringstream ss;
-      ss << "Using the simplified naming scheme without a density"
-                << std::endl;
+      ss << "Using the simplified naming scheme without a density" << std::endl;
       ss << "property is forbidden, please rename the group mat:"
-                << material_props[0];
+         << material_props[0];
       logger.error(ss.str());
       exit(EXIT_FAILURE);
     }
@@ -286,18 +282,18 @@ void dagmcMetaData::parse_importance_data() {
         } catch (const std::exception& e) {
           std::stringstream ss;
           ss << "Can't parse importance " << pair.second
-                    << " as a float: " << e.what();
+             << " as a float: " << e.what();
           logger.error(ss.str());
           exit(EXIT_FAILURE);
         }
         importance_map[eh][pair.first] = imp;
       } else {
         std::stringstream ss;
-        ss << "Volume with ID " << volid
-                  << " has more than one importance " << std::endl;
+        ss << "Volume with ID " << volid << " has more than one importance "
+           << std::endl;
         ss << "Assigned for particle type " << pair.first << std::endl;
         ss << "Only one importance value per volume per particle type "
-                     "is allowed";
+              "is allowed";
         logger.error(ss.str());
         exit(EXIT_FAILURE);
       }
@@ -371,10 +367,9 @@ void dagmcMetaData::parse_boundary_data() {
     boundary_assignment = boundary_assignments[eh];
     if (boundary_assignment.size() != 1) {
       std::stringstream ss;
-      ss<< "More than one boundary conditions specified for " << surfid
-                << std::endl;
-      ss << surfid << " has the following density assignments"
-                << std::endl;
+      ss << "More than one boundary conditions specified for " << surfid
+         << std::endl;
+      ss << surfid << " has the following density assignments" << std::endl;
       for (int j = 0; j < boundary_assignment.size(); j++) {
         ss << boundary_assignment[j] << std::endl;
       }

--- a/src/dagmc/dagmcmetadata.hpp
+++ b/src/dagmc/dagmcmetadata.hpp
@@ -4,6 +4,7 @@
 #include <set>
 
 #include "DagMC.hpp"
+#include "logger.hpp"
 
 class dagmcMetaData {
  public:
@@ -125,6 +126,8 @@ class dagmcMetaData {
   const std::string reflecting_str{"Reflecting"};
   const std::string white_str{"White"};
   const std::string periodic_str{"Periodic"};
+
+  DagMC_Logger logger;
 };
 
 #endif  // SRC_DAGMC_DAGMCMETADATA_HPP_

--- a/src/dagmc/logger.hpp
+++ b/src/dagmc/logger.hpp
@@ -1,0 +1,48 @@
+#ifndef _DAGMC_LOGGER
+#define _DAGMC_LOGGER
+
+#include <iostream>
+#include <string>
+
+class DagMC_Logger {
+
+public:
+    void DagMC_Logger(int _verbosity = 1) {
+        set_verbosity(_verbosity);
+    };
+
+    void set_verbosity(int val) {
+        int verbosity_min = 0;
+        int verbosity_max = 1;
+        if (val < verbosity_min || val > verbosity_max)
+            warning("Invalid verbosity value " + std::to_string(val) +
+                    " will be set to nearest valid value.");
+        val = std::min(std::max(verbosity_min, val), verbosity_max);
+        return verbosity = val;    
+    };
+
+    int get_verbosity() {return verbosity;};
+
+    void message(const std::string& msg, int lvl = 1, bool newline = true) const {
+        if (lvl > verbosity) return;
+        std::cout << msg;
+
+        if (newline)
+            std::cout << "\n";
+
+    };
+    void warning(const std::string& msg, int lvl = 1, bool newline = true) const{
+        message("WARNING: " + msg, -1, newline);
+    };
+
+    void error(const std::string& msg, bool newline = true) const{
+        std::cerr << "ERROR: " << msg;
+        if (newline) std::cerr << "\n";
+    };
+
+private:
+    int verbosity{1};
+
+};
+
+#endif

--- a/src/dagmc/logger.hpp
+++ b/src/dagmc/logger.hpp
@@ -19,9 +19,9 @@ public:
                     " will be set to nearest valid value.");
         val = std::min(std::max(verbosity_min, val), verbosity_max);
         verbosity = val;    
-    };
+    }
 
-    int get_verbosity() {return verbosity;};
+    int get_verbosity() const {return verbosity;};
 
     void message(const std::string& msg, int lvl = 1, bool newline = true) const {
         if (lvl > verbosity) return;
@@ -30,18 +30,19 @@ public:
         if (newline)
             std::cout << "\n";
 
-    };
+    }
+
     void warning(const std::string& msg, int lvl = 1, bool newline = true) const{
         message("WARNING: " + msg, -1, newline);
-    };
+    }
 
     void error(const std::string& msg, bool newline = true) const{
         std::cerr << "ERROR: " << msg;
         if (newline) std::cerr << "\n";
-    };
+    }
 
 private:
-    int verbosity{1};
+    int verbosity {1};
 
 };
 

--- a/src/dagmc/logger.hpp
+++ b/src/dagmc/logger.hpp
@@ -7,7 +7,7 @@
 class DagMC_Logger {
 
 public:
-    void DagMC_Logger(int _verbosity = 1) {
+    DagMC_Logger(int _verbosity = 1) {
         set_verbosity(_verbosity);
     };
 
@@ -18,7 +18,7 @@ public:
             warning("Invalid verbosity value " + std::to_string(val) +
                     " will be set to nearest valid value.");
         val = std::min(std::max(verbosity_min, val), verbosity_max);
-        return verbosity = val;    
+        verbosity = val;    
     };
 
     int get_verbosity() {return verbosity;};

--- a/src/dagmc/logger.hpp
+++ b/src/dagmc/logger.hpp
@@ -5,45 +5,39 @@
 #include <string>
 
 class DagMC_Logger {
+ public:
+  DagMC_Logger(int _verbosity = 1) { set_verbosity(_verbosity); };
 
-public:
-    DagMC_Logger(int _verbosity = 1) {
-        set_verbosity(_verbosity);
-    };
+  void set_verbosity(int val) {
+    int verbosity_min = 0;
+    int verbosity_max = 1;
+    if (val < verbosity_min || val > verbosity_max)
+      warning("Invalid verbosity value " + std::to_string(val) +
+              " will be set to nearest valid value.");
+    val = std::min(std::max(verbosity_min, val), verbosity_max);
+    verbosity = val;
+  }
 
-    void set_verbosity(int val) {
-        int verbosity_min = 0;
-        int verbosity_max = 1;
-        if (val < verbosity_min || val > verbosity_max)
-            warning("Invalid verbosity value " + std::to_string(val) +
-                    " will be set to nearest valid value.");
-        val = std::min(std::max(verbosity_min, val), verbosity_max);
-        verbosity = val;    
-    }
+  int get_verbosity() const { return verbosity; };
 
-    int get_verbosity() const {return verbosity;};
+  void message(const std::string& msg, int lvl = 1, bool newline = true) const {
+    if (lvl > verbosity) return;
+    std::cout << msg;
 
-    void message(const std::string& msg, int lvl = 1, bool newline = true) const {
-        if (lvl > verbosity) return;
-        std::cout << msg;
+    if (newline) std::cout << "\n";
+  }
 
-        if (newline)
-            std::cout << "\n";
+  void warning(const std::string& msg, int lvl = 1, bool newline = true) const {
+    message("WARNING: " + msg, -1, newline);
+  }
 
-    }
+  void error(const std::string& msg, bool newline = true) const {
+    std::cerr << "ERROR: " << msg;
+    if (newline) std::cerr << "\n";
+  }
 
-    void warning(const std::string& msg, int lvl = 1, bool newline = true) const{
-        message("WARNING: " + msg, -1, newline);
-    }
-
-    void error(const std::string& msg, bool newline = true) const{
-        std::cerr << "ERROR: " << msg;
-        if (newline) std::cerr << "\n";
-    }
-
-private:
-    int verbosity {1};
-
+ private:
+  int verbosity{1};
 };
 
 #endif


### PR DESCRIPTION
This is an attempt to streamline and add code re-use to @pshriwise's PR #872.

Per @pshriwise: This is a step toward improved console logging in some of our classes. As described in #856, DAGMC and other classes in MOAB always write some output, which can conflict with output in downstream applications and cause confusion.

A `DagMC_Logger` object is added to the `DagMC` class and the `dagmcmetadata` class.  The `DagMC_Logger` has methods `message`, `warning`, and `error`.  The first two write to `std::cout` and the third to `std::cerr`.  Warnings and errors will always be written. 

Also borrowed from @pshriwise: The message will either be written to screen or not depending on the verbosity level set on the class instance. I've specified two levels of verbosity for now, but I'm open to a more fine grain set of verbosity levels down the line.

