### PR TITLE
MNT: Use policy_max in cmake_minimum_required

### DIFF
--- a/.github/workflows/mac_build_test.yml
+++ b/.github/workflows/mac_build_test.yml
@@ -69,9 +69,8 @@ jobs:
         shell: bash -l {0}
         run: |
           cd ${HOME}
-          mkdir -pv moab/bld
-          cd moab
-          git clone https://bitbucket.org/fathomteam/moab -b 5.5.1 --depth 1 --shallow-submodules
+          mkdir -pv moab
+          git clone -b 5.5.1 --depth 1 --shallow-submodules https://bitbucket.org/fathomteam/moab moab_src
 
           # In CMavke v4 TestEndianess.c.in was renamed to TestEndianness.c.in
           # to fix a typo. MOAB v5.5.1 used a custom config/TestBigEndian.cmake
@@ -89,36 +88,40 @@ jobs:
           #
           # $ git grep -m 1 '(HAVE_' -- config/TestBigEndian.cmake
           # config/TestBigEndian.cmake:8:  IF(HAVE_${VARIABLE} MATCHES ^HAVE_${VARIABLE}$)
-          cd bld
-          cmake ../moab -DENABLE_HDF5=ON \
-                        -DENABLE_PYMOAB=OFF \
-                        -DHDF5_ROOT=$HDF5_PATH \
-                        -DBUILD_SHARED_LIBS=ON \
-                        -DENABLE_BLASLAPACK=OFF \
-                        -DENABLE_FORTRAN=OFF \
-                        -DHAVE_WORDS_BIGENDIAN=TRUE \
-                        -DCMAKE_PREFIX_PATH="$(brew --prefix)" \
-                        -DEIGEN3_DIR="${EIGEN_PREFIX}/include/eigen3"
-                        -DCMAKE_INSTALL_PREFIX=${HOME}/moab
-          make
-          make install
-          rm -rf ${HOME}/moab/moab ${HOME}/moab/bld
+          cmake \
+              -DCMAKE_INSTALL_PREFIX=${HOME}/moab \
+              -DHAVE_WORDS_BIGENDIAN=TRUE \
+              -DCMAKE_PREFIX_PATH="$(brew --prefix)" \
+              -DEIGEN3_DIR="${EIGEN_PREFIX}/include/eigen3" \
+              -DENABLE_HDF5=ON \
+              -DENABLE_PYMOAB=OFF \
+              -DBUILD_SHARED_LIBS=ON \
+              -DENABLE_BLASLAPACK=OFF \
+              -DENABLE_FORTRAN=OFF \
+              -S moab_src \
+              -B bld
+          cmake -LH bld
+          cmake --build bld --parallel
+          cmake --install bld
+          rm -rf moab_src bld lib
 
       - name: Build DAGMC
         shell: bash -l {0}
         run: |
-          mkdir -p $GITHUB_WORKSPACE/bld
-          cd $GITHUB_WORKSPACE/bld
-          cmake ../ -DMOAB_DIR=${HOME}/moab \
-                    -DCMAKE_PREFIX_PATH="${EIGEN_PREFIX};$(brew --prefix)" \
-                    -DBUILD_CI_TESTS=ON \
-                    -DBUILD_STATIC_EXE=OFF \
-                    -DBUILD_SHARED_LIBS=ON \
-                    -DBUILD_STATIC_LIBS=OFF \
-                    -DCMAKE_CXX_FLAGS="-Werror=reorder" \
-                    -DCMAKE_INSTALL_PREFIX=${HOME}/dagmc
-          make
-          make install
+          cmake \
+            -DCMAKE_INSTALL_PREFIX=${HOME}/dagmc \
+            -DCMAKE_PREFIX_PATH="${EIGEN_PREFIX};$(brew --prefix)" \
+            -DMOAB_DIR=${HOME}/moab \
+            -DBUILD_CI_TESTS=ON \
+            -DBUILD_STATIC_EXE=OFF \
+            -DBUILD_SHARED_LIBS=ON \
+            -DBUILD_STATIC_LIBS=OFF \
+            -DCMAKE_CXX_FLAGS="-Werror=reorder" \
+            -S . \
+            -B $GITHUB_WORKSPACE/bld
+          cmake -LH bld
+          cmake --build bld --parallel
+          cmake --install bld
 
       - name: Testing DAGMC
         shell: bash -l {0}

--- a/.github/workflows/mac_build_test.yml
+++ b/.github/workflows/mac_build_test.yml
@@ -16,7 +16,6 @@ on:
       - '.github/actions/**'
       - 'CI/**'
       - 'doc/**'
-
   push:
     branches:
       - develop
@@ -47,13 +46,24 @@ jobs:
       - name: Initial setup
         shell: bash -l {0}
         run: |
-          brew install eigen hdf5
+          brew install hdf5
+
+          # Homebrew's Eigen in 2026 is Eigen v5.x, which is incompatible with
+          # MOAB v5.5.1 FindEigen3.cmake. Homebrew has bad version control, and
+          # so instead of trying to force Homebrew to install a compatible version,
+          # build Eigen v3.4.0 (a header-only library) from source to ensure that
+          # Eigen3Config.cmake is generated for DAGMC's CMake invocation to use
+          # find_package(Eigen3 REQUIRED NO_MODULE).
+          curl -sL https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.bz2 | tar xj -C /tmp
+          cmake -DCMAKE_INSTALL_PREFIX=/tmp/eigen -S /tmp/eigen-3.4.0 -B /tmp/eigen-build
+          cmake --build /tmp/eigen-build --parallel
+          cmake --install /tmp/eigen-build
+          echo "EIGEN_PREFIX=/tmp/eigen" >> $GITHUB_ENV
 
       - name: Environment Variables
         shell: bash -l {0}
         run: |
           echo "HOME=$GITHUB_WORKSPACE/.." >> $GITHUB_ENV
-
 
       - name: Build MOAB
         shell: bash -l {0}
@@ -62,6 +72,23 @@ jobs:
           mkdir -pv moab/bld
           cd moab
           git clone https://bitbucket.org/fathomteam/moab -b 5.5.1 --depth 1 --shallow-submodules
+
+          # In CMavke v4 TestEndianess.c.in was renamed to TestEndianness.c.in
+          # to fix a typo. MOAB v5.5.1 used a custom config/TestBigEndian.cmake
+          # that hardcodes the use of TestEndianess.c.in.
+          #
+          #  $ git grep "TestEndianess.c.in"
+          #  config/TestBigEndian.cmake:39:    CONFIGURE_FILE("${CMAKE_ROOT}/Modules/TestEndianess.c.in"
+          #
+          # As config/ is first in CMAKE_MODULE_PATH, MOAB's broken version is
+          # used instead of CMake's working built-in module. To avoid this, set
+          # HAVE_WORDS_BIGENDIAN=TRUE to skip the test, instead of deleting the
+          # broken module. This works as HAVE_WORDS_BIGENDIAN=TRUE skips the test
+          # test_big_endian, defaulting to little-endian, which for effectively all
+          # runner platforms is correct.
+          #
+          # $ git grep -m 1 '(HAVE_' -- config/TestBigEndian.cmake
+          # config/TestBigEndian.cmake:8:  IF(HAVE_${VARIABLE} MATCHES ^HAVE_${VARIABLE}$)
           cd bld
           cmake ../moab -DENABLE_HDF5=ON \
                         -DENABLE_PYMOAB=OFF \
@@ -69,6 +96,9 @@ jobs:
                         -DBUILD_SHARED_LIBS=ON \
                         -DENABLE_BLASLAPACK=OFF \
                         -DENABLE_FORTRAN=OFF \
+                        -DHAVE_WORDS_BIGENDIAN=TRUE \
+                        -DCMAKE_PREFIX_PATH="$(brew --prefix)" \
+                        -DEIGEN3_DIR="${EIGEN_PREFIX}/include/eigen3"
                         -DCMAKE_INSTALL_PREFIX=${HOME}/moab
           make
           make install
@@ -80,6 +110,7 @@ jobs:
           mkdir -p $GITHUB_WORKSPACE/bld
           cd $GITHUB_WORKSPACE/bld
           cmake ../ -DMOAB_DIR=${HOME}/moab \
+                    -DCMAKE_PREFIX_PATH="${EIGEN_PREFIX};$(brew --prefix)" \
                     -DBUILD_CI_TESTS=ON \
                     -DBUILD_STATIC_EXE=OFF \
                     -DBUILD_SHARED_LIBS=ON \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
+cmake_minimum_required(VERSION 3.18...4.2)
 project(DAGMC)
-cmake_minimum_required(VERSION 3.18)
 enable_language(CXX)
 
 # Set DAGMC version

--- a/cmake/test_config/CMakeLists.txt
+++ b/cmake/test_config/CMakeLists.txt
@@ -1,5 +1,5 @@
+cmake_minimum_required(VERSION 2.8...4.2)
 project(Test_DAGMC_config)
-cmake_minimum_required(VERSION 2.8)
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR})
 

--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -16,6 +16,7 @@ Next version
 
 **Fixed**
   * Fixed HDF5 naming convention for docker container building and naming (#976)
+  * Allowed for modern CMake policies to be used (#989)
 
 
 v3.2.4

--- a/src/geant4/generate_geant4
+++ b/src/geant4/generate_geant4
@@ -1296,7 +1296,7 @@ def _setup_build(dag_h5m):
 
     file_contents.append('#----------------------------------------------------------------------------\n')
     file_contents.append('# Setup the project\n')
-    file_contents.append('cmake_minimum_required(VERSION 2.6 FATAL_ERROR)\n')
+    file_contents.append('cmake_minimum_required(VERSION 2.6...4.2)\n')
     file_contents.append('project(N01)\n')
     file_contents.append('\n')
     file_contents.append('#----------------------------------------------------------------------------\n')

--- a/src/gtest/gtest-1.8.0/CMakeLists.txt
+++ b/src/gtest/gtest-1.8.0/CMakeLists.txt
@@ -26,8 +26,8 @@ endif()
 # as ${gtest_SOURCE_DIR} and to the root binary directory as
 # ${gtest_BINARY_DIR}.
 # Language "C" is required for find_package(Threads).
+cmake_minimum_required(VERSION 2.6...4.2)
 project(gtest CXX C)
-cmake_minimum_required(VERSION 2.6.4)
 
 # Where gtest's .h files can be found.
 include_directories(


### PR DESCRIPTION
## Description

* Set policy_max which defines the maximum CMake policy. cmake_minimum_required sets two minimums: the real (lower) minimum and the (upper) minimum based on has been tested with. The defaults (CMake policies) will be set to the highest value possible between the two values.
   - c.f. https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html
* Move cmake_minimum_required position in files given warning:
> cmake_minimum_required() should be called prior to this top-level project()
> call.  Please see the cmake-commands(7) manual for usage documentation of
> both commands.
* Older versions of CMake v3.x policies are being deprecated and dropped and v2 policies are now longer supported.
* FATAL_ERROR option is accepted but ignored by CMake 2.6 and higher, and so is removed as it can have no effect.
* CMake policy is not changed on CMake patch releases, so specifying a CMake version beyond the minor level to the patch level is not informative or meaningful.

### Fixes to Mac Build/Test workflow

* Homebrew's Eigen in 2026 is Eigen `v5.x`, which is incompatible with MOAB `v5.5.1` `FindEigen3.cmake`. Homebrew has bad version control, and so instead of trying to force Homebrew to install a compatible version, build Eigen `v3.4.0` (a header-only library) from source to ensure that `Eigen3Config.cmake` is generated for DAGMC's CMake invocation to use `find_package(Eigen3 REQUIRED NO_MODULE)`.
* Additionally, in CMake v4 `TestEndianess.c.in` was renamed to `TestEndianness.c.in` to fix a typo. MOAB `v5.5.1` used a custom `config/TestBigEndian.cmake` that hardcodes the use of `TestEndianess.c.in`.

```console
$ git grep "TestEndianess.c.in"
config/TestBigEndian.cmake:39:  CONFIGURE_FILE("${CMAKE_ROOT}/Modules/TestEndianess.c.in"
```

As `config/` is first in `CMAKE_MODULE_PATH`, MOAB's broken version is used instead of CMake's working built-in module. To avoid this, set `HAVE_WORDS_BIGENDIAN=TRUE` to skip the test, instead of deleting the broken module. This works as `HAVE_WORDS_BIGENDIAN=TRUE` skips the test `test_big_endian`, defaulting to little-endian, which for effectively all runner platforms is correct.

```console
$ git grep -m 1 '(HAVE_' -- config/TestBigEndian.cmake
config/TestBigEndian.cmake:8:  IF(HAVE_${VARIABLE} MATCHES ^HAVE_${VARIABLE}$)
```

* Surprisingly, adopting modern CMake invocations also fixes a bug in the build related to `MOAB_DIR`, which I did not expect.

## Motivation and Context

* In use for https://github.com/conda-forge/dagmc-feedstock/pull/40
* Related to https://github.com/conda-forge/openmc-feedstock/pull/86#issuecomment-3885877819

## Changes

Maintenance and build longevity.

## Behavior
What is the current behavior? What is the new behavior?

The CMake policy is frozen at old or fully deprecated versions which are no longer accessible by modern CMake. The CMake policy_max range allows for setting the lower minimum and then updating the lower and the upper minimums as needed given changes, allowing for the most wide range of viable builds.

## Changelog file
All pull requests are required to update the [CHANGELOG](doc/CHANGELOG.rst) file with the PR.  Your update can take different forms including:

* creating a new entry describing your change, including a reference to this pull request number
* adding a reference to your pull request number to an exist entry if that entry can include your changes

:heavy_check_mark: 