### PR TITLE
propagating hdf5 version update to CI

### DIFF
--- a/.github/actions/upstream-test/action.yml
+++ b/.github/actions/upstream-test/action.yml
@@ -20,7 +20,7 @@ inputs:
   hdf5_version:
     description: Version of HDF5
     required: false
-    default: hdf5_1_14_3
+    default: 1.14.6
   moab_version:
     description: Version of MOAB
     required: false

--- a/.github/workflows/linux_build_test.yml
+++ b/.github/workflows/linux_build_test.yml
@@ -54,8 +54,8 @@ jobs:
           off,
         ]
         geant4_version : [
-          10.7.4,
-          11.1.2
+          v10.7.4,
+          v11.1.2
         ]
         double_down_version : [
           off,

--- a/.github/workflows/linux_build_test.yml
+++ b/.github/workflows/linux_build_test.yml
@@ -97,10 +97,10 @@ jobs:
           mkdir -p build
           cd build
           cmake ../ \
-              -DMOAB_DIR=${moab_install_dir} \
+              -DMOAB_DIR=${MOAB_INSTALL_DIR} \
               -DBUILD_GEANT4=$([ "${{ matrix.geant4_version }}" != "off" ] && echo "ON" || echo "OFF") \
-              -DPULL_INSTALL_MOAB=$([ "${{ matrix.pull_install_moab }}" != "on" ] && echo "OFF" || echo "ON -DHDF5_ROOT=${hdf5_install_dir}") \
-              -DGEANT4_DIR=${geant4_install_dir} \
+              -DPULL_INSTALL_MOAB=$([ "${{ matrix.pull_install_moab }}" != "on" ] && echo "OFF" || echo "ON -DHDF5_ROOT=${HDF5_INSTALL_DIR}") \
+              -DGEANT4_DIR=${GEANT4_INSTALL_DIR} \
               -DBUILD_CI_TESTS=ON \
               -DBUILD_MW_REG_TESTS=OFF \
               -DBUILD_STATIC_EXE=OFF \

--- a/.github/workflows/linux_build_test.yml
+++ b/.github/workflows/linux_build_test.yml
@@ -83,7 +83,7 @@ jobs:
                 matrix.geant4_version
               }}-double_down_${{
                 matrix.double_down_version
-              }}/moab:latest
+              }}/external_deps:latest
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/linux_build_test.yml
+++ b/.github/workflows/linux_build_test.yml
@@ -55,7 +55,7 @@ jobs:
         ]
         geant4_version : [
           v10.7.4,
-          v11.1.2
+          v11.2.1
         ]
         double_down_version : [
           off,

--- a/.github/workflows/linux_build_test.yml
+++ b/.github/workflows/linux_build_test.yml
@@ -44,7 +44,7 @@ jobs:
           clang,
         ]
         hdf5_version : [
-          1.14.3,
+          1.14.6,
         ]
         moab_version : [
           5.4.1,
@@ -64,7 +64,7 @@ jobs:
         include:
           - ubuntu_version: 22.04
             compiler: gcc
-            hdf5_version: 1.14.3
+            hdf5_version: 1.14.6
             moab_version: 5.4.1
             pull_install_moab: on
             geant4_version: off

--- a/.github/workflows/linux_build_test.yml
+++ b/.github/workflows/linux_build_test.yml
@@ -83,7 +83,7 @@ jobs:
                 matrix.geant4_version
               }}-double_down_${{
                 matrix.double_down_version
-              }}:latest
+              }}/moab:latest
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/linux_build_test.yml
+++ b/.github/workflows/linux_build_test.yml
@@ -83,7 +83,7 @@ jobs:
                 matrix.geant4_version
               }}-double_down_${{
                 matrix.double_down_version
-              }}/moab:latest
+              }}:latest
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/linux_build_test.yml
+++ b/.github/workflows/linux_build_test.yml
@@ -110,7 +110,7 @@ jobs:
               -DCMAKE_Fortran_COMPILER=gfortran \
               -DCMAKE_INSTALL_PREFIX=${install_dir}/dagmc \
               -DDOUBLE_DOWN=$([ "${{ matrix.double_down_version }}" != "off" ] && echo "ON" || echo "OFF") \
-              -Ddd_ROOT=${double_down_install_dir}
+              -Ddd_ROOT=${DOUBLE_DOWN_INSTALL_DIR}
           make -j${CI_JOBS}
           make install
 

--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -9,7 +9,7 @@ Next version
 
 **Changed:**
   * Update formating of few files to comply with clang-format (#937)
-  * Update default HDF5 version to 1.14.6 (#976)
+  * Update default HDF5 version to 1.14.6 (#976, #978)
 
 **Added:**
   * Allow download & build of MOAB from cmake at build time (#969)


### PR DESCRIPTION
This follows #976.
now updating the version of HDF5 used in the CI.