### PR TITLE
add packaging

### DIFF
--- a/CI/Dockerfile
+++ b/CI/Dockerfile
@@ -41,6 +41,7 @@ RUN apt-get -y update; \
                        python3 \
                        python3-pip \
                        python3-setuptools \
+                       python3-packaging \
                        python3-dev \
                        libpython3-dev \
                        wget \

--- a/CI/Dockerfile
+++ b/CI/Dockerfile
@@ -41,7 +41,6 @@ RUN apt-get -y update; \
                        python3 \
                        python3-pip \
                        python3-setuptools \
-                       python3-packaging \
                        python3-dev \
                        libpython3-dev \
                        wget \

--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -27,6 +27,7 @@ Next version
    * Adding flags to CI to ensure compatibility with MOOSE apps (#902)
    * Fixing order of attribute initialization in the metadata class (#903)
    * Adding const identifier to cross-reference methods (#906)
+   * Add python packaging for modern pymoab (#)
 
 **Fixed:**
    * Patch to compile with Geant4 10.6 (#803)


### PR DESCRIPTION
This adds the python `packaging` module to support updated pymoab installation in MOAB `master` branch.

**_Successful_** testing is demonstrated [here](https://github.com/gonuke/DAGMC/actions/runs/6341681335).