### PR TITLE
Adding additional output during CMake configuration when double down …

### DIFF
--- a/cmake/DAGMC_macros.cmake
+++ b/cmake/DAGMC_macros.cmake
@@ -89,11 +89,13 @@ macro (dagmc_setup_options)
   endif()
 
 if (DOUBLE_DOWN)
+  message(STATUS "DOUBLE_DOWN has been enabled for ray tracing. Searching for package...")
   find_package(DOUBLE_DOWN REQUIRED)
   if (dd_VERSION VERSION_LESS 1.1.0)
     message(FATAL_ERROR "Discovered Double Down Version: ${DOUBLE_DOWN_VERSION}. \
     Please update Double Down to version 1.1.0 or greater.")
   endif()
+  message(STATUS "Found DOUBLE_DOWN.")
 endif()
 
 

--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -9,6 +9,7 @@ Next version
 
 **Changed:**
 
+  * Adding info messages to CMake output for double down (#962)
   * Update hdf5 to v1.14.3 from v1.10.4 (#931 #933)
   * Ensure implicit complement handle is placed at the back of DAGMC volume indices (#935)
   * Update MOAB to 5.5.1 from 5.3.0 (#939 #940)


### PR DESCRIPTION
## Description
Adds some informational messages when double down is enabled in DAGMC for clarity.

## Motivation and Context
Motivated by desire for clarity on whether or not double down will be enabled in the DAGMC build.