### PR TITLE
More stable package find instructions

### DIFF
--- a/cmake/FindDOUBLE_DOWN.cmake
+++ b/cmake/FindDOUBLE_DOWN.cmake
@@ -11,7 +11,7 @@ find_path(dd_CMAKE_CONFIG NAMES ddConfig.cmake
           HINTS ${dd_ROOT} $ENV{dd_ROOT}
           PATHS ENV LD_LIBRARY_PATH
           PATHS ${DOUBLE_DOWN_DIR}
-          PATH_SUFFIXES lib Lib cmake lib/cmake/
+          PATH_SUFFIXES lib Lib cmake lib/cmake/ lib/cmake/dd
           NO_DEFAULT_PATH)
 
 message(STATUS "Found dd in ${dd_CMAKE_CONFIG}")

--- a/cmake/FindMOAB.cmake
+++ b/cmake/FindMOAB.cmake
@@ -4,7 +4,7 @@ message("")
 # Only used to determine the location of the HDF5 with which MOAB was built
 set(MOAB_SEARCH_DIRS)
 file(GLOB MOAB_SEARCH_DIRS ${MOAB_SEARCH_DIRS} "${MOAB_DIR}/lib*/cmake/MOAB")
-string(REPLACE "\n" ";" MOAB_SEARCH_DIRS ${MOAB_SEARCH_DIRS})
+string(REPLACE "\n" ";" MOAB_SEARCH_DIRS "${MOAB_SEARCH_DIRS}")
 find_path(MOAB_CMAKE_CONFIG
   NAMES MOABConfig.cmake
   PATHS ${MOAB_SEARCH_DIRS}

--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -23,7 +23,8 @@ Next version
    * Introduced logger to better manage console output (#876)
 
 **Fixed:**
-   * Patch to compile with Geant4 10.6     
+   * Patch to compile with Geant4 10.6
+   * Patched cmake-search paths for double-down and MOAB (#878)
 
 
 v3.2.2


### PR DESCRIPTION
Please follow these guidelines when making a Pull Request.
This template was adapted from [here](https://github.com/stevemao/github-issue-templates/blob/master/questions-answers/PULL_REQUEST_TEMPLATE.md) and [here](https://github.com/stevemao/github-issue-templates/blob/master/conversational/PULL_REQUEST_TEMPLATE.md).

## Description
Stabililize the search routines for MOAB and double-down

## Motivation and Context
- double-down installs its .cmake-files explicitly to a subdirectory dd. This PR adds that subdir to the search path explicitly. In cases cmake does not find them otherwise
- The MOAB search directory variable should be quoted. In some cases it can cause FindMOAB to fail. If it is installed to non-standard directory.

## Changes
Bug-fix

## Behavior
Old behaviour: can cause installation to fail.
New behaviour: more stable installation, less dependent on local cmake parameters.