### PR TITLE
Refactor FLUKA library detection in FindFluka.cmake for FLUKA.CERN version

### DIFF
--- a/cmake/FindFluka.cmake
+++ b/cmake/FindFluka.cmake
@@ -1,19 +1,39 @@
-find_path(FLUKA_LIBRARIES
-  NAMES libflukahp.a
-  HINTS ${FLUKA_DIR}
-  PATHS ENV FLUKA_DIR
-  NO_DEFAULT_PATH
+find_path(FLUKA_LIBDIR 
+    NAMES libfluka.a libflukahp.a
+    HINTS ${FLUKA_DIR}
+    PATHS ENV FLUKA_DIR
+    NO_DEFAULT_PATH
 )
-if (FLUKA_LIBRARIES)
-  get_filename_component(FLUKA_LIBRARIES ${FLUKA_LIBRARIES} ABSOLUTE)
-endif ()
 
-set(FLUKA_LIBRARIES ${FLUKA_LIBRARIES}/libflukahp.a gfortran)
+if (NOT FLUKA_LIBDIR)
+    message(FATAL_ERROR "Could not find Fluka. Please set FLUKA_DIR or ENV{FLUKA_DIR}.")
+endif()
+
+if (EXISTS "${FLUKA_LIBDIR}/libfluka.a")
+    # FLUKA.CERN
+    set(FLUKA_LIBRARIES 
+        ${FLUKA_LIBDIR}/libfluka.a
+        ${FLUKA_LIBDIR}/libgeometry.a
+        ${FLUKA_LIBDIR}/libdata.a
+        ${FLUKA_LIBDIR}/libmath.a
+        ${FLUKA_LIBDIR}/libtool.a
+        gfortran
+        z
+        pthread
+    )
+    message(STATUS "Found FLUKA installation)")
+
+elseif (EXISTS "${FLUKA_LIBDIR}/libflukahp.a")
+    # Old format: Single high-precision library
+    set(FLUKA_LIBRARIES 
+        ${FLUKA_LIBDIR}/libflukahp.a 
+        gfortran
+    )
+    message(STATUS "FLUKA installation")
+
+else()
+    # Failsafe in case the directory was found but files are missing
+    message(FATAL_ERROR "Found FLUKA_LIBDIR at ${FLUKA_LIBDIR}, but required libraries are missing.")
+endif()
 
 message(STATUS "FLUKA_LIBRARIES: ${FLUKA_LIBRARIES}")
-
-if (FLUKA_LIBRARIES)
-  message(STATUS "Found Fluka")
-else ()
-  message(FATAL_ERROR "Could not find Fluka")
-endif ()

--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -13,6 +13,7 @@ Next version
 
 **Added:**
   * Allow download & build of MOAB from cmake at build time (#969)
+  * Added linking against FLUKA version distributed by FLUKA.CERN (#991)
 
 **Fixed**
   * Fixed HDF5 naming convention for docker container building and naming (#976)


### PR DESCRIPTION
## Description
Added detection of FLUKA distributed by FLUKA.CERN team

## Motivation and Context
Possibility to use DAGMC with FLUKA distributed by FLUKA.CERN team

## Changes
Extra branch in FindFluka.cmake

## Behavior
FluDAG doesn't compile against FLUKA.CERN version. Possible to compile and pass the tests with these changes.
Compilation was done using cmake.