### PR TITLE
Remove spaces from image name

### DIFF
--- a/.github/actions/upstream-test/action.yml
+++ b/.github/actions/upstream-test/action.yml
@@ -44,13 +44,7 @@ runs:
         uses: firehed/multistage-docker-build-action@v1
         with:
           repository: >
-            ghcr.io/${{ github.repository_owner }}/
-            dagmc-ci-ubuntu-${{ inputs.ubuntu_version }}
-            -${{ inputs.compiler}}
-            -hdf5_${{ inputs.hdf5_version}}
-            -moab_${{ inputs.moab_version }}
-            -geant4_${{ inputs.geant4_version }}
-            -double_down_${{ inputs.double_down_version }}
+            ghcr.io/${{ github.repository_owner }}/dagmc-ci-ubuntu-${{ inputs.ubuntu_version }}-${{ inputs.compiler}}-hdf5_${{ inputs.hdf5_version}}-moab_${{ inputs.moab_version }}-geant4_${{ inputs.geant4_version }}-double_down_${{ inputs.double_down_version }}
           stages: base, external_deps, hdf5, moab, dagmc
           server-stage: dagmc_test
           quiet: false

--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -14,7 +14,7 @@ Next version
   * Update MOAB to 5.5.1 from 5.3.0 (#939 #940)
   * Update README regarding OpenMC (#938)
   * Simplify Housekeeping Process for DAGMC (#943)
-  * Allow Double Down v1.1.0 Installation in Dockerfile (#929 #944)
+  * Allow Double Down v1.1.0 Installation in Dockerfile (#929 #944 #948)
   * Inline documentation improvements (#945)
 
 v3.2.3


### PR DESCRIPTION
## Description
Removes extra spaces from the image used for advisory testing

## Motivation and Context
Reformatting of GitHub action was incorrect and introduced illegal spaces.
