### PR TITLE
Allow Double Down v1.1.0 Installation in Dockerfile

### DIFF
--- a/.github/actions/upstream-test/action.yml
+++ b/.github/actions/upstream-test/action.yml
@@ -24,7 +24,7 @@ inputs:
   moab_version:
     description: Version of MOAB
     required: false
-    default: 5.3.0
+    default: 5.5.1
   double_down_version:
     description: Version of Double Down
     required: false

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -34,7 +34,6 @@ jobs:
           11.1.2
         ]
         double_down_version : [
-          off,
           v1.1.0,
         ]
 
@@ -115,7 +114,6 @@ jobs:
           11.1.2
         ]
         double_down_version : [
-          off,
           v1.1.0,
         ]
 

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -30,10 +30,12 @@ jobs:
           5.5.1,
         ]
         geant4_version : [
+          off,
           10.7.4,
           11.1.2
         ]
         double_down_version : [
+          off,
           v1.1.0,
         ]
 
@@ -110,10 +112,12 @@ jobs:
           5.5.1,
         ]
         geant4_version : [
+          off,
           10.7.4,
           11.1.2
         ]
         double_down_version : [
+          off,
           v1.1.0,
         ]
 

--- a/CI/Dockerfile
+++ b/CI/Dockerfile
@@ -39,7 +39,6 @@ RUN apt-get update --yes && \
         g++ \
         gcc \
         gfortran \
-        libhdf5-dev \
         libtool \
         libeigen3-dev\
         python3 \

--- a/cmake/DAGMC_macros.cmake
+++ b/cmake/DAGMC_macros.cmake
@@ -90,7 +90,7 @@ macro (dagmc_setup_options)
 
 if (DOUBLE_DOWN)
   find_package(DOUBLE_DOWN REQUIRED)
-  if (DOUBLE_DOWN_VERSION VERSION_LESS 1.1.0)
+  if (dd_VERSION VERSION_LESS 1.1.0)
     message(FATAL_ERROR "Discovered Double Down Version: ${DOUBLE_DOWN_VERSION}. \
     Please update Double Down to version 1.1.0 or greater.")
   endif()

--- a/cmake/FindDOUBLE_DOWN.cmake
+++ b/cmake/FindDOUBLE_DOWN.cmake
@@ -6,6 +6,7 @@
 #  dd_INCLUDE_DIRS - include directories for installed dd headers
 #  dd_LIBRARY_DIRS - location of installed dd libraries
 #  dd_LIBRARIES    - set of libraries installed with dd, use to link applications against dd
+#  dd_VERSION      - version of installed dd
 
 find_path(dd_CMAKE_CONFIG NAMES ddConfig.cmake
           HINTS ${dd_ROOT} $ENV{dd_ROOT}
@@ -14,6 +15,12 @@ find_path(dd_CMAKE_CONFIG NAMES ddConfig.cmake
           PATH_SUFFIXES lib Lib cmake lib/cmake/ lib/cmake/dd
           NO_DEFAULT_PATH)
 
-message(STATUS "Found dd in ${dd_CMAKE_CONFIG}")
-
-include(${dd_CMAKE_CONFIG}/ddConfig.cmake)
+if (dd_CMAKE_CONFIG)
+    message(STATUS "Found dd in ${dd_CMAKE_CONFIG}")
+    include(${dd_CMAKE_CONFIG}/ddConfig.cmake)
+    include(${dd_CMAKE_CONFIG}/ddConfigVersion.cmake)
+    set(dd_VERSION ${PACKAGE_VERSION})
+    message(STATUS "Found dd version ${dd_VERSION}")
+else()
+    message(FATAL_ERROR "Could not find dd")
+endif()

--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -14,7 +14,7 @@ Next version
   * Update MOAB to 5.5.1 from 5.3.0 (#939 #940)
   * Update README regarding OpenMC (#938)
   * Simplify Housekeeping Process for DAGMC (#943)
-  * Allow Double Down v1.1.0 Installation in Dockerfile (#929)
+  * Allow Double Down v1.1.0 Installation in Dockerfile (#929 #944)
 
 v3.2.3
 ====================


### PR DESCRIPTION
Trying to fix the broken Docker build