### PR TITLE
Fix vaccum name in materials

### DIFF
--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -26,6 +26,7 @@ v3.2.4
   * Updated documentation to build dependencies (#963)
   * Pause support for Windows (#966)
   * Localize invocation of git submodule for PyNE (#968)
+  * Fixed the name of the Graveyard and the Vaccuum to mat:Graveyard and mat:Vacuum (and lower case) (#971)
 
 v3.2.3
 ====================

--- a/src/dagmc/dagmcmetadata.cpp
+++ b/src/dagmc/dagmcmetadata.cpp
@@ -210,10 +210,8 @@ void dagmcMetaData::parse_material_data() {
     // set the material value
     volume_material_property_data_eh[eh] = grp_name;
     logger.message("Group name -- " + grp_name);
-    bool is_graveyard =
-      to_lower(grp_name) == to_lower(graveyard_mat_str());
-    bool is_vacuum =
-        to_lower(grp_name) == to_lower(vacuum_mat_str());
+    bool is_graveyard = to_lower(grp_name) == to_lower(graveyard_mat_str());
+    bool is_vacuum = to_lower(grp_name) == to_lower(vacuum_mat_str());
 
     // not graveyard or vacuum or implicit compliment
     if (!is_graveyard && !is_vacuum && !DAG->is_implicit_complement(eh)) {

--- a/src/dagmc/dagmcmetadata.cpp
+++ b/src/dagmc/dagmcmetadata.cpp
@@ -211,9 +211,9 @@ void dagmcMetaData::parse_material_data() {
     volume_material_property_data_eh[eh] = grp_name;
     std::cout << "Group name -- " << grp_name << std::endl;
     bool is_graveyard =
-      to_lower(grp_name) == "mat:" + to_lower(graveyard_str);
+      to_lower(grp_name) == to_lower(graveyard_mat_str);
     bool is_vacuum =
-        to_lower(grp_name) == "mat:" + to_lower(vacuum_str);
+        to_lower(grp_name) == to_lower(vacuum_mat_str);
 
     // not graveyard or vacuum or implicit compliment
     if (!is_graveyard && !is_vacuum && !DAG->is_implicit_complement(eh)) {
@@ -221,12 +221,12 @@ void dagmcMetaData::parse_material_data() {
     }
     // found graveyard
     else if (is_graveyard) {
-      volume_material_property_data_eh[eh] = "mat:Graveyard";
+      volume_material_property_data_eh[eh] = graveyard_mat_str;
       volume_material_data_eh[eh] = graveyard_str;
     }
     // vacuum
     else if (is_vacuum) {
-      volume_material_property_data_eh[eh] = "mat:Vacuum";
+      volume_material_property_data_eh[eh] = vacuum_mat_str;
       volume_material_data_eh[eh] = vacuum_str;
     }
     // implicit complement

--- a/src/dagmc/dagmcmetadata.cpp
+++ b/src/dagmc/dagmcmetadata.cpp
@@ -210,8 +210,10 @@ void dagmcMetaData::parse_material_data() {
     // set the material value
     volume_material_property_data_eh[eh] = grp_name;
     logger.message("Group name -- " + grp_name);
-    bool is_graveyard = dagmc_util::to_lower(grp_name) == dagmc_util::to_lower(graveyard_mat_str());
-    bool is_vacuum = dagmc_util::to_lower(grp_name) == dagmc_util::to_lower(vacuum_mat_str());
+    bool is_graveyard = dagmc_util::to_lower(grp_name) == 
+                        dagmc_util::to_lower(graveyard_mat_str());
+    bool is_vacuum = dagmc_util::to_lower(grp_name) == 
+                     dagmc_util::to_lower(vacuum_mat_str());
 
     // not graveyard or vacuum or implicit compliment
     if (!is_graveyard && !is_vacuum && !DAG->is_implicit_complement(eh)) {
@@ -376,13 +378,17 @@ void dagmcMetaData::parse_boundary_data() {
 
     std::string bc_string = dagmc_util::to_lower(boundary_assignment[0]);
 
-    if (bc_string.find(dagmc_util::to_lower(reflecting_str())) != std::string::npos)
+    if (bc_string.find(dagmc_util::to_lower(reflecting_str())) != 
+        std::string::npos)
       surface_boundary_data_eh[eh] = reflecting_str();
-    if (bc_string.find(dagmc_util::to_lower(white_str())) != std::string::npos)
+    if (bc_string.find(dagmc_util::to_lower(white_str())) != 
+        std::string::npos)
       surface_boundary_data_eh[eh] = white_str();
-    if (bc_string.find(dagmc_util::to_lower(periodic_str())) != std::string::npos)
+    if (bc_string.find(dagmc_util::to_lower(periodic_str())) != 
+        std::string::npos)
       surface_boundary_data_eh[eh] = periodic_str();
-    if (bc_string.find(dagmc_util::to_lower(vacuum_str())) != std::string::npos)
+    if (bc_string.find(dagmc_util::to_lower(vacuum_str())) != 
+        std::string::npos)
       surface_boundary_data_eh[eh] = vacuum_str();
   }
 }

--- a/src/dagmc/dagmcmetadata.cpp
+++ b/src/dagmc/dagmcmetadata.cpp
@@ -234,7 +234,7 @@ void dagmcMetaData::parse_material_data() {
       if (implicit_complement_material == "") {
         logger.message("Implicit Complement assumed to be Vacuum");
         volume_material_property_data_eh[eh] = "mat:Vacuum";
-        volume_material_data_eh[eh] = vacuum_str;
+        volume_material_data_eh[eh] = vacuum_str();
       } else {
         volume_material_property_data_eh[eh] =
             "mat:" + implicit_complement_material;

--- a/src/dagmc/dagmcmetadata.cpp
+++ b/src/dagmc/dagmcmetadata.cpp
@@ -211,9 +211,9 @@ void dagmcMetaData::parse_material_data() {
     volume_material_property_data_eh[eh] = grp_name;
     std::cout << "Group name -- " << grp_name << std::endl;
     bool is_graveyard =
-      to_lower(grp_name) == to_lower(graveyard_mat_str);
+      to_lower(grp_name) == to_lower(graveyard_mat_str());
     bool is_vacuum =
-        to_lower(grp_name) == to_lower(vacuum_mat_str);
+        to_lower(grp_name) == to_lower(vacuum_mat_str());
 
     // not graveyard or vacuum or implicit compliment
     if (!is_graveyard && !is_vacuum && !DAG->is_implicit_complement(eh)) {
@@ -221,13 +221,13 @@ void dagmcMetaData::parse_material_data() {
     }
     // found graveyard
     else if (is_graveyard) {
-      volume_material_property_data_eh[eh] = graveyard_mat_str;
-      volume_material_data_eh[eh] = graveyard_str;
+      volume_material_property_data_eh[eh] = graveyard_mat_str();
+      volume_material_data_eh[eh] = graveyard_str();
     }
     // vacuum
     else if (is_vacuum) {
-      volume_material_property_data_eh[eh] = vacuum_mat_str;
-      volume_material_data_eh[eh] = vacuum_str;
+      volume_material_property_data_eh[eh] = vacuum_mat_str();
+      volume_material_data_eh[eh] = vacuum_str();
     }
     // implicit complement
     else if (DAG->is_implicit_complement(eh)) {
@@ -383,14 +383,14 @@ void dagmcMetaData::parse_boundary_data() {
 
     std::string bc_string = to_lower(boundary_assignment[0]);
 
-    if (bc_string.find(to_lower(reflecting_str)) != std::string::npos)
-      surface_boundary_data_eh[eh] = reflecting_str;
-    if (bc_string.find(to_lower(white_str)) != std::string::npos)
-      surface_boundary_data_eh[eh] = white_str;
-    if (bc_string.find(to_lower(periodic_str)) != std::string::npos)
-      surface_boundary_data_eh[eh] = periodic_str;
-    if (bc_string.find(to_lower(vacuum_str)) != std::string::npos)
-      surface_boundary_data_eh[eh] = vacuum_str;
+    if (bc_string.find(to_lower(reflecting_str())) != std::string::npos)
+      surface_boundary_data_eh[eh] = reflecting_str();
+    if (bc_string.find(to_lower(white_str())) != std::string::npos)
+      surface_boundary_data_eh[eh] = white_str();
+    if (bc_string.find(to_lower(periodic_str())) != std::string::npos)
+      surface_boundary_data_eh[eh] = periodic_str();
+    if (bc_string.find(to_lower(vacuum_str())) != std::string::npos)
+      surface_boundary_data_eh[eh] = vacuum_str();
   }
 }
 

--- a/src/dagmc/dagmcmetadata.cpp
+++ b/src/dagmc/dagmcmetadata.cpp
@@ -210,8 +210,8 @@ void dagmcMetaData::parse_material_data() {
     // set the material value
     volume_material_property_data_eh[eh] = grp_name;
     logger.message("Group name -- " + grp_name);
-    bool is_graveyard = to_lower(grp_name) == to_lower(graveyard_mat_str());
-    bool is_vacuum = to_lower(grp_name) == to_lower(vacuum_mat_str());
+    bool is_graveyard = (to_lower(grp_name) == to_lower(graveyard_mat_str()));
+    bool is_vacuum = (to_lower(grp_name) == to_lower(vacuum_mat_str()));
 
     // not graveyard or vacuum or implicit compliment
     if (!is_graveyard && !is_vacuum && !DAG->is_implicit_complement(eh)) {

--- a/src/dagmc/dagmcmetadata.cpp
+++ b/src/dagmc/dagmcmetadata.cpp
@@ -210,10 +210,8 @@ void dagmcMetaData::parse_material_data() {
     // set the material value
     volume_material_property_data_eh[eh] = grp_name;
     logger.message("Group name -- " + grp_name);
-    bool is_graveyard = dagmc_util::to_lower(grp_name) ==
-                        dagmc_util::to_lower(graveyard_mat_str());
-    bool is_vacuum = dagmc_util::to_lower(grp_name) ==
-                     dagmc_util::to_lower(vacuum_mat_str());
+    bool is_graveyard = to_lower(grp_name) == to_lower(graveyard_mat_str());
+    bool is_vacuum = to_lower(grp_name) == to_lower(vacuum_mat_str());
 
     // not graveyard or vacuum or implicit compliment
     if (!is_graveyard && !is_vacuum && !DAG->is_implicit_complement(eh)) {
@@ -347,6 +345,11 @@ void dagmcMetaData::parse_tally_volume_data() {
   }
 }
 
+std::string dagmcMetaData::to_lower(std::string input) {
+  dagmc_util::lowercase_str(input);
+  return input;
+}
+
 // parse the boundary data
 void dagmcMetaData::parse_boundary_data() {
   auto boundary_assignments = get_property_assignments("boundary", 2, ":");
@@ -376,18 +379,15 @@ void dagmcMetaData::parse_boundary_data() {
     // 2d entities have been tagged with the boundary condition property
     // ie. both surfaces and its member triangles
 
-    std::string bc_string = dagmc_util::to_lower(boundary_assignment[0]);
+    std::string bc_string = to_lower(boundary_assignment[0]);
 
-    if (bc_string.find(dagmc_util::to_lower(reflecting_str())) !=
-        std::string::npos)
+    if (bc_string.find(to_lower(reflecting_str())) != std::string::npos)
       surface_boundary_data_eh[eh] = reflecting_str();
-    if (bc_string.find(dagmc_util::to_lower(white_str())) !=
-        std::string::npos)
+    if (bc_string.find(to_lower(white_str())) != std::string::npos)
       surface_boundary_data_eh[eh] = white_str();
-    if (bc_string.find(dagmc_util::to_lower(periodic_str())) !=
-        std::string::npos)
+    if (bc_string.find(to_lower(periodic_str())) !=  std::string::npos)
       surface_boundary_data_eh[eh] = periodic_str();
-    if (bc_string.find(dagmc_util::to_lower(vacuum_str())) != std::string::npos)
+    if (bc_string.find(to_lower(vacuum_str())) != std::string::npos)
       surface_boundary_data_eh[eh] = vacuum_str();
   }
 }

--- a/src/dagmc/dagmcmetadata.cpp
+++ b/src/dagmc/dagmcmetadata.cpp
@@ -209,7 +209,7 @@ void dagmcMetaData::parse_material_data() {
 
     // set the material value
     volume_material_property_data_eh[eh] = grp_name;
-    std::cout << "Group name -- " << grp_name << std::endl;
+    logger.message("Group name -- " + grp_name);
     bool is_graveyard =
       to_lower(grp_name) == to_lower(graveyard_mat_str());
     bool is_vacuum =

--- a/src/dagmc/dagmcmetadata.cpp
+++ b/src/dagmc/dagmcmetadata.cpp
@@ -378,8 +378,7 @@ void dagmcMetaData::parse_boundary_data() {
 
     std::string bc_string = dagmc_util::to_lower(boundary_assignment[0]);
 
-    if (bc_string.find(dagmc_util::to_lower(reflecting_str())) !=
-        std::string::npos)
+    if (bc_string.find(dagmc_util::to_lower(reflecting_str())) != std::string::npos)
       surface_boundary_data_eh[eh] = reflecting_str();
     if (bc_string.find(dagmc_util::to_lower(white_str())) !=
         std::string::npos)

--- a/src/dagmc/dagmcmetadata.cpp
+++ b/src/dagmc/dagmcmetadata.cpp
@@ -209,11 +209,11 @@ void dagmcMetaData::parse_material_data() {
 
     // set the material value
     volume_material_property_data_eh[eh] = grp_name;
-
+    std::cout << "Group name -- " << grp_name << std::endl;
     bool is_graveyard =
-        to_lower(grp_name).find(to_lower(graveyard_str)) != std::string::npos;
+      to_lower(grp_name) == "mat:" + to_lower(graveyard_str);
     bool is_vacuum =
-        to_lower(grp_name).find(to_lower(vacuum_str)) != std::string::npos;
+        to_lower(grp_name) == "mat:" + to_lower(vacuum_str);
 
     // not graveyard or vacuum or implicit compliment
     if (!is_graveyard && !is_vacuum && !DAG->is_implicit_complement(eh)) {
@@ -379,7 +379,7 @@ void dagmcMetaData::parse_boundary_data() {
       exit(EXIT_FAILURE);
     }
     // 2d entities have been tagged with the boundary condition property
-    // ie. both surfaces and its members triangles,
+    // ie. both surfaces and its member triangles
 
     std::string bc_string = to_lower(boundary_assignment[0]);
 

--- a/src/dagmc/dagmcmetadata.cpp
+++ b/src/dagmc/dagmcmetadata.cpp
@@ -210,9 +210,9 @@ void dagmcMetaData::parse_material_data() {
     // set the material value
     volume_material_property_data_eh[eh] = grp_name;
     logger.message("Group name -- " + grp_name);
-    bool is_graveyard = dagmc_util::to_lower(grp_name) == 
+    bool is_graveyard = dagmc_util::to_lower(grp_name) ==
                         dagmc_util::to_lower(graveyard_mat_str());
-    bool is_vacuum = dagmc_util::to_lower(grp_name) == 
+    bool is_vacuum = dagmc_util::to_lower(grp_name) ==
                      dagmc_util::to_lower(vacuum_mat_str());
 
     // not graveyard or vacuum or implicit compliment
@@ -378,17 +378,16 @@ void dagmcMetaData::parse_boundary_data() {
 
     std::string bc_string = dagmc_util::to_lower(boundary_assignment[0]);
 
-    if (bc_string.find(dagmc_util::to_lower(reflecting_str())) != 
+    if (bc_string.find(dagmc_util::to_lower(reflecting_str())) !=
         std::string::npos)
       surface_boundary_data_eh[eh] = reflecting_str();
-    if (bc_string.find(dagmc_util::to_lower(white_str())) != 
+    if (bc_string.find(dagmc_util::to_lower(white_str())) !=
         std::string::npos)
       surface_boundary_data_eh[eh] = white_str();
-    if (bc_string.find(dagmc_util::to_lower(periodic_str())) != 
+    if (bc_string.find(dagmc_util::to_lower(periodic_str())) !=
         std::string::npos)
       surface_boundary_data_eh[eh] = periodic_str();
-    if (bc_string.find(dagmc_util::to_lower(vacuum_str())) != 
-        std::string::npos)
+    if (bc_string.find(dagmc_util::to_lower(vacuum_str())) != std::string::npos)
       surface_boundary_data_eh[eh] = vacuum_str();
   }
 }

--- a/src/dagmc/dagmcmetadata.cpp
+++ b/src/dagmc/dagmcmetadata.cpp
@@ -385,7 +385,7 @@ void dagmcMetaData::parse_boundary_data() {
       surface_boundary_data_eh[eh] = reflecting_str();
     if (bc_string.find(to_lower(white_str())) != std::string::npos)
       surface_boundary_data_eh[eh] = white_str();
-    if (bc_string.find(to_lower(periodic_str())) !=  std::string::npos)
+    if (bc_string.find(to_lower(periodic_str())) != std::string::npos)
       surface_boundary_data_eh[eh] = periodic_str();
     if (bc_string.find(to_lower(vacuum_str())) != std::string::npos)
       surface_boundary_data_eh[eh] = vacuum_str();

--- a/src/dagmc/dagmcmetadata.cpp
+++ b/src/dagmc/dagmcmetadata.cpp
@@ -378,7 +378,8 @@ void dagmcMetaData::parse_boundary_data() {
 
     std::string bc_string = dagmc_util::to_lower(boundary_assignment[0]);
 
-    if (bc_string.find(dagmc_util::to_lower(reflecting_str())) != std::string::npos)
+    if (bc_string.find(dagmc_util::to_lower(reflecting_str())) !=
+        std::string::npos)
       surface_boundary_data_eh[eh] = reflecting_str();
     if (bc_string.find(dagmc_util::to_lower(white_str())) !=
         std::string::npos)

--- a/src/dagmc/dagmcmetadata.cpp
+++ b/src/dagmc/dagmcmetadata.cpp
@@ -231,7 +231,7 @@ void dagmcMetaData::parse_material_data() {
     else if (DAG->is_implicit_complement(eh)) {
       if (implicit_complement_material == "") {
         logger.message("Implicit Complement assumed to be Vacuum");
-        volume_material_property_data_eh[eh] = "mat:Vacuum";
+        volume_material_property_data_eh[eh] = vacuum_mat_str();
         volume_material_data_eh[eh] = vacuum_str();
       } else {
         volume_material_property_data_eh[eh] =

--- a/src/dagmc/dagmcmetadata.cpp
+++ b/src/dagmc/dagmcmetadata.cpp
@@ -210,8 +210,8 @@ void dagmcMetaData::parse_material_data() {
     // set the material value
     volume_material_property_data_eh[eh] = grp_name;
     logger.message("Group name -- " + grp_name);
-    bool is_graveyard = to_lower(grp_name) == to_lower(graveyard_mat_str());
-    bool is_vacuum = to_lower(grp_name) == to_lower(vacuum_mat_str());
+    bool is_graveyard = dagmc_util::to_lower(grp_name) == dagmc_util::to_lower(graveyard_mat_str());
+    bool is_vacuum = dagmc_util::to_lower(grp_name) == dagmc_util::to_lower(vacuum_mat_str());
 
     // not graveyard or vacuum or implicit compliment
     if (!is_graveyard && !is_vacuum && !DAG->is_implicit_complement(eh)) {
@@ -345,11 +345,6 @@ void dagmcMetaData::parse_tally_volume_data() {
   }
 }
 
-std::string dagmcMetaData::to_lower(std::string input) {
-  dagmc_util::lowercase_str(input);
-  return input;
-}
-
 // parse the boundary data
 void dagmcMetaData::parse_boundary_data() {
   auto boundary_assignments = get_property_assignments("boundary", 2, ":");
@@ -379,15 +374,15 @@ void dagmcMetaData::parse_boundary_data() {
     // 2d entities have been tagged with the boundary condition property
     // ie. both surfaces and its member triangles
 
-    std::string bc_string = to_lower(boundary_assignment[0]);
+    std::string bc_string = dagmc_util::to_lower(boundary_assignment[0]);
 
-    if (bc_string.find(to_lower(reflecting_str())) != std::string::npos)
+    if (bc_string.find(dagmc_util::to_lower(reflecting_str())) != std::string::npos)
       surface_boundary_data_eh[eh] = reflecting_str();
-    if (bc_string.find(to_lower(white_str())) != std::string::npos)
+    if (bc_string.find(dagmc_util::to_lower(white_str())) != std::string::npos)
       surface_boundary_data_eh[eh] = white_str();
-    if (bc_string.find(to_lower(periodic_str())) != std::string::npos)
+    if (bc_string.find(dagmc_util::to_lower(periodic_str())) != std::string::npos)
       surface_boundary_data_eh[eh] = periodic_str();
-    if (bc_string.find(to_lower(vacuum_str())) != std::string::npos)
+    if (bc_string.find(dagmc_util::to_lower(vacuum_str())) != std::string::npos)
       surface_boundary_data_eh[eh] = vacuum_str();
   }
 }

--- a/src/dagmc/dagmcmetadata.hpp
+++ b/src/dagmc/dagmcmetadata.hpp
@@ -250,8 +250,6 @@ class dagmcMetaData {
    */
   std::set<std::string> set_remove_rich(std::set<std::string> properties_set);
 
-  std::string to_lower(const std::string input);
-
   // public member variables
  public:
   /**

--- a/src/dagmc/dagmcmetadata.hpp
+++ b/src/dagmc/dagmcmetadata.hpp
@@ -353,6 +353,8 @@ class dagmcMetaData {
   // Some constant keyword values
   const std::string graveyard_str{"Graveyard"};
   const std::string vacuum_str{"Vacuum"};
+  const std::string vacuum_mat_str{"mat:Vacuum"};
+  const std::string graveyard_mat_str{"mat:Graveyard"};
   const std::string reflecting_str{"Reflecting"};
   const std::string white_str{"White"};
   const std::string periodic_str{"Periodic"};

--- a/src/dagmc/dagmcmetadata.hpp
+++ b/src/dagmc/dagmcmetadata.hpp
@@ -316,6 +316,15 @@ class dagmcMetaData {
    */
   std::map<moab::EntityHandle, std::map<std::string, double>> importance_map;
 
+  // Some constant keyword values
+  const std::string& graveyard_str() const { return graveyard_str_; }
+  const std::string& vacuum_str() const { return vacuum_str_; }
+  const std::string& vacuum_mat_str() const { return vacuum_mat_str_; }
+  const std::string& graveyard_mat_str() const { return graveyard_mat_str_; }
+  const std::string& reflecting_str() const { return reflecting_str_; }
+  const std::string& white_str() const { return white_str_; }
+  const std::string& periodic_str() const { return periodic_str_; }
+
   // private member variables
  private:
   /**

--- a/src/dagmc/dagmcmetadata.hpp
+++ b/src/dagmc/dagmcmetadata.hpp
@@ -316,7 +316,7 @@ class dagmcMetaData {
    */
   std::map<moab::EntityHandle, std::map<std::string, double>> importance_map;
 
-  // Some constant keyword values
+  // Getting some constant keyword values
   const std::string& graveyard_str() const { return graveyard_str_; }
   const std::string& vacuum_str() const { return vacuum_str_; }
   const std::string& vacuum_mat_str() const { return vacuum_mat_str_; }
@@ -324,6 +324,12 @@ class dagmcMetaData {
   const std::string& reflecting_str() const { return reflecting_str_; }
   const std::string& white_str() const { return white_str_; }
   const std::string& periodic_str() const { return periodic_str_; }
+
+  // Allowing modify some constant keyword values
+  void set_graveyard_str(std::string val) { graveyard_str_ = val; }
+  void set_vacuum_str(std::string val) { vacuum_str_ = val; }
+  void set_vacuum_mat_str(std::string val) { vacuum_mat_str_ = val; }
+  void set_graveyard_mat_str(std::string val) { graveyard_mat_str_ = val; }
 
   // private member variables
  private:
@@ -360,13 +366,14 @@ class dagmcMetaData {
   std::map<std::string, std::string> keyword_synonyms;
 
   // Some constant keyword values
-  const std::string graveyard_str_{"Graveyard"};
-  const std::string vacuum_str_{"Vacuum"};
-  const std::string vacuum_mat_str_{"mat:Vacuum"};
-  const std::string graveyard_mat_str_{"mat:Graveyard"};
   const std::string reflecting_str_{"Reflecting"};
   const std::string white_str_{"White"};
   const std::string periodic_str_{"Periodic"};
+  // Some less constant keyword values
+  std::string graveyard_str_{"Graveyard"};
+  std::string vacuum_str_{"Vacuum"};
+  std::string vacuum_mat_str_{"mat:Vacuum"};
+  std::string graveyard_mat_str_{"mat:Graveyard"};
 
   DagMC_Logger logger;
 };

--- a/src/dagmc/dagmcmetadata.hpp
+++ b/src/dagmc/dagmcmetadata.hpp
@@ -250,6 +250,8 @@ class dagmcMetaData {
    */
   std::set<std::string> set_remove_rich(std::set<std::string> properties_set);
 
+  std::string to_lower(const std::string input);
+
   // public member variables
  public:
   /**

--- a/src/dagmc/dagmcmetadata.hpp
+++ b/src/dagmc/dagmcmetadata.hpp
@@ -360,13 +360,13 @@ class dagmcMetaData {
   std::map<std::string, std::string> keyword_synonyms;
 
   // Some constant keyword values
-  const std::string graveyard_str{"Graveyard"};
-  const std::string vacuum_str{"Vacuum"};
-  const std::string vacuum_mat_str{"mat:Vacuum"};
-  const std::string graveyard_mat_str{"mat:Graveyard"};
-  const std::string reflecting_str{"Reflecting"};
-  const std::string white_str{"White"};
-  const std::string periodic_str{"Periodic"};
+  const std::string graveyard_str_{"Graveyard"};
+  const std::string vacuum_str_{"Vacuum"};
+  const std::string vacuum_mat_str_{"mat:Vacuum"};
+  const std::string graveyard_mat_str_{"mat:Graveyard"};
+  const std::string reflecting_str_{"Reflecting"};
+  const std::string white_str_{"White"};
+  const std::string periodic_str_{"Periodic"};
 
   DagMC_Logger logger;
 };

--- a/src/dagmc/tests/dagmc_unit_tests.cpp
+++ b/src/dagmc/tests/dagmc_unit_tests.cpp
@@ -81,7 +81,7 @@ TEST_F(DagmcMetadataTest, TestMatAssigns) {
   }
 }
 //---------------------------------------------------------------------------//
-// FIXTURE-BASED TESTS: Tests to make sure that vacuum detection is done 
+// FIXTURE-BASED TESTS: Tests to make sure that vacuum detection is done
 // properly
 //---------------------------------------------------------------------------//
 TEST_F(DagmcMetadataTest, TestVacuumName) {

--- a/src/dagmc/tests/dagmc_unit_tests.cpp
+++ b/src/dagmc/tests/dagmc_unit_tests.cpp
@@ -81,8 +81,8 @@ TEST_F(DagmcMetadataTest, TestMatAssigns) {
   }
 }
 //---------------------------------------------------------------------------//
-// FIXTURE-BASED TESTS: Tests to make sure that all volumes have successfully
-// been assigned and successfully retreved from the metadata class
+// FIXTURE-BASED TESTS: Tests to make sure that vacuum detection is done 
+// properly
 //---------------------------------------------------------------------------//
 TEST_F(DagmcMetadataTest, TestVacuumName) {
   // Test default behavior for vacuum name
@@ -92,14 +92,11 @@ TEST_F(DagmcMetadataTest, TestVacuumName) {
     // process
     dgm->load_property_data();
 
-
-    std::string base_property = "mat:Hydrogen";
-    std::string impl_comp_prop = "mat:Vacuum";
-
     int num_vol = DAG->num_entities(3);
     std::vector<int> vol_ids = {1, 2, 3, 4};
 
-    std::vector<std::string> vacuum_names = {"Hydrogen", "Hydrogen", "Hydrogen", "Vacuum"};
+    std::vector<std::string> vacuum_names = {"Hydrogen", "Hydrogen", "Hydrogen",
+                                             "Vacuum"};
     for (int id : vol_ids){
       std::string mat_prop = dgm->get_volume_property("material", id, false);
       EXPECT_EQ(mat_prop, vacuum_names[id-1]);
@@ -115,7 +112,8 @@ TEST_F(DagmcMetadataTest, TestVacuumName) {
     int num_vol = DAG->num_entities(3);
     std::vector<int> vol_ids = {1, 2, 3, 4};
 
-    std::vector<std::string> vacuum_names = {"Vacuum", "Vacuum", "Vacuum", "Vacuum"};
+    std::vector<std::string> vacuum_names = {"Vacuum", "Vacuum", "Vacuum",
+                                             "Vacuum"};
     for (int id : vol_ids){
       std::string mat_prop = dgm->get_volume_property("material", id, false);
       EXPECT_EQ(mat_prop, vacuum_names[id-1]);
@@ -131,7 +129,8 @@ TEST_F(DagmcMetadataTest, TestVacuumName) {
     int num_vol = DAG->num_entities(3);
     std::vector<int> vol_ids = {1, 2, 3, 4};
 
-    std::vector<std::string> vacuum_names = {"Hydrogen", "Hydrogen", "Hydrogen", "Vacuum"};
+    std::vector<std::string> vacuum_names = {"Hydrogen", "Hydrogen", "Hydrogen",
+                                             "Vacuum"};
     for (int id : vol_ids){
       std::string mat_prop = dgm->get_volume_property("material", id, false);
       EXPECT_EQ(mat_prop, vacuum_names[id-1]);

--- a/src/dagmc/tests/dagmc_unit_tests.cpp
+++ b/src/dagmc/tests/dagmc_unit_tests.cpp
@@ -97,9 +97,9 @@ TEST_F(DagmcMetadataTest, TestVacuumName) {
 
     std::vector<std::string> vacuum_names = {"Hydrogen", "Hydrogen", "Hydrogen",
                                              "Vacuum"};
-    for (int id : vol_ids){
+    for (int id : vol_ids) {
       std::string mat_prop = dgm->get_volume_property("material", id, false);
-      EXPECT_EQ(mat_prop, vacuum_names[id-1]);
+      EXPECT_EQ(mat_prop, vacuum_names[id - 1]);
     }
   }
 
@@ -114,9 +114,9 @@ TEST_F(DagmcMetadataTest, TestVacuumName) {
 
     std::vector<std::string> vacuum_names = {"Vacuum", "Vacuum", "Vacuum",
                                              "Vacuum"};
-    for (int id : vol_ids){
+    for (int id : vol_ids) {
       std::string mat_prop = dgm->get_volume_property("material", id, false);
-      EXPECT_EQ(mat_prop, vacuum_names[id-1]);
+      EXPECT_EQ(mat_prop, vacuum_names[id - 1]);
     }
   }
 
@@ -131,9 +131,9 @@ TEST_F(DagmcMetadataTest, TestVacuumName) {
 
     std::vector<std::string> vacuum_names = {"Hydrogen", "Hydrogen", "Hydrogen",
                                              "Vacuum"};
-    for (int id : vol_ids){
+    for (int id : vol_ids) {
       std::string mat_prop = dgm->get_volume_property("material", id, false);
-      EXPECT_EQ(mat_prop, vacuum_names[id-1]);
+      EXPECT_EQ(mat_prop, vacuum_names[id - 1]);
     }
   }
 }

--- a/src/dagmc/tests/dagmc_unit_tests.cpp
+++ b/src/dagmc/tests/dagmc_unit_tests.cpp
@@ -81,6 +81,64 @@ TEST_F(DagmcMetadataTest, TestMatAssigns) {
   }
 }
 //---------------------------------------------------------------------------//
+// FIXTURE-BASED TESTS: Tests to make sure that all volumes have successfully
+// been assigned and successfully retreved from the metadata class
+//---------------------------------------------------------------------------//
+TEST_F(DagmcMetadataTest, TestVacuumName) {
+  // Test default behavior for vacuum name
+  {
+    // new metadata instance
+    dgm = std::make_shared<dagmcMetaData>(DAG.get());
+    // process
+    dgm->load_property_data();
+
+
+    std::string base_property = "mat:Hydrogen";
+    std::string impl_comp_prop = "mat:Vacuum";
+
+    int num_vol = DAG->num_entities(3);
+    std::vector<int> vol_ids = {1, 2, 3, 4};
+
+    std::vector<std::string> vacuum_names = {"Hydrogen", "Hydrogen", "Hydrogen", "Vacuum"};
+    for (int id : vol_ids){
+      std::string mat_prop = dgm->get_volume_property("material", id, false);
+      EXPECT_EQ(mat_prop, vacuum_names[id-1]);
+    }
+  }
+
+  // Changing the vacuum name to detect mat:Hydrogen as the vacuum
+  {
+    dgm = std::make_shared<dagmcMetaData>(DAG.get());
+
+    dgm->set_vacuum_mat_str("mat:Hydrogen");
+    dgm->load_property_data();
+    int num_vol = DAG->num_entities(3);
+    std::vector<int> vol_ids = {1, 2, 3, 4};
+
+    std::vector<std::string> vacuum_names = {"Vacuum", "Vacuum", "Vacuum", "Vacuum"};
+    for (int id : vol_ids){
+      std::string mat_prop = dgm->get_volume_property("material", id, false);
+      EXPECT_EQ(mat_prop, vacuum_names[id-1]);
+    }
+  }
+
+  // Ensuring that partial name overlap don't affect vacuum detection
+  {
+    dgm = std::make_shared<dagmcMetaData>(DAG.get());
+
+    dgm->set_vacuum_mat_str("Hydro");
+    dgm->load_property_data();
+    int num_vol = DAG->num_entities(3);
+    std::vector<int> vol_ids = {1, 2, 3, 4};
+
+    std::vector<std::string> vacuum_names = {"Hydrogen", "Hydrogen", "Hydrogen", "Vacuum"};
+    for (int id : vol_ids){
+      std::string mat_prop = dgm->get_volume_property("material", id, false);
+      EXPECT_EQ(mat_prop, vacuum_names[id-1]);
+    }
+  }
+}
+//---------------------------------------------------------------------------//
 // FIXTURE-BASED TESTS: Tests to make sure that all densities have successfully
 // been assigned and successfully retreved from the metadata class
 // in this test there was no density data assigned, so it should be ""

--- a/src/dagmc/util.hpp
+++ b/src/dagmc/util.hpp
@@ -10,5 +10,10 @@ inline void lowercase_str(std::string& input) {
                  [](unsigned char c) { return std::tolower(c); });
 }
 
+inline std::string to_lower(std::string input) {
+  lowercase_str(input);
+  return input;
+}
+
 }  // namespace dagmc_util
 #endif

--- a/src/dagmc/util.hpp
+++ b/src/dagmc/util.hpp
@@ -10,10 +10,5 @@ inline void lowercase_str(std::string& input) {
                  [](unsigned char c) { return std::tolower(c); });
 }
 
-inline std::string to_lower(std::string input) {
-  lowercase_str(input);
-  return input;
-}
-
 }  // namespace dagmc_util
 #endif

--- a/src/mcnp/mcnp_funcs.cpp
+++ b/src/mcnp/mcnp_funcs.cpp
@@ -228,9 +228,9 @@ void write_cell_cards(std::ostringstream& lcadfile,
     } else {
       std::string mat_name = DMD->volume_material_property_data_eh[entity];
       // if we not vacuum or graveyard
-      if (dagmc_util::to_lower(mat_num) != 
+      if (dagmc_util::to_lower(mat_num) !=
               dagmc_util::to_lower(DMD->graveyard_mat_str()) &&
-          dagmc_util::to_lower(mat_num) != 
+          dagmc_util::to_lower(mat_num) !=
               dagmc_util::to_lower(DMD->vacuum_mat_str())) {
         if (workflow_data->material_library.count(mat_name) == 0) {
           std::cerr << "Material with name " << mat_name << " not found "
@@ -272,7 +272,7 @@ void write_cell_cards(std::ostringstream& lcadfile,
       }
       double imp = 1.0;
       // if we find graveyard always have importance 0.0
-      if (dagmc_util::to_lower(mat_num) == dagmc_util::to_lower(DMD->graveyard_mat_str()) {
+      if (dagmc_util::to_lower(mat_num) == dagmc_util::to_lower(DMD->graveyard_mat_str())) {
         imp = 0.0;
         // no splitting can happenin vacuum set to 1
       } else if (dagmc_util::to_lower(mat_num) == dagmc_util::to_lower(DMD->vacuum_mat_str())) {

--- a/src/mcnp/mcnp_funcs.cpp
+++ b/src/mcnp/mcnp_funcs.cpp
@@ -204,7 +204,7 @@ void write_cell_cards(std::ostringstream& lcadfile,
        if (DMD->to_lower(mat_num) !=
               DMD->to_lower(DMD->graveyard_mat_str()) &&
           DMD->to_lower(mat_num) !=
-              DMD->to_lower(DMD->vacuum_mat_str())) {
+              DMD->to_lower(DMD->vacuum_mat_str()) {
          if (!DMD->try_to_make_int(mat_num)) {
            std::cerr << "Failed to cast material number to an integer"
                      << std::endl;

--- a/src/mcnp/mcnp_funcs.cpp
+++ b/src/mcnp/mcnp_funcs.cpp
@@ -2,6 +2,8 @@
 
 #include "DagMC.hpp"
 #include "dagmcmetadata.hpp"
+#include "util.hpp"
+
 using moab::DagMC;
 
 #include <assert.h>
@@ -200,8 +202,8 @@ void write_cell_cards(std::ostringstream& lcadfile,
       // that material numbers are assigned
       mat_num = DMD->volume_material_data_eh[entity];
       // if we cant make an int from the mat_num
-      if (dagmcMetaData::to_lower(mat_num) != dagmcMetaData::to_lower(DMD->graveyard_mat_str()) &&
-          dagmcMetaData::to_lower(mat_num) != dagmcMetaData::to_lower(DMD->vacuum_mat_str())) {
+      if (dagmc_utils::lowercase_str(mat_num) != dagmc_utils::lowercase_str(DMD->graveyard_mat_str()) &&
+          dagmc_utils::lowercase_str(mat_num) != dagmc_utils::lowercase_str(DMD->vacuum_mat_str())) {
         if (!DMD->try_to_make_int(mat_num)) {
           std::cerr << "Failed to cast material number to an integer"
                     << std::endl;

--- a/src/mcnp/mcnp_funcs.cpp
+++ b/src/mcnp/mcnp_funcs.cpp
@@ -2,6 +2,7 @@
 
 #include "DagMC.hpp"
 #include "dagmcmetadata.hpp"
+#include "util.hpp"
 
 using moab::DagMC;
 
@@ -201,8 +202,10 @@ void write_cell_cards(std::ostringstream& lcadfile,
       // that material numbers are assigned
       mat_num = DMD->volume_material_data_eh[entity];
       // if we cant make an int from the mat_num
-      if (dagmc_util::to_lower(mat_num) != dagmc_util::to_lower(DMD->graveyard_mat_str()) &&
-          dagmc_util::to_lower(mat_num) != dagmc_util::to_lower(DMD->vacuum_mat_str())) {
+      if (dagmc_util::to_lower(mat_num) != 
+              dagmc_util::to_lower(DMD->graveyard_mat_str()) &&
+          dagmc_util::to_lower(mat_num) != 
+              dagmc_util::to_lower(DMD->vacuum_mat_str())) {
         if (!DMD->try_to_make_int(mat_num)) {
           std::cerr << "Failed to cast material number to an integer"
                     << std::endl;
@@ -225,8 +228,10 @@ void write_cell_cards(std::ostringstream& lcadfile,
     } else {
       std::string mat_name = DMD->volume_material_property_data_eh[entity];
       // if we not vacuum or graveyard
-      if (dagmc_util::to_lower(mat_num) != dagmc_util::to_lower(DMD->graveyard_mat_str()) &&
-          dagmc_util::to_lower(mat_num) != dagmc_util::to_lower(DMD->vacuum_mat_str())) {
+      if (dagmc_util::to_lower(mat_num) != 
+              dagmc_util::to_lower(DMD->graveyard_mat_str()) &&
+          dagmc_util::to_lower(mat_num) != 
+              dagmc_util::to_lower(DMD->vacuum_mat_str())) {
         if (workflow_data->material_library.count(mat_name) == 0) {
           std::cerr << "Material with name " << mat_name << " not found "
                     << std::endl;

--- a/src/mcnp/mcnp_funcs.cpp
+++ b/src/mcnp/mcnp_funcs.cpp
@@ -201,10 +201,8 @@ void write_cell_cards(std::ostringstream& lcadfile,
       // that material numbers are assigned
       mat_num = DMD->volume_material_data_eh[entity];
       // if we cant make an int from the mat_num
-       if (DMD->to_lower(mat_num) !=
-              DMD->to_lower(DMD->graveyard_mat_str()) &&
-          DMD->to_lower(mat_num) !=
-              DMD->to_lower(DMD->vacuum_mat_str()) {
+       if (DMD->to_lower(mat_num) != DMD->to_lower(DMD->graveyard_mat_str()) &&
+          DMD->to_lower(mat_num) != DMD->to_lower(DMD->vacuum_mat_str())) {
          if (!DMD->try_to_make_int(mat_num)) {
            std::cerr << "Failed to cast material number to an integer"
                      << std::endl;

--- a/src/mcnp/mcnp_funcs.cpp
+++ b/src/mcnp/mcnp_funcs.cpp
@@ -225,8 +225,8 @@ void write_cell_cards(std::ostringstream& lcadfile,
     } else {
       std::string mat_name = DMD->volume_material_property_data_eh[entity];
       // if we not vacuum or graveyard
-      if (mat_name != DMD->vacuum_mat_str() &&
-          mat_name != DMD->graveyard_mat_str()) {
+      if (DMD->to_lower(mat_num) != DMD->to_lower(DMD->graveyard_mat_str()) &&
+          DMD->to_lower(mat_num) != DMD->to_lower(DMD->vacuum_mat_str())) {
         if (workflow_data->material_library.count(mat_name) == 0) {
           std::cerr << "Material with name " << mat_name << " not found "
                     << std::endl;
@@ -267,10 +267,10 @@ void write_cell_cards(std::ostringstream& lcadfile,
       }
       double imp = 1.0;
       // if we find graveyard always have importance 0.0
-      if (mat_name == DMD->graveyard_mat_str()) {
+      if (DMD->to_lower(mat_num) == DMD->to_lower(DMD->graveyard_mat_str()) {
         imp = 0.0;
         // no splitting can happenin vacuum set to 1
-      } else if (mat_name == DMD->vacuum_mat_str()) {
+      } else if (DMD->to_lower(mat_num) != DMD->to_lower(DMD->vacuum_mat_str())) {
         imp = 1.0;
         // otherwise as the map says
       } else {

--- a/src/mcnp/mcnp_funcs.cpp
+++ b/src/mcnp/mcnp_funcs.cpp
@@ -201,11 +201,8 @@ void write_cell_cards(std::ostringstream& lcadfile,
       // that material numbers are assigned
       mat_num = DMD->volume_material_data_eh[entity];
       // if we cant make an int from the mat_num
-       if (DMD->to_lower(mat_num) != DMD->to_lower(DMD->graveyard_mat_str()) &&
+      if (DMD->to_lower(mat_num) != DMD->to_lower(DMD->graveyard_mat_str()) &&
           DMD->to_lower(mat_num) != DMD->to_lower(DMD->vacuum_mat_str())) {
-         if (!DMD->try_to_make_int(mat_num)) {
-           std::cerr << "Failed to cast material number to an integer"
-                     << std::endl;
         if (!DMD->try_to_make_int(mat_num)) {
           std::cerr << "Failed to cast material number to an integer"
                     << std::endl;

--- a/src/mcnp/mcnp_funcs.cpp
+++ b/src/mcnp/mcnp_funcs.cpp
@@ -1,7 +1,6 @@
 #include "mcnp_funcs.h"
 
 #include "DagMC.hpp"
-#include "dagmcmetadata.hpp"
 #include "util.hpp"
 
 using moab::DagMC;
@@ -202,10 +201,10 @@ void write_cell_cards(std::ostringstream& lcadfile,
       // that material numbers are assigned
       mat_num = DMD->volume_material_data_eh[entity];
       // if we cant make an int from the mat_num
-       if (dagmc_util::lowercase_str(mat_num) !=
-              dagmc_util::lowercase_str(DMD->graveyard_mat_str()) &&
-          dagmc_util::lowercase_str(mat_num) !=
-              dagmc_util::lowercase_str(DMD->vacuum_mat_str())) {
+       if (DMD->to_lower(mat_num) !=
+              DMD->to_lower(DMD->graveyard_mat_str()) &&
+          DMD->to_lower(mat_num) !=
+              DMD->to_lower(DMD->vacuum_mat_str())) {
          if (!DMD->try_to_make_int(mat_num)) {
            std::cerr << "Failed to cast material number to an integer"
                      << std::endl;

--- a/src/mcnp/mcnp_funcs.cpp
+++ b/src/mcnp/mcnp_funcs.cpp
@@ -272,10 +272,12 @@ void write_cell_cards(std::ostringstream& lcadfile,
       }
       double imp = 1.0;
       // if we find graveyard always have importance 0.0
-      if (dagmc_util::to_lower(mat_num) == dagmc_util::to_lower(DMD->graveyard_mat_str())) {
+      if (dagmc_util::to_lower(mat_num) ==
+          dagmc_util::to_lower(DMD->graveyard_mat_str())) {
         imp = 0.0;
         // no splitting can happenin vacuum set to 1
-      } else if (dagmc_util::to_lower(mat_num) == dagmc_util::to_lower(DMD->vacuum_mat_str())) {
+      } else if (dagmc_util::to_lower(mat_num) ==
+                 dagmc_util::to_lower(DMD->vacuum_mat_str())) {
         imp = 1.0;
         // otherwise as the map says
       } else {
@@ -285,7 +287,7 @@ void write_cell_cards(std::ostringstream& lcadfile,
     }
     // its possible no importances were assigned
     if (set.size() == 0) {
-      if (dagmc_util::to_lower(mat_num) != dagmc_util::to_lower(DMD->graveyard_mat_str()) {
+      if (dagmc_util::to_lower(mat_num) != dagmc_util::to_lower(DMD->graveyard_mat_str())) {
         importances = "imp:n=1";
       } else {
         importances = "imp:n=0";
@@ -293,7 +295,7 @@ void write_cell_cards(std::ostringstream& lcadfile,
     }
 
     // add descriptive comments for special volumes
-    if (dagmc_util::to_lower(mat_num) == dagmc_util::to_lower(DMD->graveyard_mat_str()) {
+    if (dagmc_util::to_lower(mat_num) == dagmc_util::to_lower(DMD->graveyard_mat_str())) {
       importances += "  $ graveyard";
     } else if (DAG->is_implicit_complement(entity)) {
       importances += "  $ implicit complement";

--- a/src/mcnp/mcnp_funcs.cpp
+++ b/src/mcnp/mcnp_funcs.cpp
@@ -202,9 +202,9 @@ void write_cell_cards(std::ostringstream& lcadfile,
       // that material numbers are assigned
       mat_num = DMD->volume_material_data_eh[entity];
       // if we cant make an int from the mat_num
-      if (dagmc_util::to_lower(mat_num) != 
+      if (dagmc_util::to_lower(mat_num) !=
               dagmc_util::to_lower(DMD->graveyard_mat_str()) &&
-          dagmc_util::to_lower(mat_num) != 
+          dagmc_util::to_lower(mat_num) !=
               dagmc_util::to_lower(DMD->vacuum_mat_str())) {
         if (!DMD->try_to_make_int(mat_num)) {
           std::cerr << "Failed to cast material number to an integer"
@@ -272,10 +272,10 @@ void write_cell_cards(std::ostringstream& lcadfile,
       }
       double imp = 1.0;
       // if we find graveyard always have importance 0.0
-      if (dagmc_util::to_lower(mat_nanme) == dagmc_util::to_lower(DMD->graveyard_mat_str()) {
+      if (dagmc_util::to_lower(mat_num) == dagmc_util::to_lower(DMD->graveyard_mat_str()) {
         imp = 0.0;
         // no splitting can happenin vacuum set to 1
-      } else if (dagmc_util::to_lower(mat_nanme) == dagmc_util::to_lower(DMD->vacuum_mat_str())) {
+      } else if (dagmc_util::to_lower(mat_num) == dagmc_util::to_lower(DMD->vacuum_mat_str())) {
         imp = 1.0;
         // otherwise as the map says
       } else {
@@ -285,7 +285,7 @@ void write_cell_cards(std::ostringstream& lcadfile,
     }
     // its possible no importances were assigned
     if (set.size() == 0) {
-      if (dagmc_util::to_lower(mat_nanme) != dagmc_util::to_lower(DMD->graveyard_mat_str()) {
+      if (dagmc_util::to_lower(mat_num) != dagmc_util::to_lower(DMD->graveyard_mat_str()) {
         importances = "imp:n=1";
       } else {
         importances = "imp:n=0";
@@ -293,7 +293,7 @@ void write_cell_cards(std::ostringstream& lcadfile,
     }
 
     // add descriptive comments for special volumes
-    if (dagmc_util::to_lower(mat_nanme) == dagmc_util::to_lower(DMD->graveyard_mat_str()) {
+    if (dagmc_util::to_lower(mat_num) == dagmc_util::to_lower(DMD->graveyard_mat_str()) {
       importances += "  $ graveyard";
     } else if (DAG->is_implicit_complement(entity)) {
       importances += "  $ implicit complement";

--- a/src/mcnp/mcnp_funcs.cpp
+++ b/src/mcnp/mcnp_funcs.cpp
@@ -200,8 +200,8 @@ void write_cell_cards(std::ostringstream& lcadfile,
       // that material numbers are assigned
       mat_num = DMD->volume_material_data_eh[entity];
       // if we cant make an int from the mat_num
-      if (to_lower(mat_num) != to_lower(DMD->graveyard_mat_str()) &&
-          to_lower(mat_num) != to_lower(DMD->vacuum_mat_str())) {
+      if (dagmcMetaData::to_lower(mat_num) != dagmcMetaData::to_lower(DMD->graveyard_mat_str()) &&
+          dagmcMetaData::to_lower(mat_num) != dagmcMetaData::to_lower(DMD->vacuum_mat_str())) {
         if (!DMD->try_to_make_int(mat_num)) {
           std::cerr << "Failed to cast material number to an integer"
                     << std::endl;

--- a/src/mcnp/mcnp_funcs.cpp
+++ b/src/mcnp/mcnp_funcs.cpp
@@ -1,7 +1,7 @@
 #include "mcnp_funcs.h"
 
 #include "DagMC.hpp"
-#include "util.hpp"
+#include "dagmcmetadata.hpp"
 
 using moab::DagMC;
 

--- a/src/mcnp/mcnp_funcs.cpp
+++ b/src/mcnp/mcnp_funcs.cpp
@@ -202,8 +202,13 @@ void write_cell_cards(std::ostringstream& lcadfile,
       // that material numbers are assigned
       mat_num = DMD->volume_material_data_eh[entity];
       // if we cant make an int from the mat_num
-      if (dagmc_util::lowercase_str(mat_num) != dagmc_util::lowercase_str(DMD->graveyard_mat_str()) &&
-          dagmc_util::lowercase_str(mat_num) != dagmc_util::lowercase_str(DMD->vacuum_mat_str())) {
+       if (dagmc_util::lowercase_str(mat_num) !=
+              dagmc_util::lowercase_str(DMD->graveyard_mat_str()) &&
+          dagmc_util::lowercase_str(mat_num) !=
+              dagmc_util::lowercase_str(DMD->vacuum_mat_str())) {
+         if (!DMD->try_to_make_int(mat_num)) {
+           std::cerr << "Failed to cast material number to an integer"
+                     << std::endl;
         if (!DMD->try_to_make_int(mat_num)) {
           std::cerr << "Failed to cast material number to an integer"
                     << std::endl;

--- a/src/mcnp/mcnp_funcs.cpp
+++ b/src/mcnp/mcnp_funcs.cpp
@@ -267,10 +267,10 @@ void write_cell_cards(std::ostringstream& lcadfile,
       }
       double imp = 1.0;
       // if we find graveyard always have importance 0.0
-      if (DMD->to_lower(mat_num) == DMD->to_lower(DMD->graveyard_mat_str()) {
+      if (DMD->to_lower(mat_nanme) == DMD->to_lower(DMD->graveyard_mat_str()) {
         imp = 0.0;
         // no splitting can happenin vacuum set to 1
-      } else if (DMD->to_lower(mat_num) != DMD->to_lower(DMD->vacuum_mat_str())) {
+      } else if (DMD->to_lower(mat_nanme) == DMD->to_lower(DMD->vacuum_mat_str())) {
         imp = 1.0;
         // otherwise as the map says
       } else {
@@ -280,7 +280,7 @@ void write_cell_cards(std::ostringstream& lcadfile,
     }
     // its possible no importances were assigned
     if (set.size() == 0) {
-      if (mat_name != DMD->graveyard_mat_str()) {
+      if (DMD->to_lower(mat_nanme) != DMD->to_lower(DMD->graveyard_mat_str()) {
         importances = "imp:n=1";
       } else {
         importances = "imp:n=0";
@@ -288,7 +288,7 @@ void write_cell_cards(std::ostringstream& lcadfile,
     }
 
     // add descriptive comments for special volumes
-    if (mat_name == DMD->graveyard_mat_str()) {
+    if (DMD->to_lower(mat_nanme) == DMD->to_lower(DMD->graveyard_mat_str()) {
       importances += "  $ graveyard";
     } else if (DAG->is_implicit_complement(entity)) {
       importances += "  $ implicit complement";

--- a/src/mcnp/mcnp_funcs.cpp
+++ b/src/mcnp/mcnp_funcs.cpp
@@ -200,8 +200,8 @@ void write_cell_cards(std::ostringstream& lcadfile,
       // that material numbers are assigned
       mat_num = DMD->volume_material_data_eh[entity];
       // if we cant make an int from the mat_num
-      if (mat_num != DMD->graveyard_mat_str() &&
-          mat_num != DMD->vacuum_mat_str()) {
+      if (to_lower(mat_num) != to_lower(DMD->graveyard_mat_str()) &&
+          to_lower(mat_num) != to_lower(DMD->vacuum_mat_str())) {
         if (!DMD->try_to_make_int(mat_num)) {
           std::cerr << "Failed to cast material number to an integer"
                     << std::endl;

--- a/src/mcnp/mcnp_funcs.cpp
+++ b/src/mcnp/mcnp_funcs.cpp
@@ -202,8 +202,8 @@ void write_cell_cards(std::ostringstream& lcadfile,
       // that material numbers are assigned
       mat_num = DMD->volume_material_data_eh[entity];
       // if we cant make an int from the mat_num
-      if (dagmc_utils::lowercase_str(mat_num) != dagmc_utils::lowercase_str(DMD->graveyard_mat_str()) &&
-          dagmc_utils::lowercase_str(mat_num) != dagmc_utils::lowercase_str(DMD->vacuum_mat_str())) {
+      if (dagmc_util::lowercase_str(mat_num) != dagmc_util::lowercase_str(DMD->graveyard_mat_str()) &&
+          dagmc_util::lowercase_str(mat_num) != dagmc_util::lowercase_str(DMD->vacuum_mat_str())) {
         if (!DMD->try_to_make_int(mat_num)) {
           std::cerr << "Failed to cast material number to an integer"
                     << std::endl;

--- a/src/mcnp/mcnp_funcs.cpp
+++ b/src/mcnp/mcnp_funcs.cpp
@@ -201,8 +201,8 @@ void write_cell_cards(std::ostringstream& lcadfile,
       // that material numbers are assigned
       mat_num = DMD->volume_material_data_eh[entity];
       // if we cant make an int from the mat_num
-      if (DMD->to_lower(mat_num) != DMD->to_lower(DMD->graveyard_mat_str()) &&
-          DMD->to_lower(mat_num) != DMD->to_lower(DMD->vacuum_mat_str())) {
+      if (dagmc_util::to_lower(mat_num) != dagmc_util::to_lower(DMD->graveyard_mat_str()) &&
+          dagmc_util::to_lower(mat_num) != dagmc_util::to_lower(DMD->vacuum_mat_str())) {
         if (!DMD->try_to_make_int(mat_num)) {
           std::cerr << "Failed to cast material number to an integer"
                     << std::endl;
@@ -225,8 +225,8 @@ void write_cell_cards(std::ostringstream& lcadfile,
     } else {
       std::string mat_name = DMD->volume_material_property_data_eh[entity];
       // if we not vacuum or graveyard
-      if (DMD->to_lower(mat_num) != DMD->to_lower(DMD->graveyard_mat_str()) &&
-          DMD->to_lower(mat_num) != DMD->to_lower(DMD->vacuum_mat_str())) {
+      if (dagmc_util::to_lower(mat_num) != dagmc_util::to_lower(DMD->graveyard_mat_str()) &&
+          dagmc_util::to_lower(mat_num) != dagmc_util::to_lower(DMD->vacuum_mat_str())) {
         if (workflow_data->material_library.count(mat_name) == 0) {
           std::cerr << "Material with name " << mat_name << " not found "
                     << std::endl;
@@ -267,10 +267,10 @@ void write_cell_cards(std::ostringstream& lcadfile,
       }
       double imp = 1.0;
       // if we find graveyard always have importance 0.0
-      if (DMD->to_lower(mat_nanme) == DMD->to_lower(DMD->graveyard_mat_str()) {
+      if (dagmc_util::to_lower(mat_nanme) == dagmc_util::to_lower(DMD->graveyard_mat_str()) {
         imp = 0.0;
         // no splitting can happenin vacuum set to 1
-      } else if (DMD->to_lower(mat_nanme) == DMD->to_lower(DMD->vacuum_mat_str())) {
+      } else if (dagmc_util::to_lower(mat_nanme) == dagmc_util::to_lower(DMD->vacuum_mat_str())) {
         imp = 1.0;
         // otherwise as the map says
       } else {
@@ -280,7 +280,7 @@ void write_cell_cards(std::ostringstream& lcadfile,
     }
     // its possible no importances were assigned
     if (set.size() == 0) {
-      if (DMD->to_lower(mat_nanme) != DMD->to_lower(DMD->graveyard_mat_str()) {
+      if (dagmc_util::to_lower(mat_nanme) != dagmc_util::to_lower(DMD->graveyard_mat_str()) {
         importances = "imp:n=1";
       } else {
         importances = "imp:n=0";
@@ -288,7 +288,7 @@ void write_cell_cards(std::ostringstream& lcadfile,
     }
 
     // add descriptive comments for special volumes
-    if (DMD->to_lower(mat_nanme) == DMD->to_lower(DMD->graveyard_mat_str()) {
+    if (dagmc_util::to_lower(mat_nanme) == dagmc_util::to_lower(DMD->graveyard_mat_str()) {
       importances += "  $ graveyard";
     } else if (DAG->is_implicit_complement(entity)) {
       importances += "  $ implicit complement";

--- a/src/mcnp/mcnp_funcs.cpp
+++ b/src/mcnp/mcnp_funcs.cpp
@@ -2,8 +2,6 @@
 
 #include "DagMC.hpp"
 #include "dagmcmetadata.hpp"
-#include "util.hpp"
-
 using moab::DagMC;
 
 #include <assert.h>
@@ -202,10 +200,8 @@ void write_cell_cards(std::ostringstream& lcadfile,
       // that material numbers are assigned
       mat_num = DMD->volume_material_data_eh[entity];
       // if we cant make an int from the mat_num
-      if (dagmc_util::to_lower(mat_num) !=
-              dagmc_util::to_lower(DMD->graveyard_mat_str()) &&
-          dagmc_util::to_lower(mat_num) !=
-              dagmc_util::to_lower(DMD->vacuum_mat_str())) {
+      if (mat_num.find(DMD->graveyard_str()) == std::string::npos &&
+          mat_num.find(DMD->vacuum_str()) == std::string::npos) {
         if (!DMD->try_to_make_int(mat_num)) {
           std::cerr << "Failed to cast material number to an integer"
                     << std::endl;
@@ -228,10 +224,8 @@ void write_cell_cards(std::ostringstream& lcadfile,
     } else {
       std::string mat_name = DMD->volume_material_property_data_eh[entity];
       // if we not vacuum or graveyard
-      if (dagmc_util::to_lower(mat_num) !=
-              dagmc_util::to_lower(DMD->graveyard_mat_str()) &&
-          dagmc_util::to_lower(mat_num) !=
-              dagmc_util::to_lower(DMD->vacuum_mat_str())) {
+      if (mat_name.find(DMD->vacuum_str()) == std::string::npos &&
+          mat_name.find(DMD->graveyard_str()) == std::string::npos) {
         if (workflow_data->material_library.count(mat_name) == 0) {
           std::cerr << "Material with name " << mat_name << " not found "
                     << std::endl;
@@ -272,12 +266,10 @@ void write_cell_cards(std::ostringstream& lcadfile,
       }
       double imp = 1.0;
       // if we find graveyard always have importance 0.0
-      if (dagmc_util::to_lower(mat_num) ==
-          dagmc_util::to_lower(DMD->graveyard_mat_str())) {
+      if (mat_name.find(DMD->graveyard_str()) != std::string::npos) {
         imp = 0.0;
         // no splitting can happenin vacuum set to 1
-      } else if (dagmc_util::to_lower(mat_num) ==
-                 dagmc_util::to_lower(DMD->vacuum_mat_str())) {
+      } else if (mat_name.find(DMD->vacuum_str()) != std::string::npos) {
         imp = 1.0;
         // otherwise as the map says
       } else {
@@ -287,7 +279,7 @@ void write_cell_cards(std::ostringstream& lcadfile,
     }
     // its possible no importances were assigned
     if (set.size() == 0) {
-      if (dagmc_util::to_lower(mat_num) != dagmc_util::to_lower(DMD->graveyard_mat_str())) {
+      if (mat_name.find(DMD->graveyard_str()) == std::string::npos) {
         importances = "imp:n=1";
       } else {
         importances = "imp:n=0";
@@ -295,7 +287,7 @@ void write_cell_cards(std::ostringstream& lcadfile,
     }
 
     // add descriptive comments for special volumes
-    if (dagmc_util::to_lower(mat_num) == dagmc_util::to_lower(DMD->graveyard_mat_str())) {
+    if (mat_name.find(DMD->graveyard_str()) != std::string::npos) {
       importances += "  $ graveyard";
     } else if (DAG->is_implicit_complement(entity)) {
       importances += "  $ implicit complement";

--- a/src/uwuw/tests/uwuw_unit_tests.cpp
+++ b/src/uwuw/tests/uwuw_unit_tests.cpp
@@ -146,7 +146,6 @@ TEST_F(UWUWTest, mat_write) {
   mat.metadata["mat_number"] = 1;
   // check openmc material write
   std::string openmc_rep = mat.openmc();
-  std::cout << openmc_rep << std::endl;
   std::stringstream expected_rep;
   expected_rep << "  <material id=\"1\" name=\"Water\" >\n";
   expected_rep << "    <density value=\"1.\" units=\"g/cc\" />\n";


### PR DESCRIPTION
This aims to follow up on #805.

Right now I just pulled @pshriwise branch and rebased it. 

## Description
This fixes the definition of the Graveyard and the Vacuum, to respectively exactly `mat:Graveyard` or `mat:graveyard` and `mat:Vacuum` or `mat:vacuum"`
## Motivation and Context
the previous implementation would lead to detection of a vacuum where there was not, if the name of the material contained "vacuum" or "graveyard"

## Changelog file
- [x] done ?


_This works is sponsored by [Proxima Fusion](https://www.proximafusion.com/)_ 
<img src="https://cdn.prod.website-files.com/65b10cc303e570e609b235c8/65b10cc303e570e609b23618_Asset%205.svg" data-canonical-src="https://www.proximafusion.com" width="100" height="70" /><img src="https://cdn.prod.website-files.com/65b10cc303e570e609b235c8/65b10cc303e570e609b23626_Typo.svg" data-canonical-src="https://www.proximafusion.com" height="70" />