### PR TITLE
Adding moab download if not found via fetch content

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,12 +59,12 @@ if(BUILD_MCNP5 OR BUILD_MCNP6)
   enable_language(Fortran)
 endif()
 
-include(FetchContent)
 
 # Try to find MOAB
 # find_package(MOAB QUIET)
 
 if (NOT MOAB_FOUND)
+  include(FetchContent)
   message(STATUS "MOAB not found. Fetching MOAB...")
   FetchContent_Declare(
     moab

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ if (NOT MOAB_FOUND)
   FetchContent_Declare(
     moab
     GIT_REPOSITORY https://bitbucket.org/fathomteam/moab.git
-    GIT BRANCH master
+    GIT_BRANCH master
     # GIT_TAG        5.5.1
   )
   FetchContent_MakeAvailable(moab)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,14 +66,19 @@ if (NOT MOAB_FOUND)
   message(STATUS "MOAB not found. Fetching MOAB...")
   FetchContent_Declare(
     moab
-    GIT_REPOSITORY https://bitbucket.org/fathomteam/moab.git
-    GIT_BRANCH master
+    # making use of branch on fork as it has a one line change that help this fetch command work
+    # GIT_REPOSITORY https://bitbucket.org/fathomteam/moab.git
+    # GIT_BRANCH master
     # GIT_TAG        5.5.1
+    GIT_REPOSITORY https://bitbucket.org/moab-fork/moab.git
+    GIT_TAG Jonathan-Shimwell/adding-current-to-dir
+    GIT_SHALLOW TRUE
   )
+  
   FetchContent_MakeAvailable(moab)
-  add_subdirectory(${moab_SOURCE_DIR} ${moab_BINARY_DIR}) # MOAB repository is not properly configured for a FetchContent build
+  add_subdirectory(${moab_SOURCE_DIR} ${moab_BINARY_DIR}/moab-build)
   # Set MOAB_DIR to the fetched content
-  set(MOAB_DIR ${moab_SOURCE_DIR})
+  set(MOAB_DIR ${moab_BINARY_DIR}/moab-build)
   find_package(MOAB REQUIRED)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(DAGMC)
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.16 FATAL_ERROR)
 enable_language(CXX)
 
 # Set DAGMC version
@@ -59,7 +59,26 @@ if(BUILD_MCNP5 OR BUILD_MCNP6)
   enable_language(Fortran)
 endif()
 
-find_package(MOAB REQUIRED)
+include(FetchContent)
+
+# Try to find MOAB
+# find_package(MOAB QUIET)
+
+if (NOT MOAB_FOUND)
+  message(STATUS "MOAB not found. Fetching MOAB...")
+  FetchContent_Declare(
+    moab
+    GIT_REPOSITORY https://bitbucket.org/fathomteam/moab.git
+    GIT BRANCH master
+    # GIT_TAG        5.5.1
+  )
+  FetchContent_MakeAvailable(moab)
+  add_subdirectory(${moab_SOURCE_DIR} ${moab_BINARY_DIR}) # MOAB repository is not properly configured for a FetchContent build
+  # Set MOAB_DIR to the fetched content
+  set(MOAB_DIR ${moab_SOURCE_DIR})
+  find_package(MOAB REQUIRED)
+endif()
+
 find_package(OpenMP)
 
 dagmc_setup_flags()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,9 +59,7 @@ if(BUILD_MCNP5 OR BUILD_MCNP6)
   enable_language(Fortran)
 endif()
 
-
-# Try to find MOAB
-# find_package(MOAB QUIET)
+# find_package(MOAB REQUIRED)
 
 if (NOT MOAB_FOUND)
   include(FetchContent)


### PR DESCRIPTION
## Description
To help with [this](https://github.com/openmc-dev/openmc/pull/3193) PR on the openmc repo we would need DAGMC to fetch MOAB if it is not automatically found. Just making this PR to show the idea, this won't currently work as I think changes in MOAB are needed

## Motivation and Context
This could ultimately allow openmc to be installed with dagmc without the user having to specify dirs for moab and dagmc and install them prior to the openmc compile.

## Changes
changes to the cmakelists.txt

## Behavior
current: if moab is not found cmake command terminals
with this PR: if moab not found moab gets downloaded

## TODO
## Changelog file
All pull requests are required to update the [CHANGELOG](doc/CHANGELOG.rst) file with the PR.  Your update can take different forms including:

* creating a new entry describing your change, including a reference to this pull request number
* adding a reference to your pull request number to an exist entry if that entry can include your changes