### PR TITLE
Double Down ci fix

### DIFF
--- a/.github/actions/upstream-test/action.yml
+++ b/.github/actions/upstream-test/action.yml
@@ -28,7 +28,7 @@ inputs:
   double_down_version:
     description: Version of Double Down
     required: false
-    default: develop
+    default: 1.1.0
 
 runs:
   using: "composite"

--- a/.github/actions/upstream-test/action.yml
+++ b/.github/actions/upstream-test/action.yml
@@ -5,7 +5,7 @@ inputs:
     description: token for logging in to the GHCR
     required: true
     default: ''
-  geant_version:
+  geant4_version:
     description: Version of Geant4
     required: false
     default: 11.1.2
@@ -25,10 +25,10 @@ inputs:
     description: Version of MOAB
     required: false
     default: 5.3.0
-  double_down:
-    description: Whether or not to test Double Down
+  double_down_version:
+    description: Version of Double Down
     required: false
-    default: OFF
+    default: develop
 
 runs:
   using: "composite"
@@ -50,4 +50,4 @@ runs:
           parallel: true
           tag-latest-on-default: false
           dockerfile: CI/Dockerfile
-          build-args: COMPILER=${{ inputs.compiler }}, geant4_version=${{ inputs.geant_version }}, UBUNTU_VERSION=${{ inputs.ubuntu_version }}, HDF5_VERSION=${{ inputs.hdf5_version }}, MOAB_BRANCH=${{ inputs.moab_version }}, double_down=${{ inputs.double_down }}
+          build-args: COMPILER=${{ inputs.compiler }}, Geant4_VERSION=${{ inputs.geant4_version }}, UBUNTU_VERSION=${{ inputs.ubuntu_version }}, HDF5_VERSION=${{ inputs.hdf5_version }}, MOAB_VERSION=${{ inputs.moab_version }}, DOUBLE_DOWN_VERSION=${{ inputs.double_down_version }}

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -29,7 +29,7 @@ jobs:
          5.3.0,
         ]
         double_down_version : [
-          develop,
+          1.1.0,
         ]
         geant4_version : [
           10.7.4,
@@ -91,7 +91,7 @@ jobs:
           5.3.0,
         ]
         double_down_version : [
-          develop,
+          1.1.0,
         ]
         geant4_version : [
           10.7.4,

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        ubuntu_versions : [
+        ubuntu_version : [
           20.04,
           22.04,
           ]
@@ -22,16 +22,16 @@ jobs:
           gcc,
           clang,
           ]
-        hdf5_versions : [
+        hdf5_version : [
          1.10.4,
         ]
-        moab_versions : [
+        moab_version : [
          5.3.0,
         ]
-        double_down : [
-          OFF,
+        double_down_version : [
+          develop,
         ]
-        geant_version : [
+        geant4_version : [
           10.7.4,
           11.1.2
         ]
@@ -60,14 +60,14 @@ jobs:
       - name: Installing Dependencies in Docker image
         uses: firehed/multistage-docker-build-action@v1
         with:
-          repository: ghcr.io/${{ github.repository_owner }}/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler}}-geant4_${{ matrix.geant_version }}-hdf5_${{ matrix.hdf5_versions}}-moab_${{ matrix.moab_versions }}
+          repository: ghcr.io/${{ github.repository_owner }}/dagmc-ci-ubuntu-${{ matrix.ubuntu_version }}-${{ matrix.compiler}}-geant4_${{ matrix.geant4_version }}-hdf5_${{ matrix.hdf5_version}}-moab_${{ matrix.moab_version }}
           stages: base, external_deps, hdf5, moab, dagmc
           server-stage: dagmc_test
           quiet: false
           parallel: true
           tag-latest-on-default: ${{ env.tag-latest-on-default }}
           dockerfile: CI/Dockerfile
-          build-args: double_down=${{ matrix.double_down}}, geant4_version=${{ matrix.geant_version }}, COMPILER=${{ matrix.compiler }}, UBUNTU_VERSION=${{ matrix.ubuntu_versions }}, HDF5_VERSION=${{ matrix.hdf5_versions }}, MOAB_BRANCH=${{ matrix.moab_versions }}
+          build-args: DOUBLE_DOWN_VERSION=${{ matrix.double_down_version}}, Geant4_VERSION=${{ matrix.geant4_version }}, COMPILER=${{ matrix.compiler }}, UBUNTU_VERSION=${{ matrix.ubuntu_version }}, HDF5_VERSION=${{ matrix.hdf5_version }}, MOAB_VERSION=${{ matrix.moab_version }}
 
 
   push_stable_ci_img:
@@ -76,7 +76,7 @@ jobs:
 
     strategy:
       matrix:
-        ubuntu_versions : [
+        ubuntu_version : [
           20.04,
           22.04,
           ]
@@ -84,16 +84,16 @@ jobs:
           gcc,
           clang,
           ]
-        hdf5_versions : [
-         1.10.4,
+        hdf5_version : [
+          1.10.4,
         ]
-        moab_versions : [
-         5.3.0,
+        moab_version : [
+          5.3.0,
         ]
-        double_down : [
-          OFF,
+        double_down_version : [
+          develop,
         ]
-        geant_version : [
+        geant4_version : [
           10.7.4,
           11.1.2
         ]
@@ -111,7 +111,7 @@ jobs:
       - name: Store image name
         if: ${{ github.repository_owner == 'svalinn' }}
         run: |
-          echo "image_base_tag=ghcr.io/${{ github.repository_owner }}/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler }}-geant4_${{ matrix.geant_version }}-hdf5_${{ matrix.hdf5_versions }}-moab_${{ matrix.moab_versions }}" >> "$GITHUB_ENV"
+          echo "image_base_tag=ghcr.io/${{ github.repository_owner }}/dagmc-ci-ubuntu-${{ matrix.ubuntu_version }}-${{ matrix.compiler }}-geant4_${{ matrix.geant4_version }}-hdf5_${{ matrix.hdf5_version }}-moab_${{ matrix.moab_version }}" >> "$GITHUB_ENV"
 
       - name: Push Image as latest img
         if: ${{ github.repository_owner == 'svalinn' && github.ref == 'refs/heads/develop' }}

--- a/.github/workflows/linux_build_test.yml
+++ b/.github/workflows/linux_build_test.yml
@@ -36,7 +36,7 @@ jobs:
 
     strategy:
       matrix:
-        ubuntu_versions : [
+        ubuntu_version : [
           20.04,
           22.04,
           ]
@@ -44,21 +44,18 @@ jobs:
           gcc,
           clang,
           ]
-        hdf5_versions : [
-         1.10.4,
+        hdf5_version : [
+          1.10.4,
         ]
-        moab_versions : [
+        moab_version : [
           5.3.0,
-        ]
-        double_down : [
-          OFF,
         ]
         geant_version : [
           10.7.4,
         ]
 
     container:
-      image: ghcr.io/svalinn/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler}}-geant4_${{ matrix.geant_version }}-hdf5_${{ matrix.hdf5_versions}}-moab_${{ matrix.moab_versions }}/moab:latest
+      image: ghcr.io/svalinn/dagmc-ci-ubuntu-${{ matrix.ubuntu_version }}-${{ matrix.compiler}}-geant4_${{ matrix.geant_version }}-hdf5_${{ matrix.hdf5_version}}-moab_${{ matrix.moab_version }}/moab:latest
 
     steps:
       - name: Checkout repository
@@ -83,7 +80,7 @@ jobs:
               -DCMAKE_CXX_COMPILER=${CXX} \
               -DCMAKE_Fortran_COMPILER=gfortran \
               -DCMAKE_INSTALL_PREFIX=${install_dir}/dagmc \
-              -DDOUBLE_DOWN=${double_down} \
+              -DDOUBLE_DOWN=ON \
               -DCMAKE_CXX_FLAGS="-Werror=reorder" \
               -Ddd_ROOT=${double_down_install_dir} && \
           make -j2 && \

--- a/.github/workflows/linux_upstream_test_double_down.yml
+++ b/.github/workflows/linux_upstream_test_double_down.yml
@@ -1,4 +1,4 @@
-name: Test against Double Down on PR merge
+name: Test against newer Double Down on PR merge
 
 on:
   # allows us to run workflows manually

--- a/.github/workflows/linux_upstream_test_double_down.yml
+++ b/.github/workflows/linux_upstream_test_double_down.yml
@@ -27,6 +27,4 @@ jobs:
         uses: ./.github/actions/upstream-test
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          double_down: ON
-            
-            
+          double_down_version: develop

--- a/.github/workflows/linux_upstream_test_geant4.yml
+++ b/.github/workflows/linux_upstream_test_geant4.yml
@@ -28,4 +28,3 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           geant_version: 11.1.2
-            

--- a/.github/workflows/linux_upstream_test_moab.yml
+++ b/.github/workflows/linux_upstream_test_moab.yml
@@ -1,4 +1,4 @@
-name: Test against MOAB master on PR merge
+name: Test against newer MOAB on PR merge
 
 on:
   # allows us to run workflows manually

--- a/CI/Dockerfile
+++ b/CI/Dockerfile
@@ -6,7 +6,7 @@
 # Global ARGS set before the first build stage are accessable by all build stages
 ARG UBUNTU_VERSION=22.04
 ARG HDF5_VERSION=1.10.4
-ARG EMBREE_VERSION='v4.0.1'
+ARG EMBREE_VERSION=4.0.1
 ARG Geant4_VERSION=11.1.2
 ARG MOAB_VERSION=5.3.0
 ARG DOUBLE_DOWN_VERSION=1.1.0
@@ -48,7 +48,7 @@ RUN apt-get update --yes && \
     libpython3-dev \
     software-properties-common && \
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
-    pip install "cython<3";
+    pip3 install "cython<3";
 
 ARG build_dir
 ARG install_dir
@@ -87,13 +87,14 @@ RUN mkdir -p ${geant4_build_dir}/build && \
     wget https://gitlab.cern.ch/geant4/geant4/-/archive/v${Geant4_VERSION}/${geant4_tarball} --no-check-certificate && \
     tar -xzf ${geant4_tarball} && \
     cd build && \
-    cmake ../${geant4_basename} -DCMAKE_INSTALL_RPATH=${geant4_install_dir}/lib \
-                                -DCMAKE_INSTALL_PREFIX=${geant4_install_dir} \
-                                -DGEANT4_USE_SYSTEM_EXPAT=OFF \
-                                -DCMAKE_BUILD_TYPE=Release \
-                                -DCMAKE_CXX_COMPILER=${CXX} \
-                                -DCMAKE_C_COMPILER=${CC} \
-                                -DBUILD_STATIC_LIBS=ON && \
+    cmake ../${geant4_basename} \
+        -DCMAKE_INSTALL_RPATH=${geant4_install_dir}/lib \
+        -DCMAKE_INSTALL_PREFIX=${geant4_install_dir} \
+        -DGEANT4_USE_SYSTEM_EXPAT=OFF \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_CXX_COMPILER=${CXX} \
+        -DCMAKE_C_COMPILER=${CC} \
+        -DBUILD_STATIC_LIBS=ON && \
     make -j${CI_JOBS} && \
     make install && \
     cd && \
@@ -106,7 +107,7 @@ ENV embree_build_dir=${build_dir}/embree
 # Clone and install Embree
 RUN mkdir -p ${embree_build_dir}/build && \
     cd ${embree_build_dir} && \
-    git clone -b ${EMBREE_VERSION} https://github.com/embree/embree && \
+    git clone -b v${EMBREE_VERSION} https://github.com/embree/embree && \
     cd build && \
     cmake ../embree -DCMAKE_INSTALL_PREFIX=${embree_install_dir} \
                     -DEMBREE_TASKING_SYSTEM=INTERNAL \
@@ -169,16 +170,17 @@ RUN mkdir -p ${moab_build_dir}/build && \
     cd ${moab_build_dir} && \
     git clone -b ${MOAB_VERSION} --depth 1 https://bitbucket.org/fathomteam/moab && \
     cd build && \
-    cmake ../moab -DCMAKE_INSTALL_RPATH=${hdf5_install_dir}/lib:${moab_install_dir}/lib \
-                  -DCMAKE_BUILD_TYPE=Release \
-                  -DENABLE_HDF5=ON -DHDF5_ROOT=${hdf5_install_dir} \
-                  -DCMAKE_INSTALL_PREFIX=${moab_install_dir} \
-                  -DCMAKE_CXX_COMPILER=${CXX} \
-                  -DCMAKE_C_COMPILER=${CC} \
-                  -DENABLE_BLASLAPACK=OFF \
-                  -DBUILD_SHARED_LIBS=ON \
-                  -DENABLE_FORTRAN=OFF \
-                  -DENABLE_PYMOAB=ON && \
+    cmake ../moab \
+        -DCMAKE_INSTALL_RPATH=${hdf5_install_dir}/lib:${moab_install_dir}/lib \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DENABLE_HDF5=ON -DHDF5_ROOT=${hdf5_install_dir} \
+        -DCMAKE_INSTALL_PREFIX=${moab_install_dir} \
+        -DCMAKE_CXX_COMPILER=${CXX} \
+        -DCMAKE_C_COMPILER=${CC} \
+        -DENABLE_BLASLAPACK=OFF \
+        -DBUILD_SHARED_LIBS=ON \
+        -DENABLE_FORTRAN=OFF \
+        -DENABLE_PYMOAB=ON && \
     make -j${CI_JOBS} && \
     make install && \
     cd && \
@@ -191,11 +193,12 @@ ENV double_down_install_dir=${install_dir}/double-down
 # performed after moab install as double-down requires moab
 RUN mkdir -p ${double_down_build_dir}/build && \
     cd ${double_down_build_dir} && \
-    git clone --shallow-submodules --single-branch --branch ${DOUBLE_DOWN_VERSION} --depth 1 https://github.com/pshriwise/double-down.git && \
+    git clone --shallow-submodules --single-branch --branch v${DOUBLE_DOWN_VERSION} --depth 1 https://github.com/pshriwise/double-down.git && \
     cd build && \
-    cmake ../double-down -DMOAB_DIR=${moab_install_dir} \
-                         -DCMAKE_INSTALL_PREFIX=${double_down_install_dir} \
-                         -DEMBREE_DIR=${embree_install_dir} && \
+    cmake ../double-down \
+        -DMOAB_DIR=${moab_install_dir} \
+        -DCMAKE_INSTALL_PREFIX=${double_down_install_dir} \
+        -DEMBREE_DIR=${embree_install_dir} && \
     make -j${CI_JOBS} && \
     make -j${CI_JOBS} install
 
@@ -219,20 +222,21 @@ RUN cd  ${dagmc_build_dir} && git submodule update --init
 RUN mkdir -p ${dagmc_build_dir}/build && \
     cd ${dagmc_build_dir} && \
     cd build && \
-    cmake ../ -DMOAB_DIR=${moab_install_dir} \
-              -DBUILD_GEANT4=ON \
-              -DGEANT4_DIR=${geant4_install_dir} \
-              -DBUILD_CI_TESTS=ON \
-              # reg tests disabled see issue https://github.com/svalinn/DAGMC/issues/858
-              -DBUILD_MW_REG_TESTS=OFF \
-              -DBUILD_STATIC_EXE=OFF \
-              -DBUILD_STATIC_LIBS=OFF \
-              -DCMAKE_C_COMPILER=${CC} \
-              -DCMAKE_CXX_COMPILER=${CXX} \
-              -DCMAKE_Fortran_COMPILER=gfortran \
-              -DCMAKE_INSTALL_PREFIX=${dagmc_install_dir} \
-              -DDOUBLE_DOWN=ON \
-              -Ddd_ROOT=${double_down_install_dir} && \
+    cmake ../ \
+        -DMOAB_DIR=${moab_install_dir} \
+        -DBUILD_GEANT4=ON \
+        -DGEANT4_DIR=${geant4_install_dir} \
+        -DBUILD_CI_TESTS=ON \
+        # reg tests disabled see issue https://github.com/svalinn/DAGMC/issues/858
+        -DBUILD_MW_REG_TESTS=OFF \
+        -DBUILD_STATIC_EXE=OFF \
+        -DBUILD_STATIC_LIBS=OFF \
+        -DCMAKE_C_COMPILER=${CC} \
+        -DCMAKE_CXX_COMPILER=${CXX} \
+        -DCMAKE_Fortran_COMPILER=gfortran \
+        -DCMAKE_INSTALL_PREFIX=${dagmc_install_dir} \
+        -DDOUBLE_DOWN=ON \
+        -Ddd_ROOT=${double_down_install_dir} && \
     make -j${CI_JOBS} && \
     make install
 

--- a/CI/Dockerfile
+++ b/CI/Dockerfile
@@ -77,14 +77,14 @@ ARG CI_JOBS
 ARG CXX
 ARG CC
 
-ENV geant4_basename=geant4-v${geant4_version}
+ENV geant4_basename=geant4-v${Geant4_VERSION}
 ENV geant4_tarball=${geant4_basename}.tar.gz
 ENV geant4_build_dir=${build_dir}/geant4
 ENV geant4_install_dir=${install_dir}/geant4
 
 RUN mkdir -p ${geant4_build_dir}/build && \
     cd ${geant4_build_dir} && \
-    wget https://gitlab.cern.ch/geant4/geant4/-/archive/v${geant4_version}/${geant4_tarball} --no-check-certificate && \
+    wget https://gitlab.cern.ch/geant4/geant4/-/archive/v${Geant4_VERSION}/${geant4_tarball} --no-check-certificate && \
     tar -xzf ${geant4_tarball} && \
     cd build && \
     cmake ../${geant4_basename} -DCMAKE_INSTALL_RPATH=${geant4_install_dir}/lib \

--- a/CI/Dockerfile
+++ b/CI/Dockerfile
@@ -6,10 +6,10 @@
 # Global ARGS set before the first build stage are accessable by all build stages
 ARG UBUNTU_VERSION=22.04
 ARG HDF5_VERSION=1.10.4
-ARG EMBREE_VERSION='v3.6.1'
+ARG EMBREE_VERSION='v4.0.1'
 ARG Geant4_VERSION=11.1.2
 ARG MOAB_VERSION=5.3.0
-ARG DOUBLE_DOWN_VERSION='develop'
+ARG DOUBLE_DOWN_VERSION=1.1.0
 ARG CI_JOBS=4
 
 ARG build_dir=/root/build_dir

--- a/CI/Dockerfile
+++ b/CI/Dockerfile
@@ -4,13 +4,13 @@
 # docker build -t dagmc -f CI/Dockerfile .
 
 # Global ARGS set before the first build stage are accessable by all build stages
-ARG EMBREE_BRANCH='v3.6.1'
-ARG geant4_version=11.1.2
-ARG UBUNTU_VERSION=20.04
-ARG MOAB_BRANCH=5.3.0
-ARG double_down=OFF
-ARG ci_jobs=4
+ARG UBUNTU_VERSION=22.04
 ARG HDF5_VERSION=1.10.4
+ARG EMBREE_VERSION='v3.6.1'
+ARG Geant4_VERSION=11.1.2
+ARG MOAB_VERSION=5.3.0
+ARG DOUBLE_DOWN_VERSION='develop'
+ARG CI_JOBS=4
 
 ARG build_dir=/root/build_dir
 ARG install_dir=/root/opt
@@ -26,30 +26,28 @@ SHELL ["/bin/bash", "-c"]
 ENV TZ=America/Chicago
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
-# Update core packages
-RUN apt-get -y update; \
-    apt-get -y install autoconf \
-                       clang \
-                       cmake \
-                       g++ \
-                       gcc \
-                       gfortran \
-                       libhdf5-dev \
-                       libtool \
-                       libeigen3-dev\
-                       python3-numpy \
-                       python3 \
-                       python3-pip \
-                       python3-setuptools \
-                       python3-dev \
-                       libpython3-dev \
-                       wget \
-                       software-properties-common; \
-    add-apt-repository ppa:git-core/ppa; \
-    apt-get update; \
-    apt-get install -y git; \
-    update-alternatives --install /usr/bin/python python /usr/bin/python3 10; \
-    update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 10; \
+# Install Build Dependencies
+RUN apt-get update --yes && \
+    apt-get install --yes \
+    git \
+    wget \
+    autoconf \
+    clang \
+    cmake \
+    g++ \
+    gcc \
+    gfortran \
+    libhdf5-dev \
+    libtool \
+    libeigen3-dev\
+    python3-numpy \
+    python3 \
+    python3-pip \
+    python3-setuptools \
+    python3-dev \
+    libpython3-dev \
+    software-properties-common && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* && \
     pip install "cython<3";
 
 ARG build_dir
@@ -71,17 +69,16 @@ ENV CXX=clang++
 FROM compiler-${COMPILER} as external_deps
 
 # accessing gloabl ARGs in build stage
-ARG geant4_version
-ARG EMBREE_BRANCH
+ARG Geant4_VERSION
+ARG EMBREE_VERSION
 ARG install_dir 
 ARG build_dir
-ARG ci_jobs
+ARG CI_JOBS
 ARG CXX
 ARG CC
 
 ENV geant4_basename=geant4-v${geant4_version}
 ENV geant4_tarball=${geant4_basename}.tar.gz
-ENV geant4_shasum=2397eb859dc4de095ff66059d8bda9f060fdc42e10469dd7890946293eeb0e39
 ENV geant4_build_dir=${build_dir}/geant4
 ENV geant4_install_dir=${install_dir}/geant4
 
@@ -97,7 +94,7 @@ RUN mkdir -p ${geant4_build_dir}/build && \
                                 -DCMAKE_CXX_COMPILER=${CXX} \
                                 -DCMAKE_C_COMPILER=${CC} \
                                 -DBUILD_STATIC_LIBS=ON && \
-    make -j${ci_jobs} && \
+    make -j${CI_JOBS} && \
     make install && \
     cd && \
     rm -rf ${geant4_build_dir}
@@ -109,15 +106,15 @@ ENV embree_build_dir=${build_dir}/embree
 # Clone and install Embree
 RUN mkdir -p ${embree_build_dir}/build && \
     cd ${embree_build_dir} && \
-    git clone -b ${EMBREE_BRANCH} https://github.com/embree/embree && \
+    git clone -b ${EMBREE_VERSION} https://github.com/embree/embree && \
     cd build && \
     cmake ../embree -DCMAKE_INSTALL_PREFIX=${embree_install_dir} \
                     -DEMBREE_TASKING_SYSTEM=INTERNAL \
                     -DEMBREE_ISPC_SUPPORT=OFF \
                     -DEMBREE_TUTORIALS=OFF \
                     -DEMBREE_TBB_ROOT=/usr && \
-    make -j${ci_jobs} && \
-    make -j${ci_jobs} install && \
+    make -j${CI_JOBS} && \
+    make -j${CI_JOBS} install && \
     cd && \
     rm -rf ${embree_build_dir}
 
@@ -128,7 +125,7 @@ FROM external_deps AS hdf5
 ARG HDF5_VERSION
 ARG install_dir
 ARG build_dir
-ARG ci_jobs
+ARG CI_JOBS
 ARG CXX
 ARG CC
 
@@ -137,7 +134,7 @@ ENV hdf5_install_dir=${install_dir}/hdf5
 
 RUN mkdir -p ${hdf5_build_dir}/build && \
     cd ${hdf5_build_dir} && \
-    export HDF5_VERSION_major=`python -c "print('.'.join('${HDF5_VERSION}'.split('.')[:-1]))"` && \
+    export HDF5_VERSION_major=`python3 -c "print('.'.join('${HDF5_VERSION}'.split('.')[:-1]))"` && \
     wget https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-${HDF5_VERSION_major}/hdf5-${HDF5_VERSION}/src/hdf5-${HDF5_VERSION}.tar.gz && \
     tar -xzf hdf5-${HDF5_VERSION}.tar.gz && \
     cd build && \
@@ -145,7 +142,7 @@ RUN mkdir -p ${hdf5_build_dir}/build && \
         --prefix=${hdf5_install_dir} \
         CXX=${CXX} \
         CC=${CC} && \
-    make -j${ci_jobs} && \
+    make -j${CI_JOBS} && \
     make install && \
     cd && \
     rm -rf ${hdf5_build_dir}
@@ -155,9 +152,10 @@ FROM hdf5 AS moab
 
 # accessing gloabl ARGs in build stage
 ARG install_dir
-ARG MOAB_BRANCH
+ARG MOAB_VERSION
+ARG DOUBLE_DOWN_VERSION
 ARG build_dir
-ARG ci_jobs
+ARG CI_JOBS
 ARG CXX
 ARG CC
 
@@ -169,7 +167,7 @@ ENV moab_install_dir=${install_dir}/moab
 
 RUN mkdir -p ${moab_build_dir}/build && \
     cd ${moab_build_dir} && \
-    git clone -b ${MOAB_BRANCH} --depth 1 https://bitbucket.org/fathomteam/moab && \
+    git clone -b ${MOAB_VERSION} --depth 1 https://bitbucket.org/fathomteam/moab && \
     cd build && \
     cmake ../moab -DCMAKE_INSTALL_RPATH=${hdf5_install_dir}/lib:${moab_install_dir}/lib \
                   -DCMAKE_BUILD_TYPE=Release \
@@ -181,7 +179,7 @@ RUN mkdir -p ${moab_build_dir}/build && \
                   -DBUILD_SHARED_LIBS=ON \
                   -DENABLE_FORTRAN=OFF \
                   -DENABLE_PYMOAB=ON && \
-    make -j${ci_jobs} && \
+    make -j${CI_JOBS} && \
     make install && \
     cd && \
     rm -rf ${moab_build_dir}
@@ -193,13 +191,13 @@ ENV double_down_install_dir=${install_dir}/double-down
 # performed after moab install as double-down requires moab
 RUN mkdir -p ${double_down_build_dir}/build && \
     cd ${double_down_build_dir} && \
-    git clone --shallow-submodules --single-branch --branch v1.0.0 --depth 1 https://github.com/pshriwise/double-down.git && \
+    git clone --shallow-submodules --single-branch --branch ${DOUBLE_DOWN_VERSION} --depth 1 https://github.com/pshriwise/double-down.git && \
     cd build && \
     cmake ../double-down -DMOAB_DIR=${moab_install_dir} \
                          -DCMAKE_INSTALL_PREFIX=${double_down_install_dir} \
                          -DEMBREE_DIR=${embree_install_dir} && \
-    make -j${ci_jobs} && \
-    make -j${ci_jobs} install
+    make -j${CI_JOBS} && \
+    make -j${CI_JOBS} install
 
 
 FROM moab as dagmc
@@ -207,7 +205,6 @@ FROM moab as dagmc
 # accessing gloabl ARGs in build stage
 ARG install_dir
 ARG build_dir
-ARG double_down
 ARG CXX
 ARG CC
 
@@ -234,9 +231,9 @@ RUN mkdir -p ${dagmc_build_dir}/build && \
               -DCMAKE_CXX_COMPILER=${CXX} \
               -DCMAKE_Fortran_COMPILER=gfortran \
               -DCMAKE_INSTALL_PREFIX=${dagmc_install_dir} \
-              -DDOUBLE_DOWN=${double_down} \
+              -DDOUBLE_DOWN=ON \
               -Ddd_ROOT=${double_down_install_dir} && \
-    make -j${ci_jobs} && \
+    make -j${CI_JOBS} && \
     make install
 
 

--- a/README.rst
+++ b/README.rst
@@ -42,7 +42,7 @@ Quick links:
 * `Contributors guide <https://svalinn.github.io/DAGMC/contribute/index.html>`_
 * `Release instructions <release.rst>`_
 
-*Preview CI for versions of upstream dependencies *
+**Preview CI for versions of upstream dependencies**
 
 ..  image:: https://github.com/svalinn/DAGMC/actions/workflows/linux_upstream_test_moab.yml/badge.svg?branch=develop
     :target: https://github.com/svalinn/DAGMC/actions/workflows/linux_upstream_test_moab.yml

--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -27,6 +27,7 @@ Next version
    * Adding flags to CI to ensure compatibility with MOOSE apps (#902)
    * Fixing order of attribute initialization in the metadata class (#903)
    * Adding const identifier to cross-reference methods (#906)
+   * Allow Double Down v1.1.0 Installation in Dockerfile (#929)
 
 **Fixed:**
    * Patch to compile with Geant4 11.x (#803 #907)


### PR DESCRIPTION
Double Down v1.0.0 in not compatible with new DAGMC. Thus setting develop branch for testing. Suggesting to merge the PR after new Double Down version release.