### PR TITLE
add limitation to cython version for MOAB compatibility & more selectivity about when some tests are run

### DIFF
--- a/.github/workflows/linux_build_test.yml
+++ b/.github/workflows/linux_build_test.yml
@@ -8,6 +8,8 @@ on:
       - develop
     paths-ignore:
       - '.github/workflows/docker_publish.yml'
+      - '.github/workflows/mac_build_test.yml'
+      - '.github/workflows/windows_build_test.yml'
       - '.github/workflows/housekeeping.yml'
       - 'CI/**'
   push:
@@ -15,6 +17,8 @@ on:
       - develop
     paths-ignore:
       - '.github/workflows/docker_publish.yml'
+      - '.github/workflows/mac_build_test.yml'
+      - '.github/workflows/windows_build_test.yml'
       - '.github/workflows/housekeeping.yml'
       - 'CI/**'
 

--- a/.github/workflows/mac_build_test.yml
+++ b/.github/workflows/mac_build_test.yml
@@ -6,9 +6,17 @@ on:
   pull_request:
     branches:
       - develop
+    paths-ignore:
+      - '.github/workflows/docker_publish.yml'
+      - '.github/workflows/housekeeping.yml'
+      - 'CI/**'
   push:
     branches:
       - develop
+    paths-ignore:
+      - '.github/workflows/docker_publish.yml'
+      - '.github/workflows/housekeeping.yml'
+      - 'CI/**'
 
   release:
     types: # This configuration does not affect the page_build event above

--- a/.github/workflows/mac_build_test.yml
+++ b/.github/workflows/mac_build_test.yml
@@ -8,6 +8,8 @@ on:
       - develop
     paths-ignore:
       - '.github/workflows/docker_publish.yml'
+      - '.github/workflows/linux_build_test.yml'
+      - '.github/workflows/windows_build_test.yml'
       - '.github/workflows/housekeeping.yml'
       - 'CI/**'
   push:
@@ -15,6 +17,8 @@ on:
       - develop
     paths-ignore:
       - '.github/workflows/docker_publish.yml'
+      - '.github/workflows/linux_build_test.yml'
+      - '.github/workflows/windows_build_test.yml'
       - '.github/workflows/housekeeping.yml'
       - 'CI/**'
 

--- a/.github/workflows/windows_build_test.yml
+++ b/.github/workflows/windows_build_test.yml
@@ -6,9 +6,17 @@ on:
   pull_request:
     branches:
       - develop
+    paths-ignore:
+      - '.github/workflows/docker_publish.yml'
+      - '.github/workflows/housekeeping.yml'
+      - 'CI/**'
   push:
     branches:
       - develop
+    paths-ignore:
+      - '.github/workflows/docker_publish.yml'
+      - '.github/workflows/housekeeping.yml'
+      - 'CI/**'
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/windows_build_test.yml
+++ b/.github/workflows/windows_build_test.yml
@@ -8,6 +8,8 @@ on:
       - develop
     paths-ignore:
       - '.github/workflows/docker_publish.yml'
+      - '.github/workflows/mac_build_test.yml'
+      - '.github/workflows/linux_build_test.yml'
       - '.github/workflows/housekeeping.yml'
       - 'CI/**'
   push:
@@ -15,6 +17,8 @@ on:
       - develop
     paths-ignore:
       - '.github/workflows/docker_publish.yml'
+      - '.github/workflows/mac_build_test.yml'
+      - '.github/workflows/linux_build_test.yml'
       - '.github/workflows/housekeeping.yml'
       - 'CI/**'
 

--- a/CI/Dockerfile
+++ b/CI/Dockerfile
@@ -52,7 +52,7 @@ RUN apt-get -y update; \
     apt-get install -y git; \
     update-alternatives --install /usr/bin/python python /usr/bin/python3 10; \
     update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 10; \
-    pip install cython;
+    pip install "cython<3";
 
 ARG build_dir
 ARG install_dir

--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -28,7 +28,7 @@ Next version
    * Patched cmake-search paths for double-down and MOAB (#878)
    * Patch to compile with gcc-13 (#882)
    * Tweak conda environment for Windows build to avoid conflicting gtest headers (#888)
-   * Restrict cython version for MOAB (#)
+   * Restrict cython version for MOAB (#893)
 
 v3.2.2
 ====================

--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -28,6 +28,7 @@ Next version
    * Patched cmake-search paths for double-down and MOAB (#878)
    * Patch to compile with gcc-13 (#882)
    * Tweak conda environment for Windows build to avoid conflicting gtest headers (#888)
+   * Restrict cython version for MOAB (#)
 
 v3.2.2
 ====================


### PR DESCRIPTION
## Description
Force cython version to be less than v3.0.0. At the same, be slightly more selective with triggers for some tests.

## Motivation and Context
The versions of MOAB compatible with DAGMC are not compatible with cython 3+.  pip installing cython recently changed to be v3, so we need to restrict the version.

Also, we are currently running tests on all platforms even when only changing the workflow on another platform.

## Changes
bug fix for building dependencies

Limit when tests are run based on file paths.