### PR TITLE
Simplify Housekeeping Process for DAGMC

### DIFF
--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -8,6 +8,7 @@ on:
       - develop
     paths:
       - 'src/**'
+      - '.github/workflows/housekeeping.yml'
 
 jobs:
   main:

--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -48,7 +48,7 @@ jobs:
             echo
             echo -e "\033[1;31mPlease fix the style guide and commit the result.\033[0m"
             echo
-            echo "You can use the following command to format your code at once."
+            echo "You can use the following command to format all files at once."
             echo
             echo "find src/ \\( -name \"*.hpp\" -o -name \"*.cpp\" -o -name \"*.hh\" -o -name \"*.cc\" -o -name \"*.h\" \\) \\"
             echo "              \\( -not -path \"src/gtest*\" -not -path \"src/mcnp/mcnp?/Source/*\" -not -path \"src/pyne*\" \\) \\"

--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -42,5 +42,15 @@ jobs:
             echo
             echo -e "\033[33mGit diff:\033[0m"
             git diff
+            echo
+            echo -e "\033[1;31mPlease fix the style guide and commit the result.\033[0m"
+            echo
+            echo "You can use the following command to format your code at once."
+            echo
+            echo "find src/ \\( -name \"*.hpp\" -o -name \"*.cpp\" -o -name \"*.hh\" -o -name \"*.cc\" -o -name \"*.h\" \\) \\"
+            echo "              \\( -not -path \"src/gtest*\" -not -path \"src/mcnp/mcnp?/Source/*\" -not -path \"src/pyne*\" \\)  \\"
+            echo "              -exec clang-format -style=file -i {} \\;"
+            echo 
+            echo "This command will automatically format your code according to the project's style guide."
             exit 1
           fi

--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -1,4 +1,4 @@
-name: Housekeeping checks
+name: Housekeeping Checks
 
 on:
   # allows us to run workflows manually
@@ -8,21 +8,22 @@ on:
       - develop
 
 jobs:
-  Housekeeping:
+  main:
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/svalinn/dagmc-ci-ubuntu-18.04-housekeeping:stable
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
 
+    steps:
       - name: Setup environment 
         run: |
           echo "REPO_SLUG=${GITHUB_REPOSITORY}" >> $GITHUB_ENV
           echo "PULL_REQUEST=$(echo  $GITHUB_REF | cut -d"/" -f3)" >> $GITHUB_ENV
-          mkdir /root/build_dir
-          ln -s $GITHUB_WORKSPACE /root/build_dir/DAGMC
-     
+
+      - name: Setup dependencies
+        run: |
+          sudo apt-get install -y clang-format
+
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
       - name: Housekeeping
         run: |
           cd $GITHUB_WORKSPACE
@@ -32,10 +33,14 @@ jobs:
               -exec clang-format -style=file -i {} \;
           clang_diffs=`git status --porcelain`
           if [ -z "${clang_diffs}" ]; then
-            echo "Style guide checker passed!"
+            echo -e "\033[32mStyle guide checker passed!\033[0m"
           else
-            echo "ERROR: Style guide checker failed. Please run clang-format."
-            echo "clang_diffs: ${clang_diffs}"
+            echo -e "\033[1;31mERROR: Style guide checker failed. Please run clang-format.\033[0m"
+            echo
+            echo -e "\033[33mClang diffs:\033[0m"
+            echo "${clang_diffs}"
+            echo
+            echo -e "\033[33mGit diff:\033[0m"
             git diff
             exit 1
           fi

--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -50,7 +50,7 @@ jobs:
             echo "You can use the following command to format your code at once."
             echo
             echo "find src/ \\( -name \"*.hpp\" -o -name \"*.cpp\" -o -name \"*.hh\" -o -name \"*.cc\" -o -name \"*.h\" \\) \\"
-            echo "              \\( -not -path \"src/gtest*\" -not -path \"src/mcnp/mcnp?/Source/*\" -not -path \"src/pyne*\" \\)  \\"
+            echo "              \\( -not -path \"src/gtest*\" -not -path \"src/mcnp/mcnp?/Source/*\" -not -path \"src/pyne*\" \\) \\"
             echo "              -exec clang-format -style=file -i {} \\;"
             echo 
             echo "This command will automatically format your code according to the project's style guide."

--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches:
       - develop
+    paths:
+      - 'src/**'
 
 jobs:
   main:

--- a/.github/workflows/windows_build_test.yml
+++ b/.github/workflows/windows_build_test.yml
@@ -76,7 +76,7 @@ jobs:
                 -DBUILD_SHARED_LIBS=ON \
                 -G"Visual Studio 16 2019"  \
                 -DCMAKE_INSTALL_PREFIX=../install_dir/ \
-                -DEIGEN3_DIR="${CONDA_LOC}" \
+                -DEIGEN3_DIR="${CONDA_LOC}/include/eigen3" \
                 -DHDF5_ROOT="${CONDA_LOC}" \
                 -DHDF5_hdf5_LIBRARY_RELEASE="${CONDA_LOC}/lib/libhdf5_hl.lib;${CONDA_LOC}/lib/libhdf5.lib;${CONDA_LOC}/lib/zlib.lib;${CONDA_LOC}/lib/libhdf5_cpp.lib" \
                 -DCMAKE_EXE_LINKER_FLAGS="/std:c++latest -DH5_BUILT_AS_DYNAMIC_LIB" \

--- a/.github/workflows/windows_build_test.yml
+++ b/.github/workflows/windows_build_test.yml
@@ -76,6 +76,7 @@ jobs:
                 -DBUILD_SHARED_LIBS=ON \
                 -G"Visual Studio 16 2019"  \
                 -DCMAKE_INSTALL_PREFIX=../install_dir/ \
+                -DEIGEN3_DIR="${CONDA_LOC}" \
                 -DHDF5_ROOT="${CONDA_LOC}" \
                 -DHDF5_hdf5_LIBRARY_RELEASE="${CONDA_LOC}/lib/libhdf5_hl.lib;${CONDA_LOC}/lib/libhdf5.lib;${CONDA_LOC}/lib/zlib.lib;${CONDA_LOC}/lib/libhdf5_cpp.lib" \
                 -DCMAKE_EXE_LINKER_FLAGS="/std:c++latest -DH5_BUILT_AS_DYNAMIC_LIB" \

--- a/CI/Dockerfile_1_housekeeping
+++ b/CI/Dockerfile_1_housekeeping
@@ -1,7 +1,0 @@
-ARG UBUNTU_VERSION=18.04
-ARG OWNER=svalinn
-ARG TAG=latest
-FROM ghcr.io/${OWNER}/dagmc-ci-ubuntu-${UBUNTU_VERSION}:$TAG
-
-RUN pip install sphinx; \
-    apt-get -y install clang-format

--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -12,6 +12,7 @@ Next version
   * Update hdf5 to v1.14.3 from v1.10.4 (#931 #933)
   * Ensure implicit complement handle is placed at the back of DAGMC volume indices (#935)
   * Update MOAB to 5.5.1 from 5.3.0 (#939 #940)
+  * Simplify Housekeeping Process for DAGMC (#943)
 
 v3.2.3
 ====================

--- a/src/dagmc/DagMC.hpp
+++ b/src/dagmc/DagMC.hpp
@@ -78,12 +78,10 @@ class DagMC {
         double overlap_tolerance = 0., double numerical_precision = .001,
         int verbosity = 1);
   // Deprecated Constructor
-  [
-      [deprecated("Replaced by DagMC(std::shared_ptr<Interface> mb_impl, ... "
-                  ")")]] DagMC(Interface* mb_impl,
-                               double overlap_tolerance = 0.,
-                               double numerical_precision = .001,
-                               int verbosity = 1);
+  [[deprecated(
+      "Replaced by DagMC(std::shared_ptr<Interface> mb_impl, ... "
+      ")")]] DagMC(Interface* mb_impl, double overlap_tolerance = 0.,
+                   double numerical_precision = .001, int verbosity = 1);
   // Destructor
   ~DagMC();
 

--- a/src/dagmc/tools/ray_fire_test.cpp
+++ b/src/dagmc/tools/ray_fire_test.cpp
@@ -31,7 +31,7 @@ extern "C" int getrusage(int, struct rusage*);
 using namespace moab;
 
 // define following macro for verbose debugging of random ray generation
-//#define DEBUG
+// #define DEBUG
 #if !defined(_MSC_VER) && !defined(__MINGW32__)
 void get_time_mem(double& tot_time, double& user_time, double& sys_time,
                   double& tot_mem);

--- a/src/geant4/DagSolid.cc
+++ b/src/geant4/DagSolid.cc
@@ -69,7 +69,7 @@ using namespace moab;
 
 #define plot true
 
-//#define G4SPECSDEBUG 1
+// #define G4SPECSDEBUG 1
 ///////////////////////////////////////////////////////////////////////////////
 //
 // Standard contructor has blank name and defines no facets.

--- a/src/geant4/app/include/ExN01UserScoreWriter.hh
+++ b/src/geant4/app/include/ExN01UserScoreWriter.hh
@@ -1,7 +1,6 @@
 #ifndef ExN01UserScoreWriter_h
 #define ExN01UserScoreWriter_h 1
 
-// #include "MBCore.hpp"
 #include <vector>
 
 #include "G4VScoreWriter.hh"

--- a/src/geant4/app/include/ExN01UserScoreWriter.hh
+++ b/src/geant4/app/include/ExN01UserScoreWriter.hh
@@ -1,7 +1,7 @@
 #ifndef ExN01UserScoreWriter_h
 #define ExN01UserScoreWriter_h 1
 
-//#include "MBCore.hpp"
+// #include "MBCore.hpp"
 #include <vector>
 
 #include "G4VScoreWriter.hh"

--- a/src/tally/CellTally.cpp
+++ b/src/tally/CellTally.cpp
@@ -52,9 +52,9 @@ void CellTally::write_data(double num_histories) {
 
   std::cout << "cell id = " << cell_id << std::endl;
   std::cout << "type = "
-            << (expected_type == TallyEvent::COLLISION
-                    ? "collision "
-                    : expected_type == TallyEvent::TRACK ? "track " : "none");
+            << (expected_type == TallyEvent::COLLISION ? "collision "
+                : expected_type == TallyEvent::TRACK   ? "track "
+                                                       : "none");
   std::cout << std::endl;
 
   std::cout << "volume = " << cell_volume << std::endl << std::endl;


### PR DESCRIPTION
# Description
This PR simplifies the housekeeping process for DAGMC by removing the dependency on a Docker container and installing `clang-format` directly through the workflow.

# Related Issues
Housekeeping of DAGMC is very complicated now. And it seems in the docker file, we are just installing clang-format through apt. Also, I noticed the docker publish file is changed and there is no way to rebuild a new docker image for housekeeping.

# Changes
- Removed the use of a Docker container for housekeeping.
- Installed `clang-format` directly through the workflow.

