### PR TITLE
Ensure implicit complement is placed at the back of the DAGMC index space

### DIFF
--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -10,6 +10,7 @@ Next version
 **Changed:**
 
   * Update hdf5 to v1.14.3 from v1.10.4 (#931 #933)
+  * Ensure implicit complement handle is placed at the back of DAGMC volume indices (#935)
 
 v3.2.3
 ====================

--- a/src/dagmc/DagMC.cpp
+++ b/src/dagmc/DagMC.cpp
@@ -920,17 +920,19 @@ ErrorCode DagMC::build_indices(Range& surfs, Range& vols) {
   std::copy(vols.begin(), vols.end(), iter);
 
   // Ensure the implicit complement volume is placed at the back of this vector
-  //   Many codes iterate over the DAGMC volumes by index and all explicit volumes should
-  //   be checked before the implicit complement
-  EntityHandle implicit_complement {0};
+  //   Many codes iterate over the DAGMC volumes by index and all explicit
+  //   volumes should be checked before the implicit complement
+  EntityHandle implicit_complement{0};
   rval = geom_tool()->get_implicit_complement(implicit_complement);
   if (rval == MB_SUCCESS && implicit_complement != 0) {
-    auto it = std::find(vol_handles().begin(), vol_handles().end(), implicit_complement);
+    auto it = std::find(vol_handles().begin(), vol_handles().end(),
+                        implicit_complement);
     if (it != vol_handles().end()) {
       vol_handles().erase(it);
-    }
-    else {
-      logger.message("Could not find the implicit complement in the volume handles vector");
+    } else {
+      logger.message(
+          "Could not find the implicit complement in the volume handles "
+          "vector");
       return MB_FAILURE;
     }
     // insert the implicit complement at the end of the vector

--- a/src/dagmc/DagMC.cpp
+++ b/src/dagmc/DagMC.cpp
@@ -924,19 +924,18 @@ ErrorCode DagMC::build_indices(Range& surfs, Range& vols) {
   //   be checked before the implicit complement
   EntityHandle implicit_complement {0};
   rval = geom_tool()->get_implicit_complement(implicit_complement);
-  if (rval != MB_SUCCESS || implicit_complement == 0) {
-    logger.message("Could not get the implicit complement");
-    return rval;
+  if (rval == MB_SUCCESS && implicit_complement != 0) {
+    auto it = std::find(vol_handles().begin(), vol_handles().end(), implicit_complement);
+    if (it != vol_handles().end()) {
+      vol_handles().erase(it);
+    }
+    else {
+      logger.message("Could not find the implicit complement in the volume handles vector");
+      return MB_FAILURE;
+    }
+    // insert the implicit complement at the end of the vector
+    vol_handles().push_back(implicit_complement);
   }
-  auto it = std::find(vol_handles().begin(), vol_handles().end(), implicit_complement);
-  if (it != vol_handles().end()) {
-    vol_handles().erase(it);
-  }
-  else {
-    logger.message("Could not find the implicit complement in the volume handles vector");
-    return MB_FAILURE;
-  }
-  vol_handles().push_back(implicit_complement);
 
   idx = 1;
   for (auto vol_handle : vol_handles()) {

--- a/src/dagmc/DagMC.hpp
+++ b/src/dagmc/DagMC.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "DagMCVersion.hpp"
@@ -77,10 +78,12 @@ class DagMC {
         double overlap_tolerance = 0., double numerical_precision = .001,
         int verbosity = 1);
   // Deprecated Constructor
-  [[deprecated(
-      "Replaced by DagMC(std::shared_ptr<Interface> mb_impl, ... "
-      ")")]] DagMC(Interface* mb_impl, double overlap_tolerance = 0.,
-                   double numerical_precision = .001, int verbosity = 1);
+  [
+      [deprecated("Replaced by DagMC(std::shared_ptr<Interface> mb_impl, ... "
+                  ")")]] DagMC(Interface* mb_impl,
+                               double overlap_tolerance = 0.,
+                               double numerical_precision = .001,
+                               int verbosity = 1);
   // Destructor
   ~DagMC();
 

--- a/src/dagmc/DagMC.hpp
+++ b/src/dagmc/DagMC.hpp
@@ -4,7 +4,6 @@
 #include <assert.h>
 
 #include <limits>
-#include <unordered_map>
 #include <map>
 #include <memory>
 #include <stdexcept>
@@ -78,12 +77,10 @@ class DagMC {
         double overlap_tolerance = 0., double numerical_precision = .001,
         int verbosity = 1);
   // Deprecated Constructor
-  [
-      [deprecated("Replaced by DagMC(std::shared_ptr<Interface> mb_impl, ... "
-                  ")")]] DagMC(Interface* mb_impl,
-                               double overlap_tolerance = 0.,
-                               double numerical_precision = .001,
-                               int verbosity = 1);
+  [[deprecated(
+      "Replaced by DagMC(std::shared_ptr<Interface> mb_impl, ... "
+      ")")]] DagMC(Interface* mb_impl, double overlap_tolerance = 0.,
+                   double numerical_precision = .001, int verbosity = 1);
   // Destructor
   ~DagMC();
 

--- a/src/dagmc/DagMC.hpp
+++ b/src/dagmc/DagMC.hpp
@@ -4,6 +4,7 @@
 #include <assert.h>
 
 #include <limits>
+#include <unordered_map>
 #include <map>
 #include <memory>
 #include <stdexcept>
@@ -499,10 +500,8 @@ class DagMC {
  private:
   /** store some lists indexed by handle */
   std::vector<EntityHandle> entHandles[5];
-  /** lowest-valued handle among entity sets representing surfs and vols */
-  EntityHandle setOffset;
-  /** entity index (contiguous 1-N indices); indexed like rootSets */
-  std::vector<int> entIndices;
+  /** surface and volume mapping from EntitiyHandle to DAGMC index */
+  std::unordered_map<EntityHandle, int> entIndices;
   /** corresponding geometric entities; also indexed like rootSets */
   std::vector<RefEntity*> geomEntities;
 
@@ -571,8 +570,8 @@ inline EntityHandle DagMC::entity_by_index(int dimension, int index) const {
 }
 
 inline int DagMC::index_by_handle(EntityHandle handle) const {
-  assert(handle - setOffset < entIndices.size());
-  return entIndices[handle - setOffset];
+  assert(entIndices.count(handle) > 0);
+  return entIndices.at(handle);
 }
 
 inline unsigned int DagMC::num_entities(int dimension) const {

--- a/src/dagmc/tests/CMakeLists.txt
+++ b/src/dagmc/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ dagmc_install_test(dagmc_pointinvol_test cpp)
 dagmc_install_test(dagmc_rayfire_test    cpp)
 dagmc_install_test(dagmc_simple_test     cpp)
 dagmc_install_test(dagmc_graveyard_test  cpp)
+dagmc_install_test(dagmc_ipc_index_test cpp)
 
 dagmc_install_test_file(test_dagmc.h5m)
 dagmc_install_test_file(test_dagmc_impl.h5m)

--- a/src/dagmc/tests/dagmc_ipc_index_test.cpp
+++ b/src/dagmc/tests/dagmc_ipc_index_test.cpp
@@ -1,8 +1,8 @@
 #include <gtest/gtest.h>
 
+#include <filesystem>
 #include <iostream>
 #include <memory>
-#include <filesystem>
 
 #include "DagMC.hpp"
 #include "moab/Core.hpp"
@@ -67,7 +67,8 @@ TEST_F(DagmcIPCPositionTest, dagmc_implicit_complement_position_test) {
   ASSERT_EQ(rval, MB_SUCCESS);
   ASSERT_NE(ipc, 0);
 
-  // there are 3 volumes in the original model and we've added the implicit complement
+  // there are 3 volumes in the original model and we've added the implicit
+  // complement
   int num_vols = dagmc2->num_entities(3);
   ASSERT_EQ(num_vols, 4);
 

--- a/src/dagmc/tests/dagmc_ipc_index_test.cpp
+++ b/src/dagmc/tests/dagmc_ipc_index_test.cpp
@@ -1,0 +1,62 @@
+#include <gtest/gtest.h>
+
+#include <iostream>
+#include <memory>
+#include <filesystem>
+
+#include "DagMC.hpp"
+#include "moab/Core.hpp"
+#include "moab/Interface.hpp"
+
+static std::string simple_file = "test_dagmc.h5m";
+
+class DagmcIPCPositionTest : public ::testing::Test {
+ protected:
+  virtual void SetUp() {}
+  virtual void TearDown() {
+    if (std::filesystem::exists("tmp.h5m")) {
+      std::filesystem::remove("tmp.h5m");
+    }
+  }
+};
+
+using namespace moab;
+
+
+TEST_F(DagmcIPCPositionTest, dagmc_implicit_complement_position_test) {
+  // create a DAGMC instance
+  std::unique_ptr<DagMC> dagmc = std::make_unique<DagMC>();
+
+  // load the geometry test file
+  ErrorCode rval = dagmc->load_file(simple_file.c_str());
+
+  // add a bunch of meshsets to this file
+  EntityHandle tmp;
+  for (int i = 0; i < 1E6; i++) {
+    rval = dagmc->moab_instance()->create_meshset(MESHSET_SET, tmp);
+    ASSERT_EQ(rval, MB_SUCCESS);
+  }
+
+  dagmc->moab_instance()->write_file("tmp.h5m");
+
+  // create a second DAGMC instance nd read the new file
+  std::unique_ptr<DagMC> dagmc2 = std::make_unique<DagMC>();
+
+  dagmc2->load_file("tmp.h5m");
+  dagmc2->geom_tool()->find_geomsets();
+  dagmc2->setup_impl_compl();
+  dagmc2->setup_indices();
+
+  EntityHandle ipc = 0;
+  rval = dagmc2->geom_tool()->get_implicit_complement(ipc);
+  ASSERT_EQ(rval, MB_SUCCESS);
+  ASSERT_NE(ipc, 0);
+
+  int num_vols = dagmc2->num_entities(3);
+  // 3 volumes in the original model, plus the IPC
+  ASSERT_EQ(num_vols, 4);
+
+  // Reminder: DAGMC indieces are 1-based
+  std::cout << "IPC index: " << dagmc2->index_by_handle(ipc) << std::endl;
+  ASSERT_EQ(dagmc2->index_by_handle(ipc), 4);
+}

--- a/src/dagmc/tests/dagmc_ipc_index_test.cpp
+++ b/src/dagmc/tests/dagmc_ipc_index_test.cpp
@@ -22,7 +22,14 @@ class DagmcIPCPositionTest : public ::testing::Test {
 
 using namespace moab;
 
-
+// This test exists to ensure that the IPC is correctly positioned in the model
+// See GitHub issue #934 for more information
+// The test loads a known, working DAGMC file, adds a bunch of meshsets to it,
+// and then writes a temporary file. The temporary file is then read back in
+// and the IPC is checked to ensure it is in the correct position. The condision
+// being tested is only triggered during a file read when EntityHandle sequences
+// are generated and accessed internally and cannot be reproduced
+// using the external-facing MOAB API.
 TEST_F(DagmcIPCPositionTest, dagmc_implicit_complement_position_test) {
   // create a DAGMC instance
   std::unique_ptr<DagMC> dagmc = std::make_unique<DagMC>();
@@ -30,32 +37,41 @@ TEST_F(DagmcIPCPositionTest, dagmc_implicit_complement_position_test) {
   // load the geometry test file
   ErrorCode rval = dagmc->load_file(simple_file.c_str());
 
-  // add a bunch of meshsets to this file
+  // add one million mesh sets to this file to ensure the threshold of
+  // meshsets in a file is surpassed to trigger this condition
+  // NOTE: far fewer meshsets are needed to trigger this condition, but
+  //       one million was chosen to be conservative should the internal
+  //       allocation size in MOAB change again in the future
   EntityHandle tmp;
   for (int i = 0; i < 1E6; i++) {
     rval = dagmc->moab_instance()->create_meshset(MESHSET_SET, tmp);
     ASSERT_EQ(rval, MB_SUCCESS);
   }
 
+  // write a temprary file
   dagmc->moab_instance()->write_file("tmp.h5m");
 
-  // create a second DAGMC instance nd read the new file
+  // create a second DAGMC instance and read the temporary file
   std::unique_ptr<DagMC> dagmc2 = std::make_unique<DagMC>();
-
   dagmc2->load_file("tmp.h5m");
+
+  // perform necessary DAGMC setup
   dagmc2->geom_tool()->find_geomsets();
   dagmc2->setup_impl_compl();
   dagmc2->setup_indices();
 
+  // get the implicit complement handle, it should exist after the explicit call
+  // for its creation above
   EntityHandle ipc = 0;
   rval = dagmc2->geom_tool()->get_implicit_complement(ipc);
   ASSERT_EQ(rval, MB_SUCCESS);
   ASSERT_NE(ipc, 0);
 
+  // there are 3 volumes in the original model and we've added the implicit complement
   int num_vols = dagmc2->num_entities(3);
-  // 3 volumes in the original model, plus the IPC
   ASSERT_EQ(num_vols, 4);
 
+  // Make sure the IPC handle index is highest
   // Reminder: DAGMC indieces are 1-based
   std::cout << "IPC index: " << dagmc2->index_by_handle(ipc) << std::endl;
   ASSERT_EQ(dagmc2->index_by_handle(ipc), 4);


### PR DESCRIPTION
## Description
This PR enforces placement of the implicit complement handle at the back of the surfaces and volumes vectors (contained in the `DagMC::entHandles` data member). It also changes the `EntityHandle` -> DAGMC index mapping structure (`DagMC::entIndices`) s.t. DAGMC indexes are independent of the EntityHandle ordering produced by MOAB. I decided on `std::unordered_map` for a lookup complexity O(1). The downside here is that the container use more memory, but this should be a small percentage of the overall memory use in DAGMC as I understand it. If others have approaches for maintaining the `std::vector<int>` option I'm all ears, but I have a feeling it would be more trouble than it's worth.

I've confirmed that this results in the same eigenvalue as MOAB 5.3.0 for the MSRE model mentioned in #934 with OpenMC.

## Motivation and Context
The motivation for this is described in #934.

## Changes
- Manual placement of the implicit complement handle at the back of the `entHandles` container.
- Structural change in the container type used for DAGMC indices.

## Behavior
In some cases, the implicit complement handle may not be placed at the back of the DAGMC index space and could be checked in point containment queries before other explicit volumes in the model.
