### PR TITLE
Cleanup docker deploy

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -148,14 +148,14 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push Image as latest img
-        if: ${{ github.repository_owner == 'svalinn' }}
+        if: ${{ github.repository_owner == 'svalinn' && github.ref == 'refs/heads/develop' }}
         uses: akhilerm/tag-push-action@v2.1.0
         with:
           src: ghcr.io/${{ github.repository_owner }}/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler }}-ext-hdf5_${{ matrix.hdf5_versions }}-moab_${{ matrix.moab_versions }}/dagmc:latest
           dst: ghcr.io/${{ github.repository_owner }}/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler}}-ext-hdf5_${{ matrix.hdf5_versions}}-moab_${{ matrix.moab_versions }}:latest
 
       - name: Push Image as latest img
-        if: ${{ github.repository_owner == 'svalinn' }}
+        if: ${{ github.repository_owner == 'svalinn' && github.ref == 'refs/heads/develop' }}
         uses: akhilerm/tag-push-action@v2.1.0
         with:
           src: ghcr.io/${{ github.repository_owner }}/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler }}-ext-hdf5_${{ matrix.hdf5_versions }}-moab_${{ matrix.moab_versions }}:latest

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -36,7 +36,7 @@ jobs:
           echo "tag-latest-on-default=false" >> "$GITHUB_ENV"
 
       - name: condition on trigger parameters
-        if: ${{ github.repository_owner == "svalinn" && github.ref == "refs/heads/develop" }}
+        if: ${{ github.repository_owner == 'svalinn' && github.ref == 'refs/heads/develop' }}
         run: |
           echo "tag-latest-on-default=true" >> "$GITHUB_ENV"
 
@@ -90,7 +90,7 @@ jobs:
           echo "tag-latest-on-default=false" >> "$GITHUB_ENV"
 
       - name: condition on trigger parameters
-        if: ${{ github.repository_owner == "svalinn" && github.ref == "refs/heads/develop" }}
+        if: ${{ github.repository_owner == 'svalinn' && github.ref == 'refs/heads/develop' }}
         run: |
           echo "tag-latest-on-default=true" >> "$GITHUB_ENV"
 

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -104,7 +104,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Test DAGMC in Docker image
+      - name: Build & test DAGMC in Docker image
         uses: firehed/multistage-docker-build-action@v1
         with:
           repository: ghcr.io/${{ github.repository_owner }}/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler }}-ext-hdf5_${{ matrix.hdf5_versions }}-moab_${{ matrix.moab_versions }}

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -30,7 +30,16 @@ jobs:
         ]
 
     name: Installing Dependencies
-    steps:        
+    steps:
+      - name: default environment
+        run: |
+          echo "tag-latest-on-default=false" >> "$GITHUB_ENV"
+
+      - name: condition on trigger parameters
+        if: ${{ github.repository_owner == "svalinn" && github.ref == "refs/heads/develop" }}
+        run: |
+          echo "tag-latest-on-default=true" >> "$GITHUB_ENV"
+
       - name: Log in to the Container registry
         uses: docker/login-action@v2
         with:
@@ -49,7 +58,7 @@ jobs:
           server-stage: moab
           quiet: false
           parallel: true
-          tag-latest-on-default: false
+          tag-latest-on-default: ${{ env.tag-latest-on-default }}
           dockerfile: CI/Dockerfile
           build-args: COMPILER=${{ matrix.compiler }}, UBUNTU_VERSION=${{ matrix.ubuntu_versions }}, HDF5=${{ matrix.hdf5_versions }}, MOAB=${{ matrix.moab_versions }}
 
@@ -76,6 +85,15 @@ jobs:
 
     name: Installing DAGMC
     steps:        
+      - name: default environment
+        run: |
+          echo "tag-latest-on-default=false" >> "$GITHUB_ENV"
+
+      - name: condition on trigger parameters
+        if: ${{ github.repository_owner == "svalinn" && github.ref == "refs/heads/develop" }}
+        run: |
+          echo "tag-latest-on-default=true" >> "$GITHUB_ENV"
+
       - name: Log in to the Container registry
         uses: docker/login-action@v2
         with:
@@ -94,7 +112,7 @@ jobs:
           server-stage: dagmc_test
           quiet: false
           parallel: true
-          tag-latest-on-default: false
+          tag-latest-on-default: ${{ env.tag-latest-on-default }}
           dockerfile: CI/Dockerfile
           build-args: COMPILER=${{ matrix.compiler }}, UBUNTU_VERSION=${{ matrix.ubuntu_versions }}, HDF5=${{ matrix.hdf5_versions }}, MOAB=${{ matrix.moab_versions }}
 
@@ -129,16 +147,16 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Push Image as stable img
+      - name: Push Image as latest img
         if: ${{ github.repository_owner == 'svalinn' }}
         uses: akhilerm/tag-push-action@v2.1.0
         with:
-          src: ghcr.io/${{ github.repository_owner }}/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler }}-ext-hdf5_${{ matrix.hdf5_versions }}-moab_${{ matrix.moab_versions }}/dagmc:refs_heads_${{ github.ref_name }}-bk0
-          dst: ghcr.io/${{ github.repository_owner }}/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler}}-ext-hdf5_${{ matrix.hdf5_versions }}-moab_${{ matrix.moab_versions }}:stable
+          src: ghcr.io/${{ github.repository_owner }}/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler }}-ext-hdf5_${{ matrix.hdf5_versions }}-moab_${{ matrix.moab_versions }}/dagmc:latest
+          dst: ghcr.io/${{ github.repository_owner }}/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler}}-ext-hdf5_${{ matrix.hdf5_versions}}-moab_${{ matrix.moab_versions }}:latest
 
       - name: Push Image as latest img
         if: ${{ github.repository_owner == 'svalinn' }}
         uses: akhilerm/tag-push-action@v2.1.0
         with:
-          src: ghcr.io/${{ github.repository_owner }}/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler }}-ext-hdf5_${{ matrix.hdf5_versions }}-moab_${{ matrix.moab_versions }}/dagmc:refs_heads_${{ github.ref_name }}-bk0
-          dst: ghcr.io/${{ github.repository_owner }}/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler}}-ext-hdf5_${{ matrix.hdf5_versions}}-moab_${{ matrix.moab_versions }}:latest
+          src: ghcr.io/${{ github.repository_owner }}/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler }}-ext-hdf5_${{ matrix.hdf5_versions }}-moab_${{ matrix.moab_versions }}:latest
+          dst: ghcr.io/${{ github.repository_owner }}/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler}}-ext-hdf5_${{ matrix.hdf5_versions}}-moab_${{ matrix.moab_versions }}:stable

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -11,8 +11,6 @@ on:
 jobs:
   build-dependency-img:
     runs-on: ubuntu-latest
-    env:
-      hdf5_build_dir: hdf5_build_dir
 
     strategy:
       matrix:
@@ -58,8 +56,6 @@ jobs:
   build-dagmc_test-img:
     needs: [build-dependency-img]
     runs-on: ubuntu-latest
-    env:
-      hdf5_build_dir: hdf5_build_dir
 
     strategy:
       matrix:
@@ -105,8 +101,6 @@ jobs:
   push_stable_ci_img:
     needs: [build-dagmc_test-img]
     runs-on: ubuntu-latest
-    env:
-      hdf5_build_dir: hdf5_build_dir
 
     strategy:
       matrix:

--- a/.github/workflows/linux_build_test.yml
+++ b/.github/workflows/linux_build_test.yml
@@ -12,6 +12,7 @@ on:
       - '.github/workflows/windows_build_test.yml'
       - '.github/workflows/housekeeping.yml'
       - 'CI/**'
+      - 'doc/CHANGELOG.rst'
   push:
     branches:
       - develop
@@ -21,6 +22,7 @@ on:
       - '.github/workflows/windows_build_test.yml'
       - '.github/workflows/housekeeping.yml'
       - 'CI/**'
+      - 'doc/CHANGELOG.rst'
 
 jobs:
   BuildTest:

--- a/.github/workflows/mac_build_test.yml
+++ b/.github/workflows/mac_build_test.yml
@@ -12,6 +12,8 @@ on:
       - '.github/workflows/windows_build_test.yml'
       - '.github/workflows/housekeeping.yml'
       - 'CI/**'
+      - 'doc/CHANGELOG.rst'
+
   push:
     branches:
       - develop
@@ -21,6 +23,7 @@ on:
       - '.github/workflows/windows_build_test.yml'
       - '.github/workflows/housekeeping.yml'
       - 'CI/**'
+      - 'doc/CHANGELOG.rst'
 
   release:
     types: # This configuration does not affect the page_build event above

--- a/.github/workflows/windows_build_test.yml
+++ b/.github/workflows/windows_build_test.yml
@@ -8,19 +8,22 @@ on:
       - develop
     paths-ignore:
       - '.github/workflows/docker_publish.yml'
-      - '.github/workflows/mac_build_test.yml'
       - '.github/workflows/linux_build_test.yml'
+      - '.github/workflows/mac_build_test.yml'
       - '.github/workflows/housekeeping.yml'
       - 'CI/**'
+      - 'doc/CHANGELOG.rst'
+
   push:
     branches:
       - develop
     paths-ignore:
       - '.github/workflows/docker_publish.yml'
-      - '.github/workflows/mac_build_test.yml'
       - '.github/workflows/linux_build_test.yml'
+      - '.github/workflows/mac_build_test.yml'
       - '.github/workflows/housekeeping.yml'
       - 'CI/**'
+      - 'doc/CHANGELOG.rst'
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -10,7 +10,7 @@ Next version
 **Changed:**
 
    * Improvements/corrections to graveyard capabilities (#855)
-   * Using multi stage Dockerfile to reduce the number of Dockerfile (#813)
+   * Using multi stage Dockerfile to reduce the number of Dockerfile (#813, #894)
    * Adding safe folder to allow CI to compile DAGMC (#814)
    * Correction to CMake variable name in OpenMC install instructions (#817)
    * Updating documentation publishing URL (#823)


### PR DESCRIPTION
## Description
Remove dependence on unstable image tag for retagging.

## Motivation and Context
Recent merges of our new docker image deployment have failed at the last step because we rely on a tag generated by the multi-stage-build-action that is automatically generated.  The documentation for that project recommends that we do NOT rely on that tag.  We could probably figure out something that would work, but it may be fragile based on the guidance from the authors of that action.

## Changes
This uses logic tests to determine whether or not the images should be tagged as `latest` and only does so when it is a push to `develop` on the upstream `svalinn` repository.  Pushes to other branches will still run the tests, building the full set of docker images, but will not tag them as `latest`.  

