### PR TITLE
Do not link against several transitive dependencies of HDF5

### DIFF
--- a/cmake/FindMOAB.cmake
+++ b/cmake/FindMOAB.cmake
@@ -22,6 +22,8 @@ include(${MOAB_CMAKE_CONFIG})
 set(ENV{PATH} "${HDF5_DIR}:$ENV{PATH}")
 set(CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_SHARED_LIBRARY_SUFFIX})
 find_package(HDF5 REQUIRED)
+# Remove HDF5 transitive dependencies that are system libraries
+list(FILTER HDF5_LIBRARIES EXCLUDE REGEX ".*lib(pthread|dl|m).*")
 set(HDF5_LIBRARIES_SHARED ${HDF5_LIBRARIES})
 # CMake doesn't let you find_package(HDF5) twice so we have to do this instead
 if (BUILD_STATIC_LIBS)

--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -35,6 +35,7 @@ Next version
    * Tweak conda environment for Windows build to avoid conflicting gtest headers (#888)
    * Restrict cython version for MOAB (#893)
    * Various documentation updates (#869)
+   * Fix for HDF5 library linking issue (#926)
 
 v3.2.2
 ====================


### PR DESCRIPTION
## Description

As described in conda-forge/dagmc-feedstock#25, some weirdness in how FindHDF5.cmake works results in transitive dependencies getting linked against, which causes issues in conda-forge with those libraries getting hardcoded in the installed DAGMCTargets.cmake file, thereby breaking potentially downstream applications that are trying to link against DAGMC. The "best" fix would be to use the proper `hdf5::hdf5` target provided by newer versions of CMake (3.19+), but I would hesitate to make that the required version. As such, the fix I'm proposed here is to manually remove libpthread, libdl, and libm from the list of HDF5 libraries. This should not cause any issues because:

1. For shared libraries, everything gets pulled in transitively through libhdf5 anyway
2. Nowadays, it is not required to link against libpthread or libdl **at all** (see explanation [here](https://stackoverflow.com/a/62561519))
3. libm will be [implicitly linked against for C++ applications](https://jdhao.github.io/2020/12/10/gcc_library_link_issue/)

## Motivation and Context

Described above

## Changes

Described above

## Behavior

**Old behavior**: All DAGMC libraries will be explicitly linked against HDF5 and its transitive dependencies
**New behavior**: All DAGMC libraries will be explicitly linked against HDF5 and several transitive dependencies (e.g., libcrypto, libcurl) but not libpthread, libdl, or libm

## Changelog file
All pull requests are required to update the [CHANGELOG](doc/CHANGELOG.rst) file with the PR.  Your update can take different forms including:

* creating a new entry describing your change, including a reference to this pull request number
* adding a reference to your pull request number to an exist entry if that entry can include your changes