### PR TITLE
Update Linux build test to use updated docker images

### DIFF
--- a/.github/actions/upstream-test/action.yml
+++ b/.github/actions/upstream-test/action.yml
@@ -44,13 +44,21 @@ runs:
         uses: firehed/multistage-docker-build-action@v1
         with:
           repository: >
-            ghcr.io/${{ github.repository_owner }}/
-            dagmc-ci-ubuntu-${{ inputs.ubuntu_version }}
-            -${{ inputs.compiler}}
-            -hdf5_${{ inputs.hdf5_version}}
-            -moab_${{ inputs.moab_version }}
-            -geant4_${{ inputs.geant4_version }}
-            -double_down_${{ inputs.double_down_version }}
+            ghcr.io/${{
+              github.repository_owner
+            }}/dagmc-ci-ubuntu-${{
+              inputs.ubuntu_version
+            }}-${{
+              inputs.compiler
+            }}-hdf5_${{
+              inputs.hdf5_version
+            }}-moab_${{
+              inputs.moab_version
+            }}-geant4_${{
+              inputs.geant4_version
+            }}-double_down_${{
+              inputs.double_down_version
+            }}
           stages: base, external_deps, hdf5, moab, dagmc
           server-stage: dagmc_test
           quiet: false

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -1,4 +1,4 @@
-name: Build & Publish docker image for DAGMC-CI
+name: Build & Publish docker image
 
 on:
   # allows us to run workflows manually

--- a/.github/workflows/linux_build_test.yml
+++ b/.github/workflows/linux_build_test.yml
@@ -60,8 +60,7 @@ jobs:
         ]
 
     container:
-      image: >
-        ghcr.io/svalinn/dagmc-ci-ubuntu-${{ matrix.ubuntu_version }}-${{ matrix.compiler }}-hdf5_${{ matrix.hdf5_version }}-moab_${{ matrix.moab_version }}-geant4_${{ matrix.geant4_version }}-double_down_${{ matrix.double_down_version }}/moab:latest
+      image: ghcr.io/svalinn/dagmc-ci-ubuntu-${{ matrix.ubuntu_version }}-${{ matrix.compiler }}-hdf5_${{ matrix.hdf5_version }}-moab_${{ matrix.moab_version }}-geant4_${{ matrix.geant4_version }}-double_down_${{ matrix.double_down_version }}/moab:latest
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/linux_build_test.yml
+++ b/.github/workflows/linux_build_test.yml
@@ -59,8 +59,18 @@ jobs:
           v1.1.0,
         ]
 
+    env:
+      container_image: |
+        ghcr.io/svalinn/dagmc-ci-ubuntu-
+        ${{ matrix.ubuntu_version }}-
+        ${{ matrix.compiler }}-
+        hdf5_${{ matrix.hdf5_version }}-
+        moab_${{ matrix.moab_version }}-
+        geant4_${{ matrix.geant4_version }}-
+        double_down_${{ matrix.double_down_version }}/moab:latest
+
     container:
-      image: ghcr.io/svalinn/dagmc-ci-ubuntu-${{ matrix.ubuntu_version }}-${{ matrix.compiler }}-hdf5_${{ matrix.hdf5_version }}-moab_${{ matrix.moab_version }}-geant4_${{ matrix.geant4_version }}-double_down_${{ matrix.double_down_version }}/moab:latest
+      image: ${{ env.container_image }}
 
     steps:
       - name: Checkout repository
@@ -92,4 +102,5 @@ jobs:
 
       - name: Testing DAGMC
         run: |
+          cd ${GITHUB_WORKSPACE}/build
           PATH=${install_dir}/dagmc/bin:${PATH} CTEST_OUTPUT_ON_FAILURE=1 make test

--- a/.github/workflows/linux_build_test.yml
+++ b/.github/workflows/linux_build_test.yml
@@ -1,4 +1,4 @@
-name: Linux Build/Test for PR and collaborator push
+name: Linux Build/Test
 
 on:
   # allows us to run workflows manually
@@ -36,7 +36,7 @@ jobs:
 
     strategy:
       matrix:
-        ubuntu_versions : [
+        ubuntu_version : [
           20.04,
           22.04,
         ]
@@ -44,23 +44,36 @@ jobs:
           gcc,
           clang,
         ]
-        hdf5_versions : [
+        hdf5_version : [
           1.14.3,
         ]
-        moab_versions : [
+        moab_version : [
           5.4.1,
           5.5.1,
         ]
-        double_down : [
-          OFF,
-        ]
-        geant_version : [
+        geant4_version : [
           10.7.4,
           11.1.2
         ]
+        double_down_version : [
+          v1.1.0,
+        ]
 
     container:
-      image: ghcr.io/svalinn/dagmc-ci-ubuntu-${{ matrix.ubuntu_versions }}-${{ matrix.compiler}}-geant4_${{ matrix.geant_version }}-hdf5_${{ matrix.hdf5_versions}}-moab_${{ matrix.moab_versions }}/moab:latest
+      image: >
+        ghcr.io/svalinn/dagmc-ci-ubuntu-${{ 
+          matrix.ubuntu_version
+        }}-${{ 
+          matrix.compiler
+        }}-hdf5_${{ 
+          matrix.hdf5_version
+        }}-moab_${{ 
+          matrix.moab_version 
+        }}-geant4_${{ 
+          matrix.geant4_version 
+        }}-double_down_${{ 
+          matrix.double_down_version 
+        }}:latest
 
     steps:
       - name: Checkout repository
@@ -70,12 +83,11 @@ jobs:
 
       - name: Building DAGMC
         run: |
-          ln -s $GITHUB_WORKSPACE /root/build_dir/DAGMC
-          mkdir -p ./build
-          cd ./build
-          git config --global --add safe.directory $GITHUB_WORKSPACE
-          cmake ../ -DMOAB_DIR=${moab_install_dir} \
-              -DBUILD_GEANT4=ON \
+          mkdir -p build
+          cd build
+          cmake ../ \
+              -DMOAB_DIR=${moab_install_dir} \
+              -DBUILD_GEANT4=$([ "${GEANT4_VERSION}" != "off" ] && echo "ON" || echo "OFF") \
               -DGEANT4_DIR=${geant4_install_dir} \
               -DBUILD_CI_TESTS=ON \
               -DBUILD_MW_REG_TESTS=OFF \
@@ -84,14 +96,12 @@ jobs:
               -DCMAKE_C_COMPILER=${CC} \
               -DCMAKE_CXX_COMPILER=${CXX} \
               -DCMAKE_Fortran_COMPILER=gfortran \
-              -DCMAKE_INSTALL_PREFIX=${install_dir}/dagmc \
-              -DDOUBLE_DOWN=${double_down} \
-              -DCMAKE_CXX_FLAGS="-Werror=reorder" \
-              -Ddd_ROOT=${double_down_install_dir} && \
-          make -j2 && \
+              -DCMAKE_INSTALL_PREFIX=${dagmc_install_dir} \
+              -DDOUBLE_DOWN=$([ "${DOUBLE_DOWN_VERSION}" != "off" ] && echo "ON" || echo "OFF") \
+              -Ddd_ROOT=${double_down_install_dir}
+          make -j${CI_JOBS}
           make install
 
       - name: Testing DAGMC
         run: |
-          cd $GITHUB_WORKSPACE/build
-          PATH=${install_dir}/dagmc/bin:${PATH} CTEST_OUTPUT_ON_FAILURE=1 make test
+          PATH=${dagmc_install_dir}/bin:${PATH} CTEST_OUTPUT_ON_FAILURE=1 make test

--- a/.github/workflows/linux_build_test.yml
+++ b/.github/workflows/linux_build_test.yml
@@ -70,6 +70,7 @@ jobs:
 
       - name: Building DAGMC
         run: |
+          git config --global --add safe.directory ${GITHUB_WORKSPACE}
           mkdir -p build
           cd build
           cmake ../ \

--- a/.github/workflows/linux_build_test.yml
+++ b/.github/workflows/linux_build_test.yml
@@ -73,7 +73,7 @@ jobs:
           matrix.geant4_version 
         }}-double_down_${{ 
           matrix.double_down_version 
-        }}:latest
+        }}/moab:latest
 
     steps:
       - name: Checkout repository
@@ -96,7 +96,7 @@ jobs:
               -DCMAKE_C_COMPILER=${CC} \
               -DCMAKE_CXX_COMPILER=${CXX} \
               -DCMAKE_Fortran_COMPILER=gfortran \
-              -DCMAKE_INSTALL_PREFIX=${dagmc_install_dir} \
+              -DCMAKE_INSTALL_PREFIX=${install_dir}/dagmc \
               -DDOUBLE_DOWN=$([ "${DOUBLE_DOWN_VERSION}" != "off" ] && echo "ON" || echo "OFF") \
               -Ddd_ROOT=${double_down_install_dir}
           make -j${CI_JOBS}
@@ -104,4 +104,4 @@ jobs:
 
       - name: Testing DAGMC
         run: |
-          PATH=${dagmc_install_dir}/bin:${PATH} CTEST_OUTPUT_ON_FAILURE=1 make test
+          PATH=${install_dir}/dagmc/bin:${PATH} CTEST_OUTPUT_ON_FAILURE=1 make test

--- a/.github/workflows/linux_build_test.yml
+++ b/.github/workflows/linux_build_test.yml
@@ -61,19 +61,7 @@ jobs:
 
     container:
       image: >
-        ghcr.io/svalinn/dagmc-ci-ubuntu-${{ 
-          matrix.ubuntu_version
-        }}-${{ 
-          matrix.compiler
-        }}-hdf5_${{ 
-          matrix.hdf5_version
-        }}-moab_${{ 
-          matrix.moab_version 
-        }}-geant4_${{ 
-          matrix.geant4_version 
-        }}-double_down_${{ 
-          matrix.double_down_version 
-        }}/moab:latest
+        ghcr.io/svalinn/dagmc-ci-ubuntu-${{ matrix.ubuntu_version }}-${{ matrix.compiler }}-hdf5_${{ matrix.hdf5_version }}-moab_${{ matrix.moab_version }}-geant4_${{ matrix.geant4_version }}-double_down_${{ matrix.double_down_version }}/moab:latest
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/linux_build_test.yml
+++ b/.github/workflows/linux_build_test.yml
@@ -56,22 +56,23 @@ jobs:
           11.1.2
         ]
         double_down_version : [
+          off,
           v1.1.0,
         ]
 
     container:
-      image: ghcr.io/svalinn/dagmc-ci-ubuntu-${{ 
-                matrix.ubuntu_version 
-              }}-${{ 
-                matrix.compiler 
-              }}-hdf5_${{ 
-                matrix.hdf5_version 
-              }}-moab_${{ 
-                matrix.moab_version 
-              }}-geant4_${{ 
-                matrix.geant4_version 
-              }}-double_down_${{ 
-                matrix.double_down_version 
+      image: ghcr.io/svalinn/dagmc-ci-ubuntu-${{
+                matrix.ubuntu_version
+              }}-${{
+                matrix.compiler
+              }}-hdf5_${{
+                matrix.hdf5_version
+              }}-moab_${{
+                matrix.moab_version
+              }}-geant4_${{
+                matrix.geant4_version
+              }}-double_down_${{
+                matrix.double_down_version
               }}/moab:latest
 
     steps:

--- a/.github/workflows/linux_build_test.yml
+++ b/.github/workflows/linux_build_test.yml
@@ -59,18 +59,8 @@ jobs:
           v1.1.0,
         ]
 
-    env:
-      container_image: |
-        ghcr.io/svalinn/dagmc-ci-ubuntu-
-        ${{ matrix.ubuntu_version }}-
-        ${{ matrix.compiler }}-
-        hdf5_${{ matrix.hdf5_version }}-
-        moab_${{ matrix.moab_version }}-
-        geant4_${{ matrix.geant4_version }}-
-        double_down_${{ matrix.double_down_version }}/moab:latest
-
     container:
-      image: ${{ env.container_image }}
+      image: ghcr.io/svalinn/dagmc-ci-ubuntu-${{ matrix.ubuntu_version }}-${{ matrix.compiler }}-hdf5_${{ matrix.hdf5_version }}-moab_${{ matrix.moab_version }}-geant4_${{ matrix.geant4_version }}-double_down_${{ matrix.double_down_version }}/moab:latest
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/linux_build_test.yml
+++ b/.github/workflows/linux_build_test.yml
@@ -60,7 +60,19 @@ jobs:
         ]
 
     container:
-      image: ghcr.io/svalinn/dagmc-ci-ubuntu-${{ matrix.ubuntu_version }}-${{ matrix.compiler }}-hdf5_${{ matrix.hdf5_version }}-moab_${{ matrix.moab_version }}-geant4_${{ matrix.geant4_version }}-double_down_${{ matrix.double_down_version }}/moab:latest
+      image: ghcr.io/svalinn/dagmc-ci-ubuntu-${{ 
+                matrix.ubuntu_version 
+              }}-${{ 
+                matrix.compiler 
+              }}-hdf5_${{ 
+                matrix.hdf5_version 
+              }}-moab_${{ 
+                matrix.moab_version 
+              }}-geant4_${{ 
+                matrix.geant4_version 
+              }}-double_down_${{ 
+                matrix.double_down_version 
+              }}/moab:latest
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/linux_build_test.yml
+++ b/.github/workflows/linux_build_test.yml
@@ -88,7 +88,7 @@ jobs:
           cd build
           cmake ../ \
               -DMOAB_DIR=${moab_install_dir} \
-              -DBUILD_GEANT4=$([ "${GEANT4_VERSION}" != "off" ] && echo "ON" || echo "OFF") \
+              -DBUILD_GEANT4=$([ "${{ matrix.geant4_version }}" != "off" ] && echo "ON" || echo "OFF") \
               -DGEANT4_DIR=${geant4_install_dir} \
               -DBUILD_CI_TESTS=ON \
               -DBUILD_MW_REG_TESTS=OFF \
@@ -98,7 +98,7 @@ jobs:
               -DCMAKE_CXX_COMPILER=${CXX} \
               -DCMAKE_Fortran_COMPILER=gfortran \
               -DCMAKE_INSTALL_PREFIX=${install_dir}/dagmc \
-              -DDOUBLE_DOWN=$([ "${DOUBLE_DOWN_VERSION}" != "off" ] && echo "ON" || echo "OFF") \
+              -DDOUBLE_DOWN=$([ "${{ matrix.double_down_version }}" != "off" ] && echo "ON" || echo "OFF") \
               -Ddd_ROOT=${double_down_install_dir}
           make -j${CI_JOBS}
           make install

--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -14,7 +14,7 @@ Next version
   * Update MOAB to 5.5.1 from 5.3.0 (#939 #940)
   * Update README regarding OpenMC (#938)
   * Simplify Housekeeping Process for DAGMC (#943)
-  * Allow Double Down v1.1.0 Installation in Dockerfile (#929 #944)
+  * Allow Double Down v1.1.0 Installation in Dockerfile (#929 #944 #949)
   * Inline documentation improvements (#945)
 
 v3.2.3


### PR DESCRIPTION
Update `linux_build_tect.yml` to use the updated Docker CI images