### PR TITLE
add more info to Cmake error msg

### DIFF
--- a/cmake/DAGMC_macros.cmake
+++ b/cmake/DAGMC_macros.cmake
@@ -15,7 +15,7 @@ macro (dagmc_setup_build)
   if (NOT CMAKE_BUILD_TYPE STREQUAL "Release" AND
       NOT CMAKE_BUILD_TYPE STREQUAL "Debug" AND
       NOT CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
-    message(FATAL_ERROR "Specified CMAKE_BUILD_TYPE is invalid; valid options are Release, Debug, RelWithDebInfo")
+    message(FATAL_ERROR "Specified CMAKE_BUILD_TYPE ${CMAKE_BUILD_TYPE} is invalid; valid options are Release, Debug, RelWithDebInfo")
   endif ()
   string(TOUPPER ${CMAKE_BUILD_TYPE} CMAKE_BUILD_TYPE_UPPER)
   message(STATUS "CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}")

--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -18,7 +18,7 @@ Next version
   * Inline documentation improvements (#945)
   * Streamline dependencies of docker CI images (#951 #952)
   * Update github actions to newer versions as necessary (#958)
-  * CMake error message upddate ()
+  * CMake error message update (#960)
 
 v3.2.3
 ====================

--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -18,6 +18,7 @@ Next version
   * Inline documentation improvements (#945)
   * Streamline dependencies of docker CI images (#951 #952)
   * Update github actions to newer versions as necessary (#958)
+  * CMake error message upddate ()
 
 v3.2.3
 ====================


### PR DESCRIPTION
## Description
Provide more feedback when CMAKE_BUILD_TYPE fatal error occurs

## Motivation and Context
In some build configurations, CMake fails with a fatal error about the CMAKE_BUILD_TYPE, but doesn't indicate what build type has been specified.  

## Changes
This adds the specified build type to the error message.

