### PR TITLE
Adding reorder flag to CI builds

### DIFF
--- a/.github/workflows/linux_build_test.yml
+++ b/.github/workflows/linux_build_test.yml
@@ -76,6 +76,7 @@ jobs:
               -DCMAKE_Fortran_COMPILER=gfortran \
               -DCMAKE_INSTALL_PREFIX=${install_dir}/dagmc \
               -DDOUBLE_DOWN=${double_down} \
+              -DCMAKE_CXX_FLAGS="-Wreorder" \
               -Ddd_ROOT=${double_down_install_dir} && \
           make -j2 && \
           make install

--- a/.github/workflows/linux_build_test.yml
+++ b/.github/workflows/linux_build_test.yml
@@ -76,7 +76,7 @@ jobs:
               -DCMAKE_Fortran_COMPILER=gfortran \
               -DCMAKE_INSTALL_PREFIX=${install_dir}/dagmc \
               -DDOUBLE_DOWN=${double_down} \
-              -DCMAKE_CXX_FLAGS="-Wreorder" \
+              -DCMAKE_CXX_FLAGS="-Werror=reorder" \
               -Ddd_ROOT=${double_down_install_dir} && \
           make -j2 && \
           make install

--- a/.github/workflows/mac_build_test.yml
+++ b/.github/workflows/mac_build_test.yml
@@ -51,7 +51,7 @@ jobs:
         shell: bash -l {0}
         run: |
           echo "HOME=$GITHUB_WORKSPACE/.." >> $GITHUB_ENV
-      
+
 
       - name: Build MOAB
         shell: bash -l {0}
@@ -78,11 +78,12 @@ jobs:
           mkdir -p $GITHUB_WORKSPACE/bld
           cd $GITHUB_WORKSPACE/bld
           cmake ../ -DMOAB_DIR=${HOME}/moab \
-                      -DBUILD_CI_TESTS=ON \
-                      -DBUILD_STATIC_EXE=OFF \
-                      -DBUILD_SHARED_LIBS=ON \
-                      -DBUILD_STATIC_LIBS=OFF \
-                      -DCMAKE_INSTALL_PREFIX=${HOME}/dagmc
+                    -DBUILD_CI_TESTS=ON \
+                    -DBUILD_STATIC_EXE=OFF \
+                    -DBUILD_SHARED_LIBS=ON \
+                    -DBUILD_STATIC_LIBS=OFF \
+                    -DCMAKE_CXX_FLAGS="-Wreorder" \
+                    -DCMAKE_INSTALL_PREFIX=${HOME}/dagmc
           make
           make install
 
@@ -91,4 +92,3 @@ jobs:
         run: |
           cd $GITHUB_WORKSPACE/bld
           PATH=$GITHUB_WORKSPACE/bld/bin:$PATH make test
-

--- a/.github/workflows/mac_build_test.yml
+++ b/.github/workflows/mac_build_test.yml
@@ -82,7 +82,7 @@ jobs:
                     -DBUILD_STATIC_EXE=OFF \
                     -DBUILD_SHARED_LIBS=ON \
                     -DBUILD_STATIC_LIBS=OFF \
-                    -DCMAKE_CXX_FLAGS="-Wreorder" \
+                    -DCMAKE_CXX_FLAGS="-Werror=reorder" \
                     -DCMAKE_INSTALL_PREFIX=${HOME}/dagmc
           make
           make install

--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -25,6 +25,7 @@ Next version
    * Streamline CI to take advantage of better docker image management (#880, #896)
    * Move more CI from scripts to actions (#895)
    * Add double-down to test-on-merge (#898)
+   * Adding flags to CI to ensure compatibility with MOOSE apps (#902)
 
 **Fixed:**
    * Patch to compile with Geant4 10.6 (#803)
@@ -57,7 +58,7 @@ v3.2.1
 **Removed:**
 
 **Fixed:**
-      
+
 **Security:**
 
 **Maintenance:**


### PR DESCRIPTION
## Description

@aprilnovak discovered an issue with the initialization order of the `DagMC_Logger` class and I believe has found some similar issues previously in DAGMC/MOAB. This adds the `-Wreorder` flag to our CI builds in the CMake command to ensure we catch this in the future.

![image](https://github.com/svalinn/DAGMC/assets/4563941/c1efb23e-1440-48f0-9f90-8179bbac8aad)

## Motivation and Context
Ensure that future changes/additions to the code are easy to incorporate into MOOSE applications.