### PR TITLE
Relax brew gcc

### DIFF
--- a/.github/workflows/mac_build_test.yml
+++ b/.github/workflows/mac_build_test.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Initial setup
         shell: bash -l {0}
         run: |
-          brew install eigen gcc hdf5
+          brew install eigen hdf5
 
       - name: Environment Variables
         shell: bash -l {0}

--- a/.github/workflows/mac_build_test.yml
+++ b/.github/workflows/mac_build_test.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Initial setup
         shell: bash -l {0}
         run: |
-          brew install eigen gcc@6 hdf5
+          brew install eigen gcc hdf5
 
       - name: Environment Variables
         shell: bash -l {0}

--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -27,6 +27,7 @@ Next version
    * Adding flags to CI to ensure compatibility with MOOSE apps (#902)
    * Fixing order of attribute initialization in the metadata class (#903)
    * Adding const identifier to cross-reference methods (#906)
+   * Add MacOS build to CI (#???)
 
 **Fixed:**
    * Patch to compile with Geant4 10.6 (#803)

--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -27,7 +27,7 @@ Next version
    * Adding flags to CI to ensure compatibility with MOOSE apps (#902)
    * Fixing order of attribute initialization in the metadata class (#903)
    * Adding const identifier to cross-reference methods (#906)
-   * Add MacOS build to CI (#???)
+   * Add MacOS build to CI (#922)
 
 **Fixed:**
    * Patch to compile with Geant4 10.6 (#803)


### PR DESCRIPTION
## Description
Remove GCC version pin for MacOS/homebrew

## Motivation and Context
The Github CI service no longer supports gcc@6 showing it a deprecated.

## Changes
Remove the pin on gcc and try the newest version.

