### PR TITLE
Add action to test newer hdf5 version

### DIFF
--- a/.github/workflows/linux_upstream_test_hdf5.yml
+++ b/.github/workflows/linux_upstream_test_hdf5.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - develop
+      - newer-hdf5
     paths-ignore:
       - '.github/workflows/docker_publish.yml'
       - '.github/workflows/linux_build_test.yml'

--- a/.github/workflows/linux_upstream_test_hdf5.yml
+++ b/.github/workflows/linux_upstream_test_hdf5.yml
@@ -28,4 +28,4 @@ jobs:
         uses: ./.github/actions/upstream-test
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          hdf5_version: 1.14.0
+          hdf5_version: 1.14.3

--- a/.github/workflows/linux_upstream_test_hdf5.yml
+++ b/.github/workflows/linux_upstream_test_hdf5.yml
@@ -1,0 +1,30 @@
+name: Test against newer hdf5 on PR merge
+
+on:
+  # allows us to run workflows manually
+  workflow_dispatch:
+  push:
+    branches:
+      - develop
+    paths-ignore:
+      - '.github/workflows/docker_publish.yml'
+      - '.github/workflows/linux_build_test.yml'
+      - '.github/workflows/mac_build_test.yml'
+      - '.github/workflows/windows_build_test.yml'
+      - '.github/workflows/housekeeping.yml'
+      - '.github/workflows/changelog_test.yml'
+      - 'CI/**'
+      - 'doc/**'
+jobs:
+  build-dependency-and-test-img:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: use upstream test composite action
+        uses: ./.github/actions/upstream-test
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          hdf5_version: 1.14

--- a/.github/workflows/linux_upstream_test_hdf5.yml
+++ b/.github/workflows/linux_upstream_test_hdf5.yml
@@ -28,4 +28,4 @@ jobs:
         uses: ./.github/actions/upstream-test
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          hdf5_version: 1.14
+          hdf5_version: 1.14.0

--- a/README.rst
+++ b/README.rst
@@ -53,8 +53,8 @@ Quick links:
 ..  image:: https://github.com/svalinn/DAGMC/actions/workflows/linux_upstream_test_double_down.yml/badge.svg?branch=develop
     :target: https://github.com/svalinn/DAGMC/actions/workflows/linux_upstream_test_double_down.yml
 
-..  image:: https://github.com/svalinn/DAGMC/actions/workflows/linux_upstream_test_hdf5.yml/badge.svg?branch=newer-hdf5
-    :target: https://github.com/svalinn/DAGMC/actions/workflows/linux_upstream_test_hdf5.yml
+..  image:: https://github.com/bquan0/DAGMC/actions/workflows/linux_upstream_test_hdf5.yml/badge.svg?branch=newer-hdf5
+    :target: https://github.com/bquan0/DAGMC/actions/workflows/linux_upstream_test_hdf5.yml
 
 ..  _DAGMC: https://svalinn.github.io/DAGMC
 ..  _Cubit: https://coreform.com/products/coreform-cubit/

--- a/README.rst
+++ b/README.rst
@@ -53,8 +53,8 @@ Quick links:
 ..  image:: https://github.com/svalinn/DAGMC/actions/workflows/linux_upstream_test_double_down.yml/badge.svg?branch=develop
     :target: https://github.com/svalinn/DAGMC/actions/workflows/linux_upstream_test_double_down.yml
 
-..  image:: https://github.com/bquan0/DAGMC/actions/workflows/linux_upstream_test_hdf5.yml/badge.svg?branch=newer-hdf5
-    :target: https://github.com/bquan0/DAGMC/actions/workflows/linux_upstream_test_hdf5.yml
+..  image:: https://github.com/svalinn/DAGMC/actions/workflows/linux_upstream_test_hdf5.yml/badge.svg?branch=develop
+    :target: https://github.com/svalinn/DAGMC/actions/workflows/linux_upstream_test_hdf5.yml
 
 ..  _DAGMC: https://svalinn.github.io/DAGMC
 ..  _Cubit: https://coreform.com/products/coreform-cubit/

--- a/README.rst
+++ b/README.rst
@@ -53,7 +53,7 @@ Quick links:
 ..  image:: https://github.com/svalinn/DAGMC/actions/workflows/linux_upstream_test_double_down.yml/badge.svg?branch=develop
     :target: https://github.com/svalinn/DAGMC/actions/workflows/linux_upstream_test_double_down.yml
 
-..  image:: https://github.com/svalinn/DAGMC/actions/workflows/linux_upstream_test_hdf5.yml/badge.svg?branch=develop
+..  image:: https://github.com/svalinn/DAGMC/actions/workflows/linux_upstream_test_hdf5.yml/badge.svg?branch=newer-hdf5
     :target: https://github.com/svalinn/DAGMC/actions/workflows/linux_upstream_test_hdf5.yml
 
 ..  _DAGMC: https://svalinn.github.io/DAGMC

--- a/README.rst
+++ b/README.rst
@@ -53,6 +53,9 @@ Quick links:
 ..  image:: https://github.com/svalinn/DAGMC/actions/workflows/linux_upstream_test_double_down.yml/badge.svg?branch=develop
     :target: https://github.com/svalinn/DAGMC/actions/workflows/linux_upstream_test_double_down.yml
 
+..  image:: https://github.com/svalinn/DAGMC/actions/workflows/linux_upstream_test_hdf5.yml/badge.svg?branch=develop
+    :target: https://github.com/svalinn/DAGMC/actions/workflows/linux_upstream_test_hdf5.yml
+
 ..  _DAGMC: https://svalinn.github.io/DAGMC
 ..  _Cubit: https://coreform.com/products/coreform-cubit/
 ..  _MCNP5: https://laws.lanl.gov/vhosts/mcnp.lanl.gov/mcnp5.shtml

--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -23,7 +23,7 @@ Next version
    * Introduced logger to better manage console output (#876)
    * Streamline CI to take advantage of better docker image management (#880, #896, #915)
    * Move more CI from scripts to actions (#895)
-   * Develop advisory tests on merge for MOAB, double-down and Geant4 (#870, #898, #899, #904)
+   * Develop advisory tests on merge for MOAB, double-down and Geant4, hdf5 (#870, #898, #899, #904, #925)
    * Adding flags to CI to ensure compatibility with MOOSE apps (#902)
    * Fixing order of attribute initialization in the metadata class (#903)
    * Adding const identifier to cross-reference methods (#906)


### PR DESCRIPTION
## Description
I made a copy of one of the `linux_upstream_test.yml` files and modified it slightly to use the composite action with an argument of `hdf5_version: 1.14` as specified in #916. I'm guessing this is what the issue is asking me to do? I'm not entirely sure because it wasn't specific. The issue also mentions that there are interactions between dependencies, which can be easily added with a matrix in the `linux_upstream_test_hdf5.yml` file. However, I don't know what interactions need to be tested, so I didn't add the matrix just yet. 

## Behavior
New behavior is that there will be one more action run when PRs are merged to `develop` that will test whether DAGMC works with version 1.14 of hdf5. 