### PR TITLE
explicitly include the std integer declarations

### DIFF
--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -26,7 +26,7 @@ Next version
 **Fixed:**
    * Patch to compile with Geant4 10.6
    * Patched cmake-search paths for double-down and MOAB (#878)
-
+   * Patch to compile with gcc-13
 
 v3.2.2
 ====================

--- a/src/dagmc/dagmcmetadata.cpp
+++ b/src/dagmc/dagmcmetadata.cpp
@@ -1,6 +1,7 @@
 #include "dagmcmetadata.hpp"
 
 #include <algorithm>
+#include <cstdint>
 #include <iostream>
 #include <set>
 #include <sstream>


### PR DESCRIPTION
Please follow these guidelines when making a Pull Request.
This template was adapted from [here](https://github.com/stevemao/github-issue-templates/blob/master/questions-answers/PULL_REQUEST_TEMPLATE.md) and [here](https://github.com/stevemao/github-issue-templates/blob/master/conversational/PULL_REQUEST_TEMPLATE.md).

## Description
Explicitly include the definition of int32_t

## Motivation and Context
Fixes a compile blocking error  on some systems

## Changes
bugfix

## Behavior
On some systems depending on the pedanticness of the compiler, not including this header can cause the compilation to fail. Using gcc 13 on my system.

## Other Information
Experienced the issue with gcc-13