### PR TITLE
Remove windows gtest

### DIFF
--- a/.github/workflows/windows_build_test.yml
+++ b/.github/workflows/windows_build_test.yml
@@ -28,6 +28,7 @@ jobs:
         run: |
           conda install curl eigen
           conda install -c conda-forge hdf5=1.10.6
+          conda uninstall gtest
 
       - name: Environment Variables
         shell: bash -l {0}

--- a/.github/workflows/windows_build_test.yml
+++ b/.github/workflows/windows_build_test.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           conda install curl eigen
           conda install -c conda-forge hdf5=1.10.6
-          conda uninstall gtest
+          conda remove -y gtest
 
       - name: Environment Variables
         shell: bash -l {0}

--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -26,6 +26,7 @@ Next version
 **Fixed:**
    * Patch to compile with Geant4 10.6
    * Patched cmake-search paths for double-down and MOAB (#878)
+   * Removed gtest from windows build environment (#886)
 
 
 v3.2.2

--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -24,10 +24,10 @@ Next version
    * Introduced logger to better manage console output (#876)
 
 **Fixed:**
-   * Patch to compile with Geant4 10.6
+   * Patch to compile with Geant4 10.6 (#803)
    * Patched cmake-search paths for double-down and MOAB (#878)
    * Removed gtest from windows build environment (#886)
-   * Patch to compile with gcc-13
+   * Patch to compile with gcc-13 (#882)
 
 v3.2.2
 ====================


### PR DESCRIPTION
## Description
Remove the gtest package from the windows conda environment used for CI testing.

fixes #885 

## Motivation and Context
Windows builds began failing recently when trying to build gtest. There appear to be conflicting headers in the miniconda environment.

## Changes
Bug fix in build system