### PR TITLE
CI: Fix the macOS build (zlib for HDF5's CMake config) and make steps fail fast

### DIFF
--- a/.github/workflows/changelog_test.yml
+++ b/.github/workflows/changelog_test.yml
@@ -11,18 +11,11 @@ env:
 jobs:
   changelog_update:
     runs-on: ubuntu-latest
-    container:
-      image: alpine:3.14
 
     name: Is Changelog up-to-date ?
     steps:
-      - name: Install latest git
-        run: |
-          apk add --no-cache bash git openssh
-          git --version
-
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - run: |
           git config --global --add safe.directory ${GITHUB_WORKSPACE}

--- a/.github/workflows/mac_build_test.yml
+++ b/.github/workflows/mac_build_test.yml
@@ -44,9 +44,10 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Initial setup
-        shell: bash -l {0}
+        shell: bash -leo pipefail {0}
         run: |
-          brew install hdf5
+          # zlib: see the comment on ZLIB_ROOT in the "Build DAGMC" step below.
+          brew install hdf5 zlib
 
           # Homebrew's Eigen in 2026 is Eigen v5.x, which is incompatible with
           # MOAB v5.5.1 FindEigen3.cmake. Homebrew has bad version control, and
@@ -61,12 +62,12 @@ jobs:
           echo "EIGEN_PREFIX=/tmp/eigen" >> $GITHUB_ENV
 
       - name: Environment Variables
-        shell: bash -l {0}
+        shell: bash -leo pipefail {0}
         run: |
           echo "HOME=$GITHUB_WORKSPACE/.." >> $GITHUB_ENV
 
       - name: Build MOAB
-        shell: bash -l {0}
+        shell: bash -leo pipefail {0}
         run: |
           cd ${HOME}
           mkdir -pv moab
@@ -106,11 +107,21 @@ jobs:
           rm -rf moab_src bld lib
 
       - name: Build DAGMC
-        shell: bash -l {0}
+        shell: bash -leo pipefail {0}
         run: |
+          # cmake/HDF5_macro.cmake narrows CMAKE_FIND_LIBRARY_SUFFIXES to the shared
+          # library suffix (.dylib on macOS) before calling find_package(HDF5).
+          # Homebrew's hdf5-config.cmake in turn calls find_dependency(ZLIB), and the
+          # macOS SDK ships zlib only as a .tbd stub (usr/lib/libz.tbd), which that
+          # narrowed suffix list excludes. FindZLIB then finds the SDK header but no
+          # library and the configure step dies with
+          #   Could NOT find ZLIB (missing: ZLIB_LIBRARY) (found version "1.2.12")
+          # Homebrew's zlib is a real .dylib, but keg-only and therefore not under
+          # $(brew --prefix)/lib, so point ZLIB_ROOT at its keg explicitly.
           cmake \
             -DCMAKE_INSTALL_PREFIX=${HOME}/dagmc \
             -DCMAKE_PREFIX_PATH="${EIGEN_PREFIX};$(brew --prefix)" \
+            -DZLIB_ROOT="$(brew --prefix zlib)" \
             -DMOAB_DIR=${HOME}/moab \
             -DBUILD_CI_TESTS=ON \
             -DBUILD_STATIC_EXE=OFF \
@@ -124,7 +135,7 @@ jobs:
           cmake --install bld
 
       - name: Testing DAGMC
-        shell: bash -l {0}
+        shell: bash -leo pipefail {0}
         run: |
           cd $GITHUB_WORKSPACE/bld
           PATH=$GITHUB_WORKSPACE/bld/bin:$PATH make test

--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -19,6 +19,8 @@ Next version
   * Allowed for modern CMake policies to be used (#989)
   * Fixed the macOS CI build: zlib is now found by HDF5's CMake config, and failing
     steps stop the job instead of masking the real error (#994)
+  * Fixed the changelog check, which had been failing on checkout since the Node 20
+    deprecation, by dropping the alpine:3.14 container (#994)
 
 
 v3.2.4

--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -17,6 +17,8 @@ Next version
 **Fixed**
   * Fixed HDF5 naming convention for docker container building and naming (#976)
   * Allowed for modern CMake policies to be used (#989)
+  * Fixed the macOS CI build: zlib is now found by HDF5's CMake config, and failing
+    steps stop the job instead of masking the real error (#994)
 
 
 v3.2.4


### PR DESCRIPTION
## Description

Two changes to `.github/workflows/mac_build_test.yml`. The first is what turns the `Mac Build/Test` job green again; the second is what makes the next failure readable:

1. **zlib** — pass `-DZLIB_ROOT="$(brew --prefix zlib)"` to the DAGMC configure step and install Homebrew's `zlib` alongside `hdf5`.
2. **fail fast** — the steps use a custom shell (`shell: bash -l {0}`), for which GitHub does *not* add `-e`. Changed to `shell: bash -leo pipefail {0}` so a failing command stops the step.

No CMake module is touched, so this does not overlap with the pending refactor in #987.

## Motivation and Context

`Mac Build/Test` has been failing on every branch since March 2026 — the last green run was the push to `develop` on 2026-02-16 (#990). It fails on unrelated branches, so the trigger is a runner-image update rather than anyone's patch — but the fragility it exposed is in this repository's own CMake, see below. This also makes #542 ("We have no ability to verify whether the Mac build is working") effectively true again.

The failure is in the `Build DAGMC` step:

```
CMake Error at .../FindPackageHandleStandardArgs.cmake:290 (message):
  Could NOT find ZLIB (missing: ZLIB_LIBRARY) (found version "1.2.12")
Call Stack (most recent call first):
  .../FindZLIB.cmake:242
  .../CMakeFindDependencyMacro.cmake:93 (find_package)
  /opt/homebrew/lib/cmake/hdf5/hdf5-config.cmake:155 (find_dependency)
  .../FindHDF5.cmake:678 (find_package)
  cmake/HDF5_macro.cmake:5 (find_package)
  cmake/FindMOAB.cmake:25 (find_set_HDF5)
  CMakeLists.txt:60 (find_package)
```

Chain of events on `macos-latest` (currently `macos-26-arm64`, CMake 4.4.0):

* `cmake/HDF5_macro.cmake:4` narrows `CMAKE_FIND_LIBRARY_SUFFIXES` to `${CMAKE_SHARED_LIBRARY_SUFFIX}` — i.e. `.dylib` only — before `find_package(HDF5)`.
* Homebrew's `hdf5-config.cmake` calls `find_dependency(ZLIB)`, so `FindZLIB` runs with that narrowed list.
* The macOS SDK ships zlib **only** as a `.tbd` stub (`MacOSX.sdk/usr/lib/libz.tbd`), which the narrowed suffix list excludes. The header is still found — hence the misleading `found version "1.2.12"` — but `ZLIB_LIBRARY` stays empty and the configure step fails.

Verified on the runner: a plain `find_package(ZLIB)` there resolves to `MacOSX.sdk/usr/lib/libz.tbd` with the default suffix list `.tbd;.dylib;.so;.a`, so nothing is wrong with the image — only with the interaction between the narrowed suffix list and the SDK stub. Homebrew's `zlib` is a real `.dylib`, but keg-only and therefore not under `$(brew --prefix)/lib`, so `ZLIB_ROOT` has to point at the keg. The reasoning is left as a comment in the workflow.

The second change is what made this expensive to read. With `shell: bash -l {0}` and no `-e`, the step kept going after the configure failure, so the tail of the log — the part a human sees first — is:

```
make: Makefile: No such file or directory
CMake Error: Not a file: /Users/runner/work/DAGMC/DAGMC/bld/cmake_install.cmake
```

The real error is ~150 lines above that. `bash -leo pipefail {0}` makes future failures point at their own cause.

## Changes

Bug fix, CI only. No source or CMake changes.

## Behavior

* Current: `Build DAGMC` fails at configure with `Could NOT find ZLIB`; the step then runs on and reports a missing `Makefile`.
* New: the job configures, builds and runs `make test` to completion.

Runs in my fork, same workflow, same runner:

* **before** (unmodified `develop`): https://github.com/cyb3ralbert/DAGMC/actions/runs/30522484666 — failure, `Could NOT find ZLIB`
* **after** (this branch): https://github.com/cyb3ralbert/DAGMC/actions/runs/30523318313 — success

## Other Information

If you would rather fix the cause than the symptom, the line to drop is the suffix narrowing at `cmake/HDF5_macro.cmake:4` — with the default suffix list the SDK stub is found and no `ZLIB_ROOT` is needed. I left it alone on purpose: #987 removes that file, and I would rather not put this fix behind a pending refactor. Happy to do it that way instead if you prefer.

Follows on from @matthewfeickert's CI work in February 2026 (#989, #990, and the Eigen/`TestEndianess` comments in this workflow), which is what kept this job alive up to that point.

Deliberately left out of this PR, happy to open a follow-up: no workflow in the repository sets a `permissions:` block, and `actions/checkout@v3` is still used in 9 workflows — the mac job log already warns that its Node.js 20 runtime is deprecated and being forced onto Node.js 24.

## Changelog file

Entry added under **Fixed** in `doc/CHANGELOG.rst`.
