### PR TITLE
Fix docker args

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -29,7 +29,7 @@ jobs:
          5.3.0,
         ]
 
-    name: Installing Dependencies
+    name: Installing Dependencies, Building DAGMC and running tests
     steps:
       - name: default environment
         run: |

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -60,7 +60,7 @@ jobs:
           parallel: true
           tag-latest-on-default: ${{ env.tag-latest-on-default }}
           dockerfile: CI/Dockerfile
-          build-args: COMPILER=${{ matrix.compiler }}, UBUNTU_VERSION=${{ matrix.ubuntu_versions }}, HDF5=${{ matrix.hdf5_versions }}, MOAB=${{ matrix.moab_versions }}
+          build-args: COMPILER=${{ matrix.compiler }}, UBUNTU_VERSION=${{ matrix.ubuntu_versions }}, HDF5_VERSION=${{ matrix.hdf5_versions }}, MOAB_BRANCH=${{ matrix.moab_versions }}
 
   build-dagmc_test-img:
     needs: [build-dependency-img]
@@ -114,7 +114,7 @@ jobs:
           parallel: true
           tag-latest-on-default: ${{ env.tag-latest-on-default }}
           dockerfile: CI/Dockerfile
-          build-args: COMPILER=${{ matrix.compiler }}, UBUNTU_VERSION=${{ matrix.ubuntu_versions }}, HDF5=${{ matrix.hdf5_versions }}, MOAB=${{ matrix.moab_versions }}
+          build-args: COMPILER=${{ matrix.compiler }}, UBUNTU_VERSION=${{ matrix.ubuntu_versions }}, HDF5_VERSION=${{ matrix.hdf5_versions }}, MOAB_BRANCH=${{ matrix.moab_versions }}
 
   push_stable_ci_img:
     needs: [build-dagmc_test-img]

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -9,7 +9,7 @@ on:
       - '.github/workflows/docker_publish.yml'
 
 jobs:
-  build-dependency-img:
+  build-dependency-and-test-img:
     runs-on: ubuntu-latest
 
     strategy:
@@ -54,61 +54,7 @@ jobs:
         uses: firehed/multistage-docker-build-action@v1
         with:
           repository: ghcr.io/${{ github.repository_owner }}/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler}}-ext-hdf5_${{ matrix.hdf5_versions}}-moab_${{ matrix.moab_versions }}
-          stages: base, external_deps, hdf5
-          server-stage: moab
-          quiet: false
-          parallel: true
-          tag-latest-on-default: ${{ env.tag-latest-on-default }}
-          dockerfile: CI/Dockerfile
-          build-args: COMPILER=${{ matrix.compiler }}, UBUNTU_VERSION=${{ matrix.ubuntu_versions }}, HDF5_VERSION=${{ matrix.hdf5_versions }}, MOAB_BRANCH=${{ matrix.moab_versions }}
-
-  build-dagmc_test-img:
-    needs: [build-dependency-img]
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        ubuntu_versions : [
-          20.04,
-          22.04,
-          ]
-        compiler : [
-          gcc,
-          clang,
-          ]
-        hdf5_versions : [
-         1.10.4,
-        ]
-        moab_versions : [
-         5.3.0,
-        ]
-
-    name: Installing DAGMC
-    steps:        
-      - name: default environment
-        run: |
-          echo "tag-latest-on-default=false" >> "$GITHUB_ENV"
-
-      - name: condition on trigger parameters
-        if: ${{ github.repository_owner == 'svalinn' && github.ref == 'refs/heads/develop' }}
-        run: |
-          echo "tag-latest-on-default=true" >> "$GITHUB_ENV"
-
-      - name: Log in to the Container registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Checkout repository
-        uses: actions/checkout@v3
-
-      - name: Build & test DAGMC in Docker image
-        uses: firehed/multistage-docker-build-action@v1
-        with:
-          repository: ghcr.io/${{ github.repository_owner }}/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler }}-ext-hdf5_${{ matrix.hdf5_versions }}-moab_${{ matrix.moab_versions }}
-          stages: moab, dagmc
+          stages: base, external_deps, hdf5, moab, dagmc
           server-stage: dagmc_test
           quiet: false
           parallel: true
@@ -117,7 +63,7 @@ jobs:
           build-args: COMPILER=${{ matrix.compiler }}, UBUNTU_VERSION=${{ matrix.ubuntu_versions }}, HDF5_VERSION=${{ matrix.hdf5_versions }}, MOAB_BRANCH=${{ matrix.moab_versions }}
 
   push_stable_ci_img:
-    needs: [build-dagmc_test-img]
+    needs: [build-dependency-and-test-img]
     runs-on: ubuntu-latest
 
     strategy:

--- a/CI/Dockerfile
+++ b/CI/Dockerfile
@@ -11,8 +11,6 @@ ARG MOAB_BRANCH=5.3.0
 ARG double_down=OFF
 ARG ci_jobs=4
 ARG HDF5_VERSION=1.10.4
-# currently HDF5 major version must be manually set to match HDF5 version
-ARG HDF5_VERSION_major=1.10
 
 ARG build_dir=/root/build_dir
 ARG install_dir=/root/opt
@@ -127,7 +125,6 @@ RUN mkdir -p ${embree_build_dir}/build && \
 FROM external_deps AS hdf5
 
 # accessing gloabl ARGs in build stage
-ARG HDF5_VERSION_major
 ARG HDF5_VERSION
 ARG install_dir
 ARG build_dir
@@ -140,6 +137,7 @@ ENV hdf5_install_dir=${install_dir}/hdf5
 
 RUN mkdir -p ${hdf5_build_dir}/build && \
     cd ${hdf5_build_dir} && \
+    export HDF5_VERSION_major=`python -c "print('.'.join('${HDF5_VERSION}'.split('.')[:-1]))"` && \
     wget https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-${HDF5_VERSION_major}/hdf5-${HDF5_VERSION}/src/hdf5-${HDF5_VERSION}.tar.gz && \
     tar -xzf hdf5-${HDF5_VERSION}.tar.gz && \
     cd build && \

--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -22,7 +22,7 @@ Next version
    * Added configuration options to CMake configuration file (#867)
    * Change test-on-merge against MOAB master/develop to be optional (#870)
    * Introduced logger to better manage console output (#876)
-   * Streamline CI to take advantage of better docker image management (#880)
+   * Streamline CI to take advantage of better docker image management (#880, #896)
    * Move more CI from scripts to actions (#895)
 
 **Fixed:**


### PR DESCRIPTION
## Description
Pass correctly named docker arguments to manage builds.

Also streamlines the docker build & test further taking more advantage of the multi-stage-build action.

## Motivation and Context
We currently build multiple docker images with a matrix of options.  The variable names to control the HDF5 and MOAB versions were not named correctly.  This did not create a flaw in our building/testing, because we only attempted a single version of each and those versions were the defaults anyway.  This PR corrects that.

## Changes
Rename the build args passed to Docker & combine two steps in the workflow.
