### PR TITLE
Add dd on merge

### DIFF
--- a/.github/workflows/linux_build_test.yml
+++ b/.github/workflows/linux_build_test.yml
@@ -10,6 +10,7 @@ on:
       - '.github/workflows/docker_publish.yml'
       - '.github/workflows/mac_build_test.yml'
       - '.github/workflows/windows_build_test.yml'
+      - '.github/workflows/linux_build_test_merge.yml'
       - '.github/workflows/housekeeping.yml'
       - '.github/workflows/changelog_test.yml'
       - 'CI/**'

--- a/.github/workflows/linux_build_test.yml
+++ b/.github/workflows/linux_build_test.yml
@@ -22,6 +22,7 @@ on:
       - '.github/workflows/docker_publish.yml'
       - '.github/workflows/mac_build_test.yml'
       - '.github/workflows/windows_build_test.yml'
+      - '.github/workflows/linux_build_test_merge.yml'
       - '.github/workflows/housekeeping.yml'
       - '.github/workflows/changelog_test.yml'
       - 'CI/**'

--- a/.github/workflows/linux_build_test_merge.yml
+++ b/.github/workflows/linux_build_test_merge.yml
@@ -18,7 +18,8 @@ on:
 jobs:
   build-dependency-and-test-img:
     runs-on: ubuntu-latest
-
+    continue-on-error: true
+    
     strategy:
       matrix:
         ubuntu_versions : [

--- a/.github/workflows/linux_build_test_merge.yml
+++ b/.github/workflows/linux_build_test_merge.yml
@@ -33,6 +33,15 @@ jobs:
         moab_versions : [
          master,
         ]
+        double_down : [
+          OFF,
+        ]
+        include:
+          - ubuntu_versions: 22.04
+            compiler: gcc
+            hdf5_versions: 1.10.4
+            moab_versions : 5.3.0
+            double_down : ON
 
     name: Installing Dependencies
     steps:

--- a/.github/workflows/linux_build_test_merge.yml
+++ b/.github/workflows/linux_build_test_merge.yml
@@ -16,7 +16,7 @@ on:
       - 'CI/**'
       - 'doc/**'
 jobs:
-  build-dependency-img:
+  build-dependency-and-test-img:
     runs-on: ubuntu-latest
 
     strategy:
@@ -77,7 +77,7 @@ jobs:
           build-args: COMPILER=${{ matrix.compiler }}, UBUNTU_VERSION=${{ matrix.ubuntu_versions }}, HDF5_VERSION=${{ matrix.hdf5_versions }}, MOAB_BRANCH=${{ matrix.moab_versions }}, double_down=${{ matrix.double_down }}
 
   push_stable_ci_img:
-    needs: [build-dagmc_test-img]
+    needs: [build-dependency-and-test-img]
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/linux_build_test_merge.yml
+++ b/.github/workflows/linux_build_test_merge.yml
@@ -68,65 +68,13 @@ jobs:
         uses: firehed/multistage-docker-build-action@v1
         with:
           repository: ghcr.io/${{ github.repository_owner }}/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler}}-ext-hdf5_${{ matrix.hdf5_versions}}-moab_${{ matrix.moab_versions }}
-          stages: base, external_deps, hdf5
-          server-stage: moab
-          quiet: false
-          parallel: true
-          tag-latest-on-default: ${{ env.tag-latest-on-default }}
-          dockerfile: CI/Dockerfile
-          build-args: COMPILER=${{ matrix.compiler }}, UBUNTU_VERSION=${{ matrix.ubuntu_versions }}, HDF5_VERSION=${{ matrix.hdf5_versions }}, MOAB_BRANCH=${{ matrix.moab_versions }}
-
-  build-dagmc_test-img:
-    needs: [build-dependency-img]
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        ubuntu_versions : [
-          22.04,
-          ]
-        compiler : [
-          gcc,
-          ]
-        hdf5_versions : [
-         1.10.4,
-        ]
-        moab_versions : [
-         master,
-        ]
-
-    name: Installing DAGMC
-    steps:        
-      - name: default environment
-        run: |
-          echo "tag-latest-on-default=false" >> "$GITHUB_ENV"
-
-      - name: condition on trigger parameters
-        if: ${{ github.repository_owner == 'svalinn' && github.ref == 'refs/heads/develop' }}
-        run: |
-          echo "tag-latest-on-default=true" >> "$GITHUB_ENV"
-
-      - name: Log in to the Container registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Checkout repository
-        uses: actions/checkout@v3
-
-      - name: Build & test DAGMC in Docker image
-        uses: firehed/multistage-docker-build-action@v1
-        with:
-          repository: ghcr.io/${{ github.repository_owner }}/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler }}-ext-hdf5_${{ matrix.hdf5_versions }}-moab_${{ matrix.moab_versions }}
-          stages: moab, dagmc
+          stages: base, external_deps, hdf5, moab, dagmc
           server-stage: dagmc_test
           quiet: false
           parallel: true
           tag-latest-on-default: ${{ env.tag-latest-on-default }}
           dockerfile: CI/Dockerfile
-          build-args: COMPILER=${{ matrix.compiler }}, UBUNTU_VERSION=${{ matrix.ubuntu_versions }}, HDF5_VERSION=${{ matrix.hdf5_versions }}, MOAB_BRANCH=${{ matrix.moab_versions }}
+          build-args: COMPILER=${{ matrix.compiler }}, UBUNTU_VERSION=${{ matrix.ubuntu_versions }}, HDF5_VERSION=${{ matrix.hdf5_versions }}, MOAB_BRANCH=${{ matrix.moab_versions }}, double_down=${{ matrix.double_down }}
 
   push_stable_ci_img:
     needs: [build-dagmc_test-img]

--- a/.github/workflows/mac_build_test.yml
+++ b/.github/workflows/mac_build_test.yml
@@ -9,6 +9,7 @@ on:
     paths-ignore:
       - '.github/workflows/docker_publish.yml'
       - '.github/workflows/linux_build_test.yml'
+      - '.github/workflows/linux_build_test_merge.yml'
       - '.github/workflows/windows_build_test.yml'
       - '.github/workflows/housekeeping.yml'
       - '.github/workflows/changelog_test.yml'

--- a/.github/workflows/mac_build_test.yml
+++ b/.github/workflows/mac_build_test.yml
@@ -22,6 +22,7 @@ on:
     paths-ignore:
       - '.github/workflows/docker_publish.yml'
       - '.github/workflows/linux_build_test.yml'
+      - '.github/workflows/linux_build_test_merge.yml'
       - '.github/workflows/windows_build_test.yml'
       - '.github/workflows/housekeeping.yml'
       - '.github/workflows/changelog_test.yml'

--- a/.github/workflows/windows_build_test.yml
+++ b/.github/workflows/windows_build_test.yml
@@ -9,6 +9,7 @@ on:
     paths-ignore:
       - '.github/workflows/docker_publish.yml'
       - '.github/workflows/linux_build_test.yml'
+      - '.github/workflows/linux_build_test_merge.yml'
       - '.github/workflows/mac_build_test.yml'
       - '.github/workflows/housekeeping.yml'
       - '.github/workflows/changelog_test.yml'

--- a/.github/workflows/windows_build_test.yml
+++ b/.github/workflows/windows_build_test.yml
@@ -22,6 +22,7 @@ on:
     paths-ignore:
       - '.github/workflows/docker_publish.yml'
       - '.github/workflows/linux_build_test.yml'
+      - '.github/workflows/linux_build_test_merge.yml'
       - '.github/workflows/mac_build_test.yml'
       - '.github/workflows/housekeeping.yml'
       - '.github/workflows/changelog_test.yml'

--- a/CI/Dockerfile
+++ b/CI/Dockerfile
@@ -207,6 +207,7 @@ FROM moab as dagmc
 # accessing gloabl ARGs in build stage
 ARG install_dir
 ARG build_dir
+ARG double_down
 ARG CXX
 ARG CC
 

--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -24,6 +24,7 @@ Next version
    * Introduced logger to better manage console output (#876)
    * Streamline CI to take advantage of better docker image management (#880, #896)
    * Move more CI from scripts to actions (#895)
+   * Add double-down to test-on-merge ()
 
 **Fixed:**
    * Patch to compile with Geant4 10.6 (#803)

--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -24,7 +24,7 @@ Next version
    * Introduced logger to better manage console output (#876)
    * Streamline CI to take advantage of better docker image management (#880, #896)
    * Move more CI from scripts to actions (#895)
-   * Add double-down to test-on-merge ()
+   * Add double-down to test-on-merge (#898)
 
 **Fixed:**
    * Patch to compile with Geant4 10.6 (#803)


### PR DESCRIPTION
## Description
Add a test with Double Down on merge.

## Motivation and Context
We discovered after a recent PR was merged that it broke compatibility with Double Down.  For the time being, we have decided to only test that compatibility at merge and not with each PR.

## Changes
Adds a matrix option to build DAGMC using Double Down.  Also allows jobs to continue on error so that all options are tested even if one fails, since this is advisory post merge.

Also took the opportunity to collapse the docker builds in this workflow, and to exclude changes to this file from triggering other build/test actions.

Fixes #897 
