### PR TITLE
add 1.11.2 geant4 to routine build testing

### DIFF
--- a/.github/workflows/linux_build_test.yml
+++ b/.github/workflows/linux_build_test.yml
@@ -55,6 +55,7 @@ jobs:
         ]
         geant_version : [
           10.7.4,
+          11.1.2
         ]
 
     container:

--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -29,7 +29,7 @@ Next version
    * Adding const identifier to cross-reference methods (#906)
 
 **Fixed:**
-   * Patch to compile with Geant4 11.x (#803 #907)
+   * Patch to compile with Geant4 11.x (#803 #907 #927)
    * Patched cmake-search paths for double-down and MOAB (#878)
    * Patch to compile with gcc-13 (#882)
    * Tweak conda environment for Windows build to avoid conflicting gtest headers (#888)


### PR DESCRIPTION
Add routine testing against Geant4 1.11.2 now that the docker images support it.

I promise this is the last step in getting the Geant4 update done.