### PR TITLE
Add g4 11 docker

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -33,6 +33,7 @@ jobs:
         ]
         geant_version : [
           10.7.4,
+          11.1.2
         ]
 
     name: Installing Dependencies, Building DAGMC and running tests

--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -37,7 +37,7 @@ Next version
    * Various documentation updates (#869)
 
 **Added:**
-   * Add Geant4 v11.1.2 to docker builds for CI ()
+   * Add Geant4 v11.1.2 to docker builds for CI (#923)
 
 v3.2.2
 ====================

--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -36,6 +36,9 @@ Next version
    * Restrict cython version for MOAB (#893)
    * Various documentation updates (#869)
 
+**Added:**
+   * Add Geant4 v11.1.2 to docker builds for CI ()
+
 v3.2.2
 ====================
 


### PR DESCRIPTION
## Description
Add Geant4 v11.1.2 to the build matrix

## Motivation and Context
The newest version of Geant4 is 11.1.2 and collaborator @ahnaf-tahmid-chowdhury has prepared a PR (#907) to support this newer version.  In order to test it properly, we need a docker image that supports it.

## Changes
Add v11.1.2 to the test matrix

## Behavior
The only change expected here is to expand the number of docker images/packages that are prepared and sync'ed to the GHCR.
