### PR TITLE
Update build instructions for DAGMC dependencies

### DIFF
--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -20,6 +20,7 @@ Next version
   * Streamline dependencies of docker CI images (#951 #952)
   * Update github actions to newer versions as necessary (#958)
   * CMake error message update (#960)
+  * Updated documentation to build dependencies ()
 
 v3.2.3
 ====================

--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -20,7 +20,7 @@ Next version
   * Streamline dependencies of docker CI images (#951 #952)
   * Update github actions to newer versions as necessary (#958)
   * CMake error message update (#960)
-  * Updated documentation to build dependencies ()
+  * Updated documentation to build dependencies (#963)
 
 v3.2.3
 ====================

--- a/doc/install/dependencies.rst
+++ b/doc/install/dependencies.rst
@@ -73,7 +73,9 @@ Debian linux users can install the latest HDF5 release with:
 Redhat linux users can do likewise with:
 ::
 
-    $ sudo yum install libhdf5-dev
+    $ sudo yum install -y epel-release
+    $ sudo yum config-manager --enable epel
+    $ sudo yum install hdf5-devel
 
 MOAB installation
 ~~~~~~~~~~~~~~~~~

--- a/doc/install/dependencies.rst
+++ b/doc/install/dependencies.rst
@@ -47,18 +47,17 @@ Source installation
 
 The tarball containing the HDF5 source code can also be downloaded from the
 `HDF5 website <HDF5_>`_. Note that if you choose this option, we recommend you
-obtain HDF5 version 1.8.13 instead of the newest version. The following commands
+obtain HDF5 version 1.14.3 instead of the newest version. The following commands
 can be used to install HDF5 from source.
 ::
 
-    $ mkdir -p $HOME/dagmc_bld/HDF5/bld
+    $ mkdir -p $HOME/dagmc_bld/HDF5/build
     $ cd $HOME/dagmc_bld/HDF5
-    $ wget https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.8/hdf5-1.8.13/src/hdf5-1.8.13.tar.gz
-    $ tar -xzvf hdf5-1.8.13.tar.gz
-    $ ln -s hdf5-1.8.13 src
-    $ cd bld
-    $ ../src/configure --enable-shared \
-                       --prefix=$HOME/dagmc_bld/HDF5
+    $ git clone -b 1.14.3 --depth 1 https://github.com/HDFGroup/hdf5.git && \
+    $ cd build
+    $ cmake ../hdf5 \
+        -DCMAKE_INSTALL_PREFIX=$HOME/dagmc_bld/HDF5 \
+        -DBUILD_SHARED_LIBS=ON
     $ make
     $ make check
     $ make install
@@ -79,7 +78,7 @@ Redhat linux users can do likewise with:
 MOAB installation
 ~~~~~~~~~~~~~~~~~
 
-As of DAGMC version 3.2, a MOAB version between 5.1.0 and 5.3.0 is required. The following
+As of DAGMC version 3.2.3, MOAB version 5.5.1 is preferred. The following
 commands can be used to download MOAB from its `source repository <MOAB_>`_ and
 set it up for building.
 ::
@@ -87,20 +86,20 @@ set it up for building.
     $ cd $HOME/dagmc_bld
     $ mkdir -p MOAB/bld
     $ cd MOAB
-    $ git clone --depth 1 -b 5.3.0 https://bitbucket.org/fathomteam/moab
+    $ git clone --depth 1 -b 5.5.1 https://bitbucket.org/fathomteam/moab
 
 To build moab using the default packages:
 ::
 
     $ cd bld
-    $ cmake ../moab -DENABLE_HDF5=ON -DHDF5_ROOT=${hdf5_install_dir} \
+    $ cmake ../moab -DENABLE_HDF5=ON -DHDF5_ROOT=$HOME/dagmc_bld/HDF5 \
               -DCMAKE_BUILD_TYPE=Release \
               -DENABLE_PYMOAB=ON \
               -DENABLE_BLASLAPACK=OFF \
               -DENABLE_FORTRAN=OFF \
               -DCMAKE_INSTALL_PREFIX=$HOME/dagmc_bld/MOAB \
               -DBUILD_SHARED_LIBS=ON \
-              -DCMAKE_INSTALL_RPATH=${hdf5_install_dir}/lib:${moab_install_dir}/lib
+              -DCMAKE_INSTALL_RPATH=$HOME/dagmc_bld/HDF5/lib:$HOME/dagmc_bld/MOAB/lib
     $ make
     $ make check
     $ make install
@@ -128,5 +127,5 @@ If you have installed the dependencies correctly, you are now ready to
 `install DAGMC <dagmc.html>`_.
 
 ..  _HDF5: http://www.hdfgroup.org/HDF5
-..  _MOAB: http://press3.mcs.anl.gov/sigma/moab-library
+..  _MOAB: http://bitbucket.org/fathomteam/moab
 ..  _Eigen3: http://eigen.tuxfamily.org/index.php

--- a/doc/install/dependencies.rst
+++ b/doc/install/dependencies.rst
@@ -127,5 +127,5 @@ If you have installed the dependencies correctly, you are now ready to
 `install DAGMC <dagmc.html>`_.
 
 ..  _HDF5: http://www.hdfgroup.org/HDF5
-..  _MOAB: http://bitbucket.org/fathomteam/moab
+..  _MOAB: https://sigma.mcs.anl.gov/moab-library/
 ..  _Eigen3: http://eigen.tuxfamily.org/index.php


### PR DESCRIPTION
The instructions for building DAGMC were extremely out of date.

This updates them, and we will try to publish new ones.