### PR TITLE
Update for newer images with geant name

### DIFF
--- a/.github/workflows/linux_build_test.yml
+++ b/.github/workflows/linux_build_test.yml
@@ -50,9 +50,15 @@ jobs:
         moab_versions : [
           5.3.0,
         ]
+        double_down : [
+          OFF,
+        ]
+        geant_version : [
+          10.7.4,
+        ]
 
     container:
-      image: ghcr.io/${{ github.repository_owner }}/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler}}-ext-hdf5_${{ matrix.hdf5_versions}}-moab_${{ matrix.moab_versions }}/moab:latest
+      image: ghcr.io/${{ github.repository_owner }}/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler}}-geant4_${{ matrix.geant_version }}-hdf5_${{ matrix.hdf5_versions}}-moab_${{ matrix.moab_versions }}/moab:latest
 
     steps:
       - name: Checkout repository

--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -23,7 +23,7 @@ Next version
    * Introduced logger to better manage console output (#876)
    * Streamline CI to take advantage of better docker image management (#880, #896)
    * Move more CI from scripts to actions (#895)
-   * Develop advisory tests on merge for MOAB, double-down and Geant4 (#870, #898, #899)
+   * Develop advisory tests on merge for MOAB, double-down and Geant4 (#870, #898, #899, #904)
    * Adding flags to CI to ensure compatibility with MOOSE apps (#902)
    * Fixing order of attribute initialization in the metadata class (#903)
 


### PR DESCRIPTION
Following the update in #899 this changes the routine testing on linux to use the new images.