### PR TITLE
Remove yaml-cpp conda pkg from Windows CI env to avoid gtest conflict

### DIFF
--- a/.github/workflows/windows_build_test.yml
+++ b/.github/workflows/windows_build_test.yml
@@ -23,12 +23,12 @@ jobs:
           auto-activate-base: true
           activate-environment: ""
 
+      # yaml-cpp package has conflicting gtest headers and is not needed for this project
       - name: Conda dependencies
         shell:  bash -l {0}
         run: |
           conda install curl eigen
           conda install -c conda-forge hdf5=1.10.6
-#         yaml-cpp package has conflicting gtest headers and is not needed for this project
           conda remove -y yaml-cpp
 
       - name: Environment Variables

--- a/.github/workflows/windows_build_test.yml
+++ b/.github/workflows/windows_build_test.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           conda install curl eigen
           conda install -c conda-forge hdf5=1.10.6
-          conda package -w "C:\Miniconda\Library\include\gtest\gtest.h"
+          conda remove -y yaml-cpp
 
       # - name: Environment Variables
       #   shell: bash -l {0}

--- a/.github/workflows/windows_build_test.yml
+++ b/.github/workflows/windows_build_test.yml
@@ -26,89 +26,90 @@ jobs:
         run: |
           conda install curl eigen
           conda install -c conda-forge hdf5=1.10.6
+          conda package -w "C:\Miniconda\Library\include\gtest\gtest.h"
 
-      - name: Environment Variables
-        shell: bash -l {0}
-        run: |
-          echo "HOME_PATH=$GITHUB_WORKSPACE/.." >> $GITHUB_ENV
-          echo "CONDA_LOC=C:/Miniconda/Library" >> $GITHUB_ENV
-          cd ${HOME_PATH}
-          mkdir install_dir
+      # - name: Environment Variables
+      #   shell: bash -l {0}
+      #   run: |
+      #     echo "HOME_PATH=$GITHUB_WORKSPACE/.." >> $GITHUB_ENV
+      #     echo "CONDA_LOC=C:/Miniconda/Library" >> $GITHUB_ENV
+      #     cd ${HOME_PATH}
+      #     mkdir install_dir
 
-      - name: Build MOAB
-        shell: bash -l {0}
-        run: |
-          cd ${HOME_PATH}
-          git clone --depth 1 https://bitbucket.org/fathomteam/moab -b 5.3.0
-          mkdir moab_build
-          cd moab_build
-          cmake ../moab \
-                -DENABLE_BLASLAPACK=OFF \
-                -DENABLE_FORTRAN=OFF \
-                -DENABLE_IMESH=OFF \
-                -DENABLE_TESTING=OFF \
-                -DENABLE_HDF5=ON \
-                -DBUILD_SHARED_LIBS=ON \
-                -G"Visual Studio 16 2019"  \
-                -DCMAKE_INSTALL_PREFIX=../install_dir/ \
-                -DHDF5_ROOT="${CONDA_LOC}" \
-                -DHDF5_hdf5_LIBRARY_RELEASE="${CONDA_LOC}/lib/libhdf5_hl.lib;${CONDA_LOC}/lib/libhdf5.lib;${CONDA_LOC}/lib/zlib.lib;${CONDA_LOC}/lib/libhdf5_cpp.lib" \
-                -DCMAKE_EXE_LINKER_FLAGS="/std:c++latest -DH5_BUILT_AS_DYNAMIC_LIB" \
-                -DCMAKE_MODULE_LINKER_FLAGS="/std:c++latest" \
-                -DCMAKE_SHARED_LINKER_FLAGS="/std:c++latest" \
-                -DCMAKE_STATIC_LINKER_FLAGS="" \
-                -DCMAKE_BUILD_TYPE=Release \
-                -DCMAKE_C_COMPILER="C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Tools/MSVC/14.27.29110/bin/Hostx64/x64/cl.exe" \
-                -DCMAKE_CXX_COMPILER="C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Tools/MSVC/14.27.29110/bin/Hostx64/x64/cl.exe"
-          cmake --build . --config Release
-          cmake --install . --config Release
+      # - name: Build MOAB
+      #   shell: bash -l {0}
+      #   run: |
+      #     cd ${HOME_PATH}
+      #     git clone --depth 1 https://bitbucket.org/fathomteam/moab -b 5.3.0
+      #     mkdir moab_build
+      #     cd moab_build
+      #     cmake ../moab \
+      #           -DENABLE_BLASLAPACK=OFF \
+      #           -DENABLE_FORTRAN=OFF \
+      #           -DENABLE_IMESH=OFF \
+      #           -DENABLE_TESTING=OFF \
+      #           -DENABLE_HDF5=ON \
+      #           -DBUILD_SHARED_LIBS=ON \
+      #           -G"Visual Studio 16 2019"  \
+      #           -DCMAKE_INSTALL_PREFIX=../install_dir/ \
+      #           -DHDF5_ROOT="${CONDA_LOC}" \
+      #           -DHDF5_hdf5_LIBRARY_RELEASE="${CONDA_LOC}/lib/libhdf5_hl.lib;${CONDA_LOC}/lib/libhdf5.lib;${CONDA_LOC}/lib/zlib.lib;${CONDA_LOC}/lib/libhdf5_cpp.lib" \
+      #           -DCMAKE_EXE_LINKER_FLAGS="/std:c++latest -DH5_BUILT_AS_DYNAMIC_LIB" \
+      #           -DCMAKE_MODULE_LINKER_FLAGS="/std:c++latest" \
+      #           -DCMAKE_SHARED_LINKER_FLAGS="/std:c++latest" \
+      #           -DCMAKE_STATIC_LINKER_FLAGS="" \
+      #           -DCMAKE_BUILD_TYPE=Release \
+      #           -DCMAKE_C_COMPILER="C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Tools/MSVC/14.27.29110/bin/Hostx64/x64/cl.exe" \
+      #           -DCMAKE_CXX_COMPILER="C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Tools/MSVC/14.27.29110/bin/Hostx64/x64/cl.exe"
+      #     cmake --build . --config Release
+      #     cmake --install . --config Release
 
-      - uses: actions/checkout@v3
+      # - uses: actions/checkout@v3
 
-      - name: build DAGMC
-        shell: bash -l {0}
-        run: |
-          cd ${HOME_PATH}
-          mkdir build
-          cd build
-          cmake ../dagmc \
-                -G"Visual Studio 16 2019" \
-                -DBUILD_EXE=ON \
-                -DBUILD_STATIC_EXE=ON \
-                -DBUILD_SHARED_LIBS=OFF \
-                -DBUILD_STATIC_LIBS=ON \
-                -DBUILD_TALLY=OFF \
-                -DBUILD_BUILD_OBB=OFF \
-                -DBUILD_UWUW=ON \
-                -DBUILD_MAKE_WATERTIGHT=ON \
-                -DBUILD_OVERLAP_CHECK=OFF \
-                -DBUILD_TESTS=ON \
-                -DMOAB_DIR=../install_dir \
-                -DHDF5_ROOT="${CONDA_LOC}" \
-                -DHDF5_hdf5_LIBRARY_RELEASE="${CONDA_LOC}/lib/libhdf5_hl.lib;${CONDA_LOC}/lib/libhdf5.lib;${CONDA_LOC}/lib/zlib.lib;${CONDA_LOC}/lib/libhdf5_cpp.lib" \
-                -DCMAKE_INSTALL_PREFIX=../install_dir/ \
-                -DCMAKE_EXE_LINKER_FLAGS="" \
-                -DCMAKE_MODULE_LINKER_FLAGS="" \
-                -DCMAKE_SHARED_LINKER_FLAGS="" \
-                -DCMAKE_STATIC_LINKER_FLAGS="" \
-                -DCMAKE_BUILD_TYPE=Release
-          cmake --build . --config Release
-          cmake --install . --config Release
+      # - name: build DAGMC
+      #   shell: bash -l {0}
+      #   run: |
+      #     cd ${HOME_PATH}
+      #     mkdir build
+      #     cd build
+      #     cmake ../dagmc \
+      #           -G"Visual Studio 16 2019" \
+      #           -DBUILD_EXE=ON \
+      #           -DBUILD_STATIC_EXE=ON \
+      #           -DBUILD_SHARED_LIBS=OFF \
+      #           -DBUILD_STATIC_LIBS=ON \
+      #           -DBUILD_TALLY=OFF \
+      #           -DBUILD_BUILD_OBB=OFF \
+      #           -DBUILD_UWUW=ON \
+      #           -DBUILD_MAKE_WATERTIGHT=ON \
+      #           -DBUILD_OVERLAP_CHECK=OFF \
+      #           -DBUILD_TESTS=ON \
+      #           -DMOAB_DIR=../install_dir \
+      #           -DHDF5_ROOT="${CONDA_LOC}" \
+      #           -DHDF5_hdf5_LIBRARY_RELEASE="${CONDA_LOC}/lib/libhdf5_hl.lib;${CONDA_LOC}/lib/libhdf5.lib;${CONDA_LOC}/lib/zlib.lib;${CONDA_LOC}/lib/libhdf5_cpp.lib" \
+      #           -DCMAKE_INSTALL_PREFIX=../install_dir/ \
+      #           -DCMAKE_EXE_LINKER_FLAGS="" \
+      #           -DCMAKE_MODULE_LINKER_FLAGS="" \
+      #           -DCMAKE_SHARED_LINKER_FLAGS="" \
+      #           -DCMAKE_STATIC_LINKER_FLAGS="" \
+      #           -DCMAKE_BUILD_TYPE=Release
+      #     cmake --build . --config Release
+      #     cmake --install . --config Release
 
-      - name: Installation Environment Variables
-        shell: bash -l {0}
-        run: |
-          echo "PATH=$PATH:/d/a/DAGMC/install_dir/bin:/d/a/DAGMC/install_dir/tests" >> $GITHUB_ENV
+      # - name: Installation Environment Variables
+      #   shell: bash -l {0}
+      #   run: |
+      #     echo "PATH=$PATH:/d/a/DAGMC/install_dir/bin:/d/a/DAGMC/install_dir/tests" >> $GITHUB_ENV
 
-      - name: test DAGMC
-        shell: bash -l {0}
-        run: |
-          cd $HOME_PATH/install_dir/tests
-          dagmc_pointinvol_test.exe
-          dagmc_rayfire_test.exe
-          dagmc_simple_test.exe
-          dagmc_unit_tests.exe
-          make_watertight_cone_tests.exe
-          make_watertight_cylinder_tests.exe
-          make_watertight_no_curve_sphere_tests.exe
-          make_watertight_sphere_n_box_test.exe
+      # - name: test DAGMC
+      #   shell: bash -l {0}
+      #   run: |
+      #     cd $HOME_PATH/install_dir/tests
+      #     dagmc_pointinvol_test.exe
+      #     dagmc_rayfire_test.exe
+      #     dagmc_simple_test.exe
+      #     dagmc_unit_tests.exe
+      #     make_watertight_cone_tests.exe
+      #     make_watertight_cylinder_tests.exe
+      #     make_watertight_no_curve_sphere_tests.exe
+      #     make_watertight_sphere_n_box_test.exe

--- a/.github/workflows/windows_build_test.yml
+++ b/.github/workflows/windows_build_test.yml
@@ -7,8 +7,6 @@ on:
     branches:
       - develop
   push:
-    branches:
-      - develop
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/windows_build_test.yml
+++ b/.github/workflows/windows_build_test.yml
@@ -26,6 +26,7 @@ jobs:
         run: |
           conda install curl eigen
           conda install -c conda-forge hdf5=1.10.6
+#         yaml-cpp package has conflicting gtest headers and is not needed for this project
           conda remove -y yaml-cpp
 
       - name: Environment Variables

--- a/.github/workflows/windows_build_test.yml
+++ b/.github/workflows/windows_build_test.yml
@@ -7,6 +7,8 @@ on:
     branches:
       - develop
   push:
+    branches:
+      - develop
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/windows_build_test.yml
+++ b/.github/workflows/windows_build_test.yml
@@ -28,88 +28,88 @@ jobs:
           conda install -c conda-forge hdf5=1.10.6
           conda remove -y yaml-cpp
 
-      # - name: Environment Variables
-      #   shell: bash -l {0}
-      #   run: |
-      #     echo "HOME_PATH=$GITHUB_WORKSPACE/.." >> $GITHUB_ENV
-      #     echo "CONDA_LOC=C:/Miniconda/Library" >> $GITHUB_ENV
-      #     cd ${HOME_PATH}
-      #     mkdir install_dir
+      - name: Environment Variables
+        shell: bash -l {0}
+        run: |
+          echo "HOME_PATH=$GITHUB_WORKSPACE/.." >> $GITHUB_ENV
+          echo "CONDA_LOC=C:/Miniconda/Library" >> $GITHUB_ENV
+          cd ${HOME_PATH}
+          mkdir install_dir
 
-      # - name: Build MOAB
-      #   shell: bash -l {0}
-      #   run: |
-      #     cd ${HOME_PATH}
-      #     git clone --depth 1 https://bitbucket.org/fathomteam/moab -b 5.3.0
-      #     mkdir moab_build
-      #     cd moab_build
-      #     cmake ../moab \
-      #           -DENABLE_BLASLAPACK=OFF \
-      #           -DENABLE_FORTRAN=OFF \
-      #           -DENABLE_IMESH=OFF \
-      #           -DENABLE_TESTING=OFF \
-      #           -DENABLE_HDF5=ON \
-      #           -DBUILD_SHARED_LIBS=ON \
-      #           -G"Visual Studio 16 2019"  \
-      #           -DCMAKE_INSTALL_PREFIX=../install_dir/ \
-      #           -DHDF5_ROOT="${CONDA_LOC}" \
-      #           -DHDF5_hdf5_LIBRARY_RELEASE="${CONDA_LOC}/lib/libhdf5_hl.lib;${CONDA_LOC}/lib/libhdf5.lib;${CONDA_LOC}/lib/zlib.lib;${CONDA_LOC}/lib/libhdf5_cpp.lib" \
-      #           -DCMAKE_EXE_LINKER_FLAGS="/std:c++latest -DH5_BUILT_AS_DYNAMIC_LIB" \
-      #           -DCMAKE_MODULE_LINKER_FLAGS="/std:c++latest" \
-      #           -DCMAKE_SHARED_LINKER_FLAGS="/std:c++latest" \
-      #           -DCMAKE_STATIC_LINKER_FLAGS="" \
-      #           -DCMAKE_BUILD_TYPE=Release \
-      #           -DCMAKE_C_COMPILER="C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Tools/MSVC/14.27.29110/bin/Hostx64/x64/cl.exe" \
-      #           -DCMAKE_CXX_COMPILER="C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Tools/MSVC/14.27.29110/bin/Hostx64/x64/cl.exe"
-      #     cmake --build . --config Release
-      #     cmake --install . --config Release
+      - name: Build MOAB
+        shell: bash -l {0}
+        run: |
+          cd ${HOME_PATH}
+          git clone --depth 1 https://bitbucket.org/fathomteam/moab -b 5.3.0
+          mkdir moab_build
+          cd moab_build
+          cmake ../moab \
+                -DENABLE_BLASLAPACK=OFF \
+                -DENABLE_FORTRAN=OFF \
+                -DENABLE_IMESH=OFF \
+                -DENABLE_TESTING=OFF \
+                -DENABLE_HDF5=ON \
+                -DBUILD_SHARED_LIBS=ON \
+                -G"Visual Studio 16 2019"  \
+                -DCMAKE_INSTALL_PREFIX=../install_dir/ \
+                -DHDF5_ROOT="${CONDA_LOC}" \
+                -DHDF5_hdf5_LIBRARY_RELEASE="${CONDA_LOC}/lib/libhdf5_hl.lib;${CONDA_LOC}/lib/libhdf5.lib;${CONDA_LOC}/lib/zlib.lib;${CONDA_LOC}/lib/libhdf5_cpp.lib" \
+                -DCMAKE_EXE_LINKER_FLAGS="/std:c++latest -DH5_BUILT_AS_DYNAMIC_LIB" \
+                -DCMAKE_MODULE_LINKER_FLAGS="/std:c++latest" \
+                -DCMAKE_SHARED_LINKER_FLAGS="/std:c++latest" \
+                -DCMAKE_STATIC_LINKER_FLAGS="" \
+                -DCMAKE_BUILD_TYPE=Release \
+                -DCMAKE_C_COMPILER="C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Tools/MSVC/14.27.29110/bin/Hostx64/x64/cl.exe" \
+                -DCMAKE_CXX_COMPILER="C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Tools/MSVC/14.27.29110/bin/Hostx64/x64/cl.exe"
+          cmake --build . --config Release
+          cmake --install . --config Release
 
-      # - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-      # - name: build DAGMC
-      #   shell: bash -l {0}
-      #   run: |
-      #     cd ${HOME_PATH}
-      #     mkdir build
-      #     cd build
-      #     cmake ../dagmc \
-      #           -G"Visual Studio 16 2019" \
-      #           -DBUILD_EXE=ON \
-      #           -DBUILD_STATIC_EXE=ON \
-      #           -DBUILD_SHARED_LIBS=OFF \
-      #           -DBUILD_STATIC_LIBS=ON \
-      #           -DBUILD_TALLY=OFF \
-      #           -DBUILD_BUILD_OBB=OFF \
-      #           -DBUILD_UWUW=ON \
-      #           -DBUILD_MAKE_WATERTIGHT=ON \
-      #           -DBUILD_OVERLAP_CHECK=OFF \
-      #           -DBUILD_TESTS=ON \
-      #           -DMOAB_DIR=../install_dir \
-      #           -DHDF5_ROOT="${CONDA_LOC}" \
-      #           -DHDF5_hdf5_LIBRARY_RELEASE="${CONDA_LOC}/lib/libhdf5_hl.lib;${CONDA_LOC}/lib/libhdf5.lib;${CONDA_LOC}/lib/zlib.lib;${CONDA_LOC}/lib/libhdf5_cpp.lib" \
-      #           -DCMAKE_INSTALL_PREFIX=../install_dir/ \
-      #           -DCMAKE_EXE_LINKER_FLAGS="" \
-      #           -DCMAKE_MODULE_LINKER_FLAGS="" \
-      #           -DCMAKE_SHARED_LINKER_FLAGS="" \
-      #           -DCMAKE_STATIC_LINKER_FLAGS="" \
-      #           -DCMAKE_BUILD_TYPE=Release
-      #     cmake --build . --config Release
-      #     cmake --install . --config Release
+      - name: build DAGMC
+        shell: bash -l {0}
+        run: |
+          cd ${HOME_PATH}
+          mkdir build
+          cd build
+          cmake ../dagmc \
+                -G"Visual Studio 16 2019" \
+                -DBUILD_EXE=ON \
+                -DBUILD_STATIC_EXE=ON \
+                -DBUILD_SHARED_LIBS=OFF \
+                -DBUILD_STATIC_LIBS=ON \
+                -DBUILD_TALLY=OFF \
+                -DBUILD_BUILD_OBB=OFF \
+                -DBUILD_UWUW=ON \
+                -DBUILD_MAKE_WATERTIGHT=ON \
+                -DBUILD_OVERLAP_CHECK=OFF \
+                -DBUILD_TESTS=ON \
+                -DMOAB_DIR=../install_dir \
+                -DHDF5_ROOT="${CONDA_LOC}" \
+                -DHDF5_hdf5_LIBRARY_RELEASE="${CONDA_LOC}/lib/libhdf5_hl.lib;${CONDA_LOC}/lib/libhdf5.lib;${CONDA_LOC}/lib/zlib.lib;${CONDA_LOC}/lib/libhdf5_cpp.lib" \
+                -DCMAKE_INSTALL_PREFIX=../install_dir/ \
+                -DCMAKE_EXE_LINKER_FLAGS="" \
+                -DCMAKE_MODULE_LINKER_FLAGS="" \
+                -DCMAKE_SHARED_LINKER_FLAGS="" \
+                -DCMAKE_STATIC_LINKER_FLAGS="" \
+                -DCMAKE_BUILD_TYPE=Release
+          cmake --build . --config Release
+          cmake --install . --config Release
 
-      # - name: Installation Environment Variables
-      #   shell: bash -l {0}
-      #   run: |
-      #     echo "PATH=$PATH:/d/a/DAGMC/install_dir/bin:/d/a/DAGMC/install_dir/tests" >> $GITHUB_ENV
+      - name: Installation Environment Variables
+        shell: bash -l {0}
+        run: |
+          echo "PATH=$PATH:/d/a/DAGMC/install_dir/bin:/d/a/DAGMC/install_dir/tests" >> $GITHUB_ENV
 
-      # - name: test DAGMC
-      #   shell: bash -l {0}
-      #   run: |
-      #     cd $HOME_PATH/install_dir/tests
-      #     dagmc_pointinvol_test.exe
-      #     dagmc_rayfire_test.exe
-      #     dagmc_simple_test.exe
-      #     dagmc_unit_tests.exe
-      #     make_watertight_cone_tests.exe
-      #     make_watertight_cylinder_tests.exe
-      #     make_watertight_no_curve_sphere_tests.exe
-      #     make_watertight_sphere_n_box_test.exe
+      - name: test DAGMC
+        shell: bash -l {0}
+        run: |
+          cd $HOME_PATH/install_dir/tests
+          dagmc_pointinvol_test.exe
+          dagmc_rayfire_test.exe
+          dagmc_simple_test.exe
+          dagmc_unit_tests.exe
+          make_watertight_cone_tests.exe
+          make_watertight_cylinder_tests.exe
+          make_watertight_no_curve_sphere_tests.exe
+          make_watertight_sphere_n_box_test.exe

--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -24,9 +24,9 @@ Next version
    * Introduced logger to better manage console output (#876)
 
 **Fixed:**
-   * Patch to compile with Geant4 10.6
+   * Patch to compile with Geant4 10.6 (#803)
    * Patched cmake-search paths for double-down and MOAB (#878)
-   * Patch to compile with gcc-13
+   * Patch to compile with gcc-13 (#882)
 
 v3.2.2
 ====================

--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -27,7 +27,7 @@ Next version
    * Patch to compile with Geant4 10.6 (#803)
    * Patched cmake-search paths for double-down and MOAB (#878)
    * Patch to compile with gcc-13 (#882)
-   * Tweak conda environment for Windows build to avoid conflicting gtest headers ()
+   * Tweak conda environment for Windows build to avoid conflicting gtest headers (#888)
 
 v3.2.2
 ====================

--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -27,6 +27,7 @@ Next version
    * Patch to compile with Geant4 10.6 (#803)
    * Patched cmake-search paths for double-down and MOAB (#878)
    * Patch to compile with gcc-13 (#882)
+   * Tweak conda environment for Windows build to avoid conflicting gtest headers ()
 
 v3.2.2
 ====================


### PR DESCRIPTION
## Description
Removes conda pkg `yaml-cpp` from windows CI build environment.

Fixes #885 

## Motivation and Context
The `yaml-cpp` conda package installs a version of `gtest`, currently a version that is not compatible with the one we use.  While it is questionable whether this package *should* install `gtest`, we don't need this package for our build so we can simply remove it.

