### PR TITLE
Making methods const where possible

### DIFF
--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -26,6 +26,7 @@ Next version
    * Develop advisory tests on merge for MOAB, double-down and Geant4 (#870, #898, #899, #904)
    * Adding flags to CI to ensure compatibility with MOOSE apps (#902)
    * Fixing order of attribute initialization in the metadata class (#903)
+   * Adding const identifier to cross-reference methods (#906)
 
 **Fixed:**
    * Patch to compile with Geant4 10.6 (#803)

--- a/src/dagmc/DagMC.cpp
+++ b/src/dagmc/DagMC.cpp
@@ -870,11 +870,11 @@ ErrorCode DagMC::next_vol(EntityHandle surface, EntityHandle old_volume,
 
 /* SECTION III: Indexing & Cross-referencing */
 
-EntityHandle DagMC::entity_by_id(int dimension, int id) {
+EntityHandle DagMC::entity_by_id(int dimension, int id) const {
   return GTT->entity_by_id(dimension, id);
 }
 
-int DagMC::id_by_index(int dimension, int index) {
+int DagMC::id_by_index(int dimension, int index) const {
   EntityHandle h = entity_by_index(dimension, index);
   if (!h) return 0;
 
@@ -883,7 +883,7 @@ int DagMC::id_by_index(int dimension, int index) {
   return result;
 }
 
-int DagMC::get_entity_id(EntityHandle this_ent) {
+int DagMC::get_entity_id(EntityHandle this_ent) const {
   return GTT->global_id(this_ent);
 }
 

--- a/src/dagmc/DagMC.hpp
+++ b/src/dagmc/DagMC.hpp
@@ -263,16 +263,16 @@ class DagMC {
    */
 
   /** map from dimension & global ID to EntityHandle */
-  EntityHandle entity_by_id(int dimension, int id);
+  EntityHandle entity_by_id(int dimension, int id) const;
   /** map from dimension & base-1 ordinal index to EntityHandle */
-  EntityHandle entity_by_index(int dimension, int index);
+  EntityHandle entity_by_index(int dimension, int index) const;
   /** map from dimension & base-1 ordinal index to global ID */
-  int id_by_index(int dimension, int index);
+  int id_by_index(int dimension, int index) const;
   /** PPHW: Missing dim & global ID ==> base-1 ordinal index */
   /** map from EntityHandle to base-1 ordinal index */
-  int index_by_handle(EntityHandle handle);
+  int index_by_handle(EntityHandle handle) const;
   /** map from EntityHandle to global ID */
-  int get_entity_id(EntityHandle this_ent);
+  int get_entity_id(EntityHandle this_ent) const;
 
   /**\brief get number of geometric sets corresponding to geometry of specified
    *dimension
@@ -282,7 +282,7 @@ class DagMC {
    *the dimensionality of the entities in question \return integer number of
    *entities of that dimension
    */
-  unsigned int num_entities(int dimension);
+  unsigned int num_entities(int dimension) const;
 
  private:
   /** get all group sets on the model */
@@ -564,18 +564,18 @@ class DagMC {
 
 };  // end DagMC
 
-inline EntityHandle DagMC::entity_by_index(int dimension, int index) {
+inline EntityHandle DagMC::entity_by_index(int dimension, int index) const {
   assert(2 <= dimension && 3 >= dimension &&
          (unsigned)index < entHandles[dimension].size());
   return entHandles[dimension][index];
 }
 
-inline int DagMC::index_by_handle(EntityHandle handle) {
+inline int DagMC::index_by_handle(EntityHandle handle) const {
   assert(handle - setOffset < entIndices.size());
   return entIndices[handle - setOffset];
 }
 
-inline unsigned int DagMC::num_entities(int dimension) {
+inline unsigned int DagMC::num_entities(int dimension) const {
   assert(vertex_handle_idx <= dimension && groups_handle_idx >= dimension);
   return entHandles[dimension].size() - 1;
 }


### PR DESCRIPTION
## Description
This PR adds a `const` identifier to the cross-reference methods to translate between entity handle, ID, and index.

There are probably other methods that this identifier can be applied to, but I didn't search them all out and figured it made sense to change these for sure.

## Motivation and Context
In downstream applications, it would be nice to be able to use `const DagMC*` when possible for safety. (see https://github.com/openmc-dev/openmc/pull/2687/commits/37a10fb74c1723df733035278af0a44c98dc92ee). 

## Behavior
No change in the behavior of the code here. Just improved practices.
