### PR TITLE
updated cmake min version to 3.18

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(DAGMC)
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.18)
 enable_language(CXX)
 
 # Set DAGMC version

--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -21,6 +21,7 @@ Next version
   * Update github actions to newer versions as necessary (#958)
   * CMake error message update (#960)
   * Updated documentation to build dependencies (#963)
+  * Updated CMake version required to 3.18 (#970)
 
 v3.2.3
 ====================


### PR DESCRIPTION
## Description
This tiny PR attempts to update the minimum version of CMake required to compile DAGMC.

I believe this would be useful for two other PRs where @ahnaf-tahmid-chowdhury and @bam241 have both been keen to update the version of CMake.
#969 
#966 


## Motivation and Context
Why is this change required? What problem does it solve?
Packaging issues solved

## Changes
What kind of change does this PR introduce? (Bug fix, feature, documentation update...)
Update to Cmake version used

## Behavior
What is the current behavior? What is the new behavior?
Compile with cmake 3.1 or above -> compile with cmake 3.18 or above

## Other Information
Other relevant information to this pull request.

Ubuntu 22.04 has CMake version 3.22.1 and Ubuntu 24.04 has CMake version 3.27.4 so this bum to CMake 3.18 is easily covered by the two latest stable releases of Ubuntu

## Changelog file
Done